### PR TITLE
Introduce policy, fixes #15.

### DIFF
--- a/src/main/scala/org/scalafmt/Split.scala
+++ b/src/main/scala/org/scalafmt/Split.scala
@@ -1,8 +1,10 @@
 package org.scalafmt
 
+case class Decision(formatToken: FormatToken, split: List[Split])
+
 sealed abstract class Split(val cost: Int,
                             val indent: Int,
-                            val Strategy: Strategy = EmptyStrategy) {
+                            val policy: Decision => Decision = identity) {
   def length: Int = this match {
     case _: NoSplit => 0
     case _: Newline => 0
@@ -15,13 +17,14 @@ sealed abstract class Split(val cost: Int,
 case class NoSplit(override val cost: Int) extends Split(cost, 0)
 
 case class Space(override val cost: Int,
-                 override val Strategy: Strategy = EmptyStrategy)
-  extends Split(cost: Int, 0, Strategy)
+                 override val policy: Decision => Decision = identity)
+
+  extends Split(cost: Int, 0,  policy)
 
 case class Newline(override val cost: Int,
                    override val indent: Int,
-                   override val Strategy: Strategy = EmptyStrategy)
-  extends Split(cost, indent, Strategy)
+                   override val policy: Decision => Decision = identity)
+  extends Split(cost, indent, policy)
 
 // objects
 
@@ -29,7 +32,7 @@ object NoSplitFree extends NoSplit(0)
 
 object SpaceFree extends Space(0)
 
-class NewlineFree(indent: Int) extends Newline(0, indent, EmptyStrategy)
+class NewlineFree(indent: Int) extends Newline(0, indent)
 
 object Newline0 extends NewlineFree(0)
 

--- a/src/main/scala/org/scalafmt/State.scala
+++ b/src/main/scala/org/scalafmt/State.scala
@@ -4,13 +4,12 @@ package org.scalafmt
   * A state represents one potential solution to reach token at index,
   *
   * @param cost
-  * @param strategy
   * @param path
   * @param indentation
   * @param column
   */
 case class State(cost: Int,
-                 strategy: PartialFunction[FormatToken, List[Split]],
+                policy: Decision => Decision,
                  path: Vector[Split],
                  indentation: Int,
                  column: Int) extends Ordered[State] {
@@ -18,10 +17,11 @@ case class State(cost: Int,
   import scala.math.Ordered.orderingToOrdered
 
   def compare(that: State): Int =
-    (-this.cost, this.path.length) compare(-that.cost, that.path.length)
+    (-this.cost, this.path.length, -this.indentation) compare
+      (-that.cost, that.path.length, -that.indentation)
 }
 
 
 object State {
-  val start = State(0, EmptyStrategy, Vector.empty[Split], 0, 0)
+  val start = State(0, identity, Vector.empty[Split], 0, 0)
 }

--- a/src/main/scala/org/scalafmt/package.scala
+++ b/src/main/scala/org/scalafmt/package.scala
@@ -2,7 +2,4 @@ package org
 
 package object scalafmt {
 
-  type Strategy = PartialFunction[FormatToken, List[Split]]
-  val EmptyStrategy = PartialFunction.empty[FormatToken, List[Split]]
-
 }

--- a/src/test/resources/basic.test
+++ b/src/test/resources/basic.test
@@ -36,7 +36,7 @@ object aaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
   val bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     = 1
 }
-<<< SKIP case statement splits block, see #15.
+<<< case statement splits block, see #15.
 object Object {
   val x = { case 2 => 1
     case 1 => 3 }
@@ -46,6 +46,30 @@ object Object {
   val x = {
     case 2 => 1
     case 1 => 3
+  }
+}
+<<< One-liner object contains no newlines
+object Object { function_____________() }
+>>>
+object Object {
+  function_____________()
+}
+<<< One single-line, one multiline
+object Object { object Object______ { } }
+>>>
+object Object {
+  object Object______ {}
+}
+<<< SKIP One single-line, two multiline
+object Object {
+  object A { }
+  object B________________________ { bbbb }
+}
+>>>
+object Object {
+  object A { }
+  object B________________________ {
+    bbbb
   }
 }
 <<< SKIP #15 Split at higher levels


### PR DESCRIPTION
Policies replace strategies to enforcenon-local decisions. Policies are
applied to Splits before being saved to a state. This way you can for
example increase costs or remove illegal splits.