### PR TITLE
Add column-limit with basic strategies.

### DIFF
--- a/scalafmt/src/main/scala/org/scalafmt/FormatToken.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/FormatToken.scala
@@ -1,8 +1,43 @@
 package org.scalafmt
 
+import scala.collection.mutable
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token.Whitespace
+import scala.meta.tokens.Tokens
 
 case class FormatToken(left: Token, right: Token, between: Vector[Whitespace])
+
+object FormatToken {
+
+  /**
+    * Convert scala.meta Tokens to FormatTokens.
+    *
+    * Since tokens might be very large, we try to allocate as
+    * little memory as possible.
+    */
+  def formatTokens(tokens: Tokens): Array[FormatToken] = {
+    val N = tokens.length
+    require(N > 1)
+    var i = 1
+    var left = tokens.head
+    val ts = tokens.toArray
+    val result = mutable.ArrayBuilder.make[FormatToken]
+    val whitespace = mutable.ArrayBuilder.make[Whitespace]()
+    while (i < N) {
+      ts(i) match {
+        case t: Whitespace =>
+          whitespace += t
+        case right =>
+          // TODO(olafur) avoid result.toVector
+          result += FormatToken(left, right, whitespace.result.toVector)
+          left = right
+          whitespace.clear()
+      }
+      i += 1
+    }
+    result.result
+  }
+
+}
 
 

--- a/scalafmt/src/main/scala/org/scalafmt/Formatter.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/Formatter.scala
@@ -1,0 +1,134 @@
+package org.scalafmt
+
+import scala.meta.Tree
+import scala.meta.tokens.Token
+import scala.meta.tokens.Token._
+
+class Formatter(style: ScalaStyle,
+                owners: Map[Token, Tree]) extends ScalaFmtLogger {
+
+  lazy val GetSplits = Default orElse Fail
+
+  val Fail: Strategy = {
+    case tok =>
+      logger.debug(
+        s"""
+           |=========== FAIL ============
+           |${log(tok.left)}
+           |${log(tok.between: _*)}
+           |${log(tok.right)}""".stripMargin)
+      ???
+  }
+  val Default: Strategy = {
+    case FormatToken(_: BOF, _, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_, _: EOF, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_, _: `,`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: `,`, _, _) => List(
+      SpaceFree,
+      Newline0
+    )
+    case FormatToken(open: `{`, _, _) => List(
+      oneLinerBlock(open),
+      multiLineBlock(open)
+    )
+    case FormatToken(_, _: `{`, _) => List(
+      SpaceFree
+    )
+    case FormatToken(_, _: `;`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: `;`, _, _) => List(
+      Newline(0, 0)
+    )
+    case FormatToken(_, _: `:`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_, _: `=`, _) => List(
+      SpaceFree,
+      Newline(3, 2)
+    )
+    case FormatToken(_: `:` | _: `=`, _, _) => List(
+      SpaceFree
+    )
+    case FormatToken(_, _: `@`, _) => List(
+      Newline0
+    )
+    case FormatToken(_: `@`, _, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: Ident, _: `.` | _: `#`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: `.` | _: `#`, _: Ident, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: Ident | _: Literal, _: Ident | _: Literal, _) => List(
+      SpaceFree
+    )
+    case FormatToken(_, _: `)` | _: `]`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_, _: `(` | _: `[`, _) => List(
+      NoSplitFree
+    )
+    case FormatToken(_: `(` | _: `[`, _, _) => List(
+      NoSplitFree,
+      Newline0
+    )
+    case FormatToken(_, _: `val` | _: `case`, _) => List(
+      Newline0
+    )
+    case FormatToken(_: Keyword | _: Modifier, _, _) =>
+      List(
+        SpaceFree,
+        Newline(100, 4)
+      )
+    case FormatToken(_, _: Keyword, _) =>
+      List(
+        SpaceFree,
+        Newline(6, 3)
+      )
+    case FormatToken(_, c: Comment, _) => List(
+      SpaceFree
+    )
+    case FormatToken(c: Comment, _, _) =>
+      if (c.code.startsWith("//")) List(Newline0)
+      else List(SpaceFree, Newline0)
+    case FormatToken(_, _: Delim, _) => List(
+      SpaceFree
+    )
+    case FormatToken(_: Delim, _, _) => List(
+      SpaceFree
+    )
+    // TODO(olafur) Ugly hack. Is there a better way?
+    case tok if tok.left.name.startsWith("xml") &&
+      tok.right.name.startsWith("xml") => List(
+      NoSplitFree
+    )
+  }
+
+  def oneLinerBlock(open: `{`): Split =
+    Space(1, {
+      case FormatToken(_, close: `}`, _)
+        if owners.get(open) == owners.get(close) =>
+        List(
+          SpaceFree
+        )
+    })
+
+  def multiLineBlock(open: `{`): Split =
+    Newline(1, 2, {
+      // TODO(olafur) find matching parens, see #15.
+      case FormatToken(_, close: `}`, _)
+        if owners.get(open) == owners.get(close) =>
+        List(
+          Newline_2
+        )
+    })
+}

