### PR TITLE
More polish.

### DIFF
--- a/src/main/scala/org/scalafmt/Split.scala
+++ b/src/main/scala/org/scalafmt/Split.scala
@@ -54,12 +54,17 @@ case class Split(modification: Modification,
 
   }
 
+  val indentation = indents.map(_.length match {
+    case Num(x) => x.toString
+    case _ => toString
+  }).mkString("[", ", ", "]")
+
   def withModification(newModification: Modification): Split =
     new Split(newModification, cost, ignoreIf, indents, policy, penalty,
       optimalAt)(line)
 
   override def toString =
-    s"""$modification:${line.value}(cost=$cost${if (indents.nonEmpty) s", indent=$indents" else ""})"""
+    s"""$modification:${line.value}(cost=$cost, indents=$indentation)"""
 
   // TODO(olafur) come with better concept of split equality.
   // For example update line in withOptimal.

--- a/src/main/scala/org/scalafmt/State.scala
+++ b/src/main/scala/org/scalafmt/State.scala
@@ -87,7 +87,7 @@ object State extends ScalaFmtLogger {
       case (tok, split) =>
         // TIP. Use the following line to debug origin of splits.
         if (debug)
-          logger.debug(f"${tok.left.code.slice(0, 10)}%-10s $split ${state.pushes}")
+          logger.debug(f"${tok.left.code.slice(0, 10)}%-10s $split")
         state = state.next(style, split, tok)
         val whitespace = split.modification match {
           case Space => " "

--- a/src/main/scala/org/scalafmt/package.scala
+++ b/src/main/scala/org/scalafmt/package.scala
@@ -22,4 +22,12 @@ package object scalafmt {
   def childOf(tok: Token, tree: Tree, owners: Map[Token, Tree]): Boolean =
     childOf(owners(tok), tree)
 
+  // TODO(olafur) Move these elsewhere.
+  @tailrec
+  final def parents(tree: Tree, accum: Seq[Tree] = Seq.empty): Seq[Tree] = {
+    tree.parent match {
+      case Some(parent) => parents(parent, parent +: accum)
+      case _ => accum
+    }
+  }
 }

--- a/src/test/resources/standard/Apply.stat
+++ b/src/test/resources/standard/Apply.stat
@@ -1,5 +1,5 @@
 80 columns                                                                     |
-<<< Massive argument
+<<< Massive 1
 List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
            Split(nl, 1).withPolicy({
              case Decision(t@FormatToken(_, `close`, _), s) =>
@@ -11,7 +11,7 @@ List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
        case Decision(t@FormatToken(_, `close`, _), s) =>
          Decision(t, List(Split(Newline, 0)))
      }).withIndent(2, close, Right))
-<<< Massive argument 2
+<<< Massive 2
  List(Split(Space,
             0,
             policy = SingleLineBlock(close),
@@ -31,3 +31,51 @@ List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
             policy = {
             case Decision(t@FormatToken(_, `close`, _), s) =>
             Decision(t, List(Split(Newline, 0)))
+<<< Massive (good API) 3
+Split(Space, 0).withPolicy {
+    // Following case:
+    // package foo // this is cool
+    //
+    // object a
+    case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
+        if !between.exists(_.isInstanceOf[`\n`]) =>
+      Decision(t, splits.map(_.withModification(Space)))
+    case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
+      Decision(t, splits.map(_.withModification(Newline2x)))
+}
+>>>
+Split(Space, 0).withPolicy {
+  // Following case:
+  // package foo // this is cool
+  //
+  // object a
+  case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
+      if !between.exists(_.isInstanceOf[`\n`]) =>
+    Decision(t, splits.map(_.withModification(Space)))
+  case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
+    Decision(t, splits.map(_.withModification(Newline2x)))
+}
+<<< Massive (bad API) 3
+Split(Space, 0, policy = {
+    // Following case:
+    // package foo // this is cool
+    //
+    // object a
+    case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
+        if !between.exists(_.isInstanceOf[`\n`]) =>
+      Decision(t, splits.map(_.withModification(Space)))
+    case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
+      Decision(t, splits.map(_.withModification(Newline2x)))
+})
+>>>
+Split(Space, 0, policy = {
+      // Following case:
+      // package foo // this is cool
+      //
+      // object a
+      case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
+          if !between.exists(_.isInstanceOf[`\n`]) =>
+        Decision(t, splits.map(_.withModification(Space)))
+      case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
+        Decision(t, splits.map(_.withModification(Newline2x)))
+    })

--- a/src/test/resources/standard/Class.stat
+++ b/src/test/resources/standard/Class.stat
@@ -16,3 +16,7 @@ case class State(
 case class State(cost: Int, policy: Decision => Decision,
     splits: Vector[Split], indentation: Int, indents: Vector[Push],
     column: Int) extends Ordered[State] with ScalaFmtLogger
+<<< With targs
+case class Indent[ T <: Length] (length: T, expire: Token, expiresAt: ExpiresOn)
+>>>
+case class Indent[T <: Length](length: T, expire: Token, expiresAt: ExpiresOn)

--- a/src/test/resources/standard/Select.stat
+++ b/src/test/resources/standard/Select.stat
@@ -1,0 +1,35 @@
+80 columns                                                                     |
+<<< Break on .
+val expire =
+        owner.body.tokens.filterNot(_.isInstanceOf[Whitespace]).lastOption.getOrElse(
+            arrow)
+>>>
+val expire = owner.body.tokens.filterNot(_.isInstanceOf[Whitespace]).lastOption
+  .getOrElse(arrow)
+<<< Bind . to closing }
+map {
+    // foo
+} .withIndent
+>>>
+map {
+  // foo
+}.withIndent
+<<< Break on . 2
+Split(NoSplit, 0, policy = SingleLineBlock(owner.thenp.tokens.last)).withIndent(
+              StateColumn, close, Left)
+>>>
+Split(NoSplit, 0, policy = SingleLineBlock(owner.thenp.tokens.last))
+  .withIndent(StateColumn, close, Left)
+<<< Break on . 3
+val expire = owner.tokens.find(_.isInstanceOf[`{`]).getOrElse(owner.tokens.last)
+>>>
+val expire = owner.tokens.find(_.isInstanceOf[`{`])
+  .getOrElse(owner.tokens.last)
+<<< state explosion
+a.b.c.d.e.f.g.h.i.j.k {
+// Crazy comment =================================================================>
+}
+>>>
+a.b.c.d.e.f.g.h.i.j.k {
+  // Crazy comment =================================================================>
+}

--- a/src/test/resources/standard/Val.stat
+++ b/src/test/resources/standard/Val.stat
@@ -5,3 +5,8 @@ val newIndents: Vector[Indent[Num]]
 >>>
 val newIndents: Vector[Indent[Num]] =
   nonExpiredIndents ++ split.indents.map(_.withNum(column, indentation))
+<<< Don't break
+var inside =
+    false
+>>>
+var inside = false

--- a/src/test/resources/unit/Case.stat
+++ b/src/test/resources/unit/Case.stat
@@ -50,3 +50,35 @@ x match {
   case 2 => 1
   case 1 => 3
 }
+<<< Bind comment to case
+x match {
+
+    case 1 =>
+      banana
+      1
+    // I bind to default
+    case default => ???
+}
+>>>
+x match {
+  case 1 =>
+    banana
+    1
+  // I bind to default
+  case default => ???
+}
+<<< Bind comment to body
+x match {
+    case 1 =>
+      banana
+      1 // I bind to 1
+
+    case default => ???
+}
+>>>
+x match {
+  case 1 =>
+    banana
+    1 // I bind to 1
+  case default => ???
+}

--- a/src/test/resources/unit/If.stat
+++ b/src/test/resources/unit/If.stat
@@ -21,12 +21,3 @@ val newColumn = if(split == Newline) newIndent
 val newColumn =
   if (split == Newline) newIndent
   else column + split.length
-<<< If assignment with parens
-val newColumn = tok.length + (
-if(split == Newline) newIndent
-else column + split.length)
->>>
-val newColumn =
-  tok.length + (
-    if (split == Newline) newIndent
-    else column + split.length)

--- a/src/test/resources/unit/TermApply.stat
+++ b/src/test/resources/unit/TermApply.stat
@@ -34,20 +34,20 @@ new Compiler(
     sourceMap.options.has("source-map"));
 >>>
 new Compiler(
-    assertions.options.has(
-        "checked-mode"),
-    annotations.options.has(
-        "annotations"),
-    primitives.options.has(
-        "primitives"),
+    assertions.options
+      .has("checked-mode"),
+    annotations.options
+      .has("annotations"),
+    primitives.options
+      .has("primitives"),
     minify.options.has("minify"),
     preserve.options.has("preserve"),
-    liveAnalysis.check(
-        options.has("live"),
-        options.has("analysis")),
+    liveAnalysis
+      .check(options.has("live"),
+             options.has("analysis")),
     multi.options.has("multi"),
-    sourceMap.options.has(
-        "source-map"));
+    sourceMap.options
+      .has("source-map"));
 <<< SKIP comment after (
 var list = List( // comment
   function(a: A, b: B, c: C)

--- a/src/test/resources/unit/UnaryApply.stat
+++ b/src/test/resources/unit/UnaryApply.stat
@@ -11,3 +11,26 @@
 -this.foo
 >>>
 -this.foo
+<<< Tuple with first unary
+( -this.cost, this.splits.length,
+-this.indentation)
+>>>
+(-this.cost,
+ this.splits.length,
+ -this.indentation)
+<<< bang
+(
+          !right.isInstanceOf[Comment] ||
+          between.exists(_.isInstanceOf[`\n`]))
+>>>
+(!right.isInstanceOf[Comment] ||
+  between.exists(_.isInstanceOf[`\n`]))
+<<< If assignment with parens
+val newColumn = tok.length + (
+if(split == Newline) newIndent
+else column + split.length)
+>>>
+val newColumn =
+  tok.length + (
+    if (split == Newline) newIndent
+    else column + split.length)

--- a/src/test/scala/org/scalafmt/ManualTests.scala
+++ b/src/test/scala/org/scalafmt/ManualTests.scala
@@ -6,7 +6,7 @@ object ManualTests extends HasTests {
 
   val manual = ".manual"
 
-  def tests: Seq[DiffTest] = {
+  lazy val tests: Seq[DiffTest] = {
     import FilesUtil._
     val manualFiles = for {
       filename <- listFiles(testDir) if filename.endsWith(manual)

--- a/src/test/scala/org/scalafmt/UnitTests.scala
+++ b/src/test/scala/org/scalafmt/UnitTests.scala
@@ -2,7 +2,7 @@ package org.scalafmt
 
 object UnitTests extends HasTests with ScalaFmtLogger {
 
-  override def tests: Seq[DiffTest] = {
+  override lazy val tests: Seq[DiffTest] = {
     import FilesUtil._
     for {
       filename <- listFiles(testDir) if filename2parse(filename).isDefined


### PR DESCRIPTION
* Fix output for remaining ugliest parts of Formatter.scala, including
* sequences of select/apply: a.b(c.d).e(f).g. PROBLEM: this again causes
  formatter to choke.
* Await for 20 seconds to submit results if running on Travis.
* Treat blocks inside arguments as 1 character width.  Not sure if this
  makes sense in all cases, but gives nice results in my tests.