### PR TITLE
OptimalAt keyed by state.column -> format token.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ pomExtra := (
     </developers>)
 
 libraryDependencies ++= Seq(
+  "com.github.scopt" %% "scopt" % "3.3.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "ch.qos.logback" % "logback-classic" % "1.1.3",
   "org.scalameta" %% "scalameta" % "0.0.5-M1",
@@ -44,4 +45,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
 
+mainClass in assembly := Some("org.scalafmt.Cli")
 
+assemblyJarName in assembly := "scalafmt.jar"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/src/main/scala/org/scalafmt/Cli.scala
+++ b/src/main/scala/org/scalafmt/Cli.scala
@@ -1,0 +1,30 @@
+package org.scalafmt
+
+import java.io.File
+
+import scala.io.Source
+
+case class Config(stdin: Boolean = true,
+                  file: Option[File] = None, // Must be set if stdin is false.
+                  rangeFrom: Option[Int] = None,
+                  rangeTo: Option[Int] = None)
+
+object Cli extends App {
+  val parser = new scopt.OptionParser[Config]("scalafmt") {
+    head("scalafmt", "0.1")
+    opt[Int]("from") action { (from, c) =>
+      c.copy(rangeFrom = Some(from))
+    } text "from must be an int."
+    opt[Int]("to") action { (to, c) =>
+      c.copy(rangeTo = Some(to))
+    } text "to must be an int."
+    opt[File]('f', "file") action { (file, c) =>
+      c.copy(file = Some(file))
+    } text "std must be bool."
+  }
+
+  val code = Source.fromInputStream(System.in).getLines().mkString("\n")
+  val fmt = new ScalaFmt(Standard)
+  val output = fmt.formatSource(code)
+  println(output)
+}

--- a/src/main/scala/org/scalafmt/State.scala
+++ b/src/main/scala/org/scalafmt/State.scala
@@ -27,7 +27,7 @@ case class State(cost: Int,
   def alwaysBetter(other: State): Boolean =
     this.cost <= other.cost && this.indentation <= other.indentation
 
-  override def toString = s"State($cost, ${splits.length}, $splits)"
+  override def toString = s"State($cost, ${splits.length})"
 
 
   /**

--- a/src/test/resources/standard/Case.stat
+++ b/src/test/resources/standard/Case.stat
@@ -12,3 +12,30 @@ val Route: PartialFunction[Decision, Decision] = {
       _: Ident | _: `this` | _: `_ ` | _: `(`, _: `.` | _: `#`, _) =>
     List(NoSplit0)
 }
+<<< What idiot wrote this code
+List(Split(Space, 0).withPolicy {
+            case Decision(t, s) if tok.right.end <= lastToken.end =>
+              Decision(t, s.map {
+                    case nl if nl.modification.isNewline =>
+                      val result =
+                        if (t.right.isInstanceOf[`if`] &&
+                            owners(t.right) == owner)
+                          nl
+                        else nl.withPenalty(1)
+                      result.withPolicy(breakOnArrow)
+                    case x => x
+                  })
+            })
+>>>
+List(Split(Space, 0).withPolicy {
+      case Decision(t, s) if tok.right.end <= lastToken.end =>
+        Decision(t, s.map {
+              case nl if nl.modification.isNewline =>
+                val result =
+                  if (t.right.isInstanceOf[`if`] && owners(t.right) == owner)
+                    nl
+                  else nl.withPenalty(1)
+                result.withPolicy(breakOnArrow)
+              case x => x
+            })
+    })

--- a/src/test/resources/standard/If.stat
+++ b/src/test/resources/standard/If.stat
@@ -1,0 +1,8 @@
+80 columns                                                                     |
+<<< Break before then condition
+if (between.lastOption.exists(_.isInstanceOf[`\n`])) List(Split(NoIndentNewline, 0))
+else List(Split(Newline, 0))
+>>>
+if (between.lastOption.exists(_.isInstanceOf[`\n`]))
+  List(Split(NoIndentNewline, 0))
+else List(Split(Newline, 0))

--- a/src/test/resources/standard/Select.stat
+++ b/src/test/resources/standard/Select.stat
@@ -1,4 +1,12 @@
 80 columns                                                                     |
+<<< basic
+a .b .c
+>>>
+a.b.c
+<<< longer
+val logger = Logger(this .getClass)
+>>>
+val logger = Logger(this.getClass)
 <<< Break on .
 val expire =
         owner.body.tokens.filterNot(_.isInstanceOf[Whitespace]).lastOption.getOrElse(
@@ -31,5 +39,13 @@ a.b.c.d.e.f.g.h.i.j.k {
 }
 >>>
 a.b.c.d.e.f.g.h.i.j.k {
+  // Crazy comment =================================================================>
+}
+<<< state explosion 2
+a.b(c).d(e).f(g).h(i).j(k) {
+// Crazy comment =================================================================>
+}
+>>>
+a.b(c).d(e).f(g).h(i).j(k) {
   // Crazy comment =================================================================>
 }

--- a/src/test/resources/unit/Case.stat
+++ b/src/test/resources/unit/Case.stat
@@ -82,3 +82,13 @@ x match {
     1 // I bind to 1
   case default => ???
 }
+<<< partial function
+parens.foreach {
+  case (_: `{`, _: `}`) =>
+  case (_: `}`, _: `{`) =>
+}
+>>>
+parens.foreach {
+  case (_: `{`, _: `}`) =>
+  case (_: `}`, _: `{`) =>
+}

--- a/src/test/resources/unit/If.stat
+++ b/src/test/resources/unit/If.stat
@@ -21,3 +21,4 @@ val newColumn = if(split == Newline) newIndent
 val newColumn =
   if (split == Newline) newIndent
   else column + split.length
+

--- a/src/test/resources/unit/TermApply.stat
+++ b/src/test/resources/unit/TermApply.stat
@@ -1,12 +1,4 @@
 40 columns                              |
-<<< basic
-a .b .c
->>>
-a.b.c
-<<< longer
-val logger = Logger(this .getClass)
->>>
-val logger = Logger(this.getClass)
 <<< one arg chained (state explosion)
 a(b).c(d).e(f).g(h).i(j).k { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa }
 >>>
@@ -22,6 +14,30 @@ function(
     firstCall(a, b, c, d, e, f, g, h),
     secondCall(
         "very long argument string"));
+<<< Presentation
+MyObject(config.getBoolean("shortKey"),
+         config.getString("reallyReallyReallyLongKey"),
+         liveAnalysis.check(options.has("live"),
+                            options.has("analysis")))
+>>>
+MyObject(
+    config.getBoolean("shortKey"),
+    config.getString(
+        "reallyReallyReallyLongKey"),
+    liveAnalysis
+      .check(options.has("live"),
+             options.has("analysis")))
+<<< optimalAt memoization is by split prefix
+new Compiler(
+    primitives.options.has("primitives"),
+    minify.options.has("minify"),
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+>>>
+new Compiler(
+    primitives.options
+      .has("primitives"),
+    minify.options.has("minify"),
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
 <<< Prune redundant branches
 new Compiler(
     assertions.options.has("checked-mode"),
@@ -82,3 +98,11 @@ var list = List(
     function(a: A, b: B, c: C),
     function(a: A, b: B, c: C),
     function(a: A, b: B, c: C));
+<<< Single line with block {}
+function(a, b, c, {
+    case Foo("a", 1) => Foo("b", 2)
+  })
+>>>
+function(a, b, c, {
+      case Foo("a", 1) => Foo("b", 2)
+    })

--- a/src/test/scala/org/scalafmt/FormatTest.scala
+++ b/src/test/scala/org/scalafmt/FormatTest.scala
@@ -108,16 +108,14 @@ class FormatTest
       val fmt = new ScalaFmt(t.style)
       test(paddedName) {
         Debug.newTest()
-        failAfter(10 seconds) {
-          filename2parse(t.filename) match {
-            case Some(parse) =>
-              val obtained = fmt.format(t.original)(parse)
-              saveResult(t, obtained)
-              assertParses(obtained, t.original)(parse)
-              assertNoDiff(obtained, t.expected)
-            case None =>
-              logger.warn(s"Found no parse for filename ${t.filename}")
-          }
+        filename2parse(t.filename) match {
+          case Some(parse) =>
+            val obtained = fmt.format(t.original)(parse)
+            saveResult(t, obtained)
+            assertParses(obtained, t.original)(parse)
+            assertNoDiff(obtained, t.expected)
+          case None =>
+            logger.warn(s"Found no parse for filename ${t.filename}")
         }
       }
     }

--- a/src/test/scala/org/scalafmt/ProjectTest.scala
+++ b/src/test/scala/org/scalafmt/ProjectTest.scala
@@ -4,6 +4,8 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.CopyOnWriteArrayList
 
+import org.scalatest.FunSuite
+
 import collection.JavaConversions._
 
 import scala.concurrent.Await
@@ -16,7 +18,7 @@ import scala.meta._
  * Mostly borrowed from
  * https://github.com/lihaoyi/fastparse/blob/0d67eca8f9264bfaff68e5cbb227045ceac4a15f/scalaparse/jvm/src/test/scala/scalaparse/ProjectTests.scala
  */
-class ProjectTest {
+object ProjectTest extends App {
 
   var parseFailures: java.util.List[ParseErr] = new CopyOnWriteArrayList
   var otherFailures: java.util.List[UnknownFailure] = new CopyOnWriteArrayList
@@ -105,7 +107,7 @@ class ProjectTest {
 
   def bullet[T](msg: T) = s"* $msg"
 
-  def run: Unit = {
+  def run(): Unit = {
     checkRepo("https://github.com/scala/scala", scalaIgnore)
     checkRepo("https://github.com/akka/akka")
     checkRepo("https://github.com/apache/spark")
@@ -160,4 +162,5 @@ class ProjectTest {
     println(f"Successes: ${successes.length}, avg time to parse a single file $avgTime%2.2f ms")
     println(s"Skipped: ${skipped.length}")
   }
+  run()
 }


### PR DESCRIPTION
We must key by column to prevent bugs like in test unit/TermApply
optimalAt memoization.

* Fix cost of newline before if in cond.
* Make compare report green when shrinking state.
* Demo CLI interface for vim integration.
* Fixed bug in partial functions.