--- a/scalafmt/src/main/scala/org/scalafmt/ScalaStyle.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/ScalaStyle.scala
@@ -1,4 +1,9 @@
 package org.scalafmt
 
-trait ScalaStyle
+trait ScalaStyle {
+  def maxColumn: Int = 80
+}
 case object Standard extends ScalaStyle
+case object ScalaFmtTesting extends ScalaStyle {
+  override def maxColumn = 40
+}

--- a/scalafmt/src/main/scala/org/scalafmt/Split.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/Split.scala
@@ -1,10 +1,46 @@
 package org.scalafmt
 
-trait Split
+sealed abstract class Split(val cost: Int,
+                            val indent: Int,
+                            val Strategy: Strategy = EmptyStrategy) {
+  def length: Int = this match {
+    case _: NoSplit => 0
+    case _: Newline => 0
+    case _: Space => 1
+  }
+}
 
-case object NoSplit extends Split
+// Direct subclasses.
 
-case object Space extends Split
+case class NoSplit(override val cost: Int) extends Split(cost, 0)
 
-case object Newline extends Split
+case class Space(override val cost: Int,
+                 override val Strategy: Strategy = EmptyStrategy)
+  extends Split(cost: Int, 0, Strategy)
+
+case class Newline(override val cost: Int,
+                   override val indent: Int,
+                   override val Strategy: Strategy = EmptyStrategy)
+  extends Split(cost, indent, Strategy)
+
+// objects
+
+object NoSplitFree extends NoSplit(0)
+
+object SpaceFree extends Space(0)
+
+class NewlineFree(indent: Int) extends Newline(0, indent, EmptyStrategy)
+
+object Newline0 extends NewlineFree(0)
+
+object Newline_2 extends NewlineFree(-2)
+
+object Newline2 extends NewlineFree(2)
+
+object Newline_4 extends NewlineFree(-4)
+
+object Newline4 extends NewlineFree(4)
+
+
+
 

--- a/scalafmt/src/main/scala/org/scalafmt/State.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/State.scala
@@ -1,13 +1,19 @@
 package org.scalafmt
 
-
 /**
   * A state represents one potential solution to reach token at index,
-  * @param cost The penalty for using path
-  * @param path The splits/decicions made to reach here.
+  *
+  * @param cost
+  * @param strategy
+  * @param path
+  * @param indentation
+  * @param column
   */
 case class State(cost: Int,
-                 path: Vector[Split]) extends Ordered[State] {
+                 strategy: PartialFunction[FormatToken, List[Split]],
+                 path: Vector[Split],
+                 indentation: Int,
+                 column: Int) extends Ordered[State] {
 
   import scala.math.Ordered.orderingToOrdered
 
@@ -15,3 +21,7 @@ case class State(cost: Int,
     (-this.cost, this.path.length) compare(-that.cost, that.path.length)
 }
 
+
+object State {
+  val start = State(0, EmptyStrategy, Vector.empty[Split], 0, 0)
+}

--- a/scalafmt/src/main/scala/org/scalafmt/package.scala
+++ b/scalafmt/src/main/scala/org/scalafmt/package.scala
@@ -1,0 +1,8 @@
+package org
+
+package object scalafmt {
+
+  type Strategy = PartialFunction[FormatToken, List[Split]]
+  val EmptyStrategy = PartialFunction.empty[FormatToken, List[Split]]
+
+}

--- a/scalafmt/src/test/resources/basic.test
+++ b/scalafmt/src/test/resources/basic.test
@@ -1,9 +1,63 @@
 40 columns                              |
+<<< Warmup
+@foobar object a {val x:Int=1}
+>>>
+@foobar object a { val x: Int = 1 }
 <<< Object definition fits in one line
 @foobar object   a   {val x:Int=1}
 >>>
 @foobar object a { val x: Int = 1 }
-<<< DISABLE Pathological case
+<<< Object almost fits in one line
+@foobar object aaaaaaa { val x: Int = 1 }
+>>>
+@foobar object aaaaaaa {
+  val x: Int = 1
+}
+<<< Indentation is included for penalty.
+object aaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  val bbbbbbbbbbbbbbbbbbbbbbbbbbbb = 1; aaa }
+>>>
+object aaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  val bbbbbbbbbbbbbbbbbbbbbbbbbbbb = 1;
+  aaa
+}
+<<< Multiline object definition
+@foobar object LoooooooooooongNaaame { val x: Int = 1 }
+>>>
+@foobar object LoooooooooooongNaaame {
+  val x: Int = 1
+}
+<<< SKIP Unindent when leaving block, see #19.
+object aaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  val bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = 1
+}
+>>>
+object aaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+  val bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    = 1
+}
+<<< SKIP case statement splits block, see #15.
+object Object {
+  val x = { case 2 => 1
+    case 1 => 3 }
+}
+>>>
+object Object {
+  val x = {
+    case 2 => 1
+    case 1 => 3
+  }
+}
+<<< SKIP #15 Split at higher levels
+object Object {
+  val x = function(first(a, b), second(c, d))
+}
+>>>
+object Object {
+  val x = function(first(a, b),
+                   second(c, d))
+}
+<<< SKIP Pathological case
 @ foobar("annot", {
   val x = 2
   val y = 2 // y=2
@@ -32,13 +86,13 @@
   x + y
 })
 object a extends b with c {
-   def foo[
-     T:Int#Double#Triple,
-     R <% String](
-     @annot1 x : Int @annot2 = 2,
-     y: Int = 3): Int = {
+   def foo[T:Int#Double#Triple,
+           R <% String](
+       @annot1 x : Int @annot2 = 2,
+       y: Int = 3): Int = {
      "match" match {
-       case 1 | 2 => 3
+       case   1 |
+              2 => 3
        case <A>2</A> => 2
      }
    }

--- a/scalafmt/src/test/scala/org/scalafmt/FormatTest.scala
+++ b/scalafmt/src/test/scala/org/scalafmt/FormatTest.scala
@@ -10,7 +10,7 @@ case class Test(name: String, original: String, expected: String)
 
 class FormatTest extends FunSuite with Timeouts with ScalaFmtLogger {
 
-  val fmt = new ScalaFmt(Standard)
+  val fmt = new ScalaFmt(ScalaFmtTesting)
 
   def tests: Seq[Test] = {
     import FilesUtil._
@@ -31,7 +31,12 @@ class FormatTest extends FunSuite with Timeouts with ScalaFmtLogger {
     }
   }
 
-  tests.withFilter(!_.name.startsWith("DISABLE")).foreach {
+  val onlyOne = tests.exists(_.name.startsWith("ONLY"))
+
+  tests.withFilter { t =>
+    !t.name.startsWith("SKIP") &&
+      (!onlyOne || t.name.startsWith("ONLY"))
+  }.foreach {
     case Test(name, original, expected) =>
       test(name) {
         failAfter(1 second) {


### PR DESCRIPTION
The column limit penalty, if any, is added to each split cost.

A split can attach a strategy to itself to limit/enchance future splits,
for example if we want to do a one-line block we don't want to allow
splits inside the block. The current implementation has limitations
shown in basic.test.