### PR TITLE
Prepare for optimisations.

### DIFF
--- a/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -57,8 +57,15 @@ abstract class FormatBenchmark(path: String*) {
   }
 
   @Benchmark
+  def scalametaParser(): Unit = {
+    import scala.meta._
+    code.parse[Source]
+  }
+
+  @Benchmark
   def scalafmt(): String = {
-    ScalaFmt.format_![Source](code, ScalaStyle.Standard)(scala.meta.parsers.parseSource)
+    ScalaFmt.format_![Source](code,
+      ScalaStyle.Standard)(scala.meta.parsers.parseSource)
   }
 
   @Benchmark

--- a/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
+++ b/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
@@ -1,9 +1,12 @@
 package org.scalafmt
 
+import org.scalafmt.util.FormatAssertions
 import org.scalatest.FunSuite
 
-class BenchmarkOK extends FunSuite {
+class BenchmarkOK extends FunSuite with FormatAssertions {
   import org.scalafmt.benchmarks.run._
+
+  import scala.meta._
 
   // TODO(olafur) DRY.
   val formatBenchmarks = Seq(
@@ -11,8 +14,8 @@ class BenchmarkOK extends FunSuite {
     new Utils,
     new SourceMapWriter,
    // TODO(olafur) make larger files integration tests.
-//    new Division,
-//    new BaseLinker,
+    new Division,
+    new BaseLinker,
     new JsDependency
   )
   formatBenchmarks.foreach { formatBenchmark =>

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val buildSettings = Seq(
       Wart.Nothing, // Can't provide explicit type for scala.meta.Tree.collect.
       Wart.ToString, // Issues in logger, solvable with Loggable typeclass.
       Wart.Any, // Issues in logger with format strings.
+      Wart.AsInstanceOf, // pops up in pattern matching, why? It's guarded.
 
       Wart.Throw,
       Wart.NoNeedForMonad,
@@ -136,5 +137,5 @@ lazy val benchmarks = project
       "-Xmx2G",
       "-server"
     )
-  ).dependsOn(core)
+  ).dependsOn(core % "compile->test")
   .enablePlugins(JmhPlugin)

--- a/core/src/main/scala/org/scalafmt/ScalaStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalaStyle.scala
@@ -52,7 +52,7 @@ object ScalaStyle {
   protected[scalafmt] case object ManualTest extends ScalaStyle {
     override val debug = true
 
-    override def maxStateVisits = 20000
+    override def maxStateVisits = 50000
 
     override def maxDuration = Duration(10, "min")
   }

--- a/core/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -7,4 +7,4 @@ import org.scalafmt._
   *
   * Used by [[Policy]] to enforce non-local formatting.
   */
-case class Decision(formatToken: FormatToken, split: List[Split])
+case class Decision(formatToken: FormatToken, splits: Seq[Split])

--- a/core/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -1,0 +1,32 @@
+package org.scalafmt.internal
+
+
+/**
+  * The decision made by [[Router]].
+  *
+  * Used by [[Policy]] to enforce non-local formatting.
+  *
+  * @param f is applied to every decision until expire
+  * @param expire The latest token offset.
+  */
+case class Policy(f: PartialFunction[Decision, Decision],
+                  expire: Int, noDequeue: Boolean = false)(implicit val line: sourcecode.Line) {
+
+  def apply(decision: Decision): Decision = f(decision)
+
+  def orElse(other: Policy): Policy =
+    Policy(f orElse other.f, Math.max(expire, other.expire),
+      // TODO(olafur) wrong in some corner cases
+      noDequeue || other.noDequeue )
+
+  override def toString = s"P:${line.value}(D=$noDequeue)"
+
+}
+
+object Policy {
+  val IdentityPolicy: PartialFunction[Decision, Decision] = {
+    case d => d
+  }
+  val empty = Policy(IdentityPolicy, Integer.MAX_VALUE)
+}
+

--- a/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -1,0 +1,27 @@
+package org.scalafmt.internal
+
+class PolicySummary(val policies: Seq[Policy]) {
+
+  val noDequeue = policies.exists(_.noDequeue)
+
+  def combine(other: Policy, position: Int): PolicySummary = {
+    // TODO(olafur) filter policies by expiration date
+//    val activePolicies = policies.filter(_.expire >= position)
+      new PolicySummary(policies :+ other)
+    }
+
+  def execute(decision: Decision): Decision = {
+    var result = decision
+    policies.foreach { policy =>
+      if (policy.f.isDefinedAt(result)) {
+        result = policy.f(result)
+      }
+    }
+    result
+  }
+}
+
+
+object PolicySummary {
+  val empty = new PolicySummary(Seq.empty[Policy])
+}

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -24,10 +24,13 @@ import scala.meta.tokens.Token._
   */
 class Router(style: ScalaStyle,
              tree: Tree,
-             toks: Array[FormatToken],
-             matching: Map[Token, Token],
-             statementStarts: Map[Token, Tree],
-             owners: Map[Token, Tree]) extends ScalaFmtLogger {
+             tokens: Array[FormatToken],
+             matchingParentheses: Map[Long, Token],
+             statementStarts: Map[Long, Tree],
+             ownersMap: Map[Long, Tree]) extends ScalaFmtLogger {
+
+  @inline def owners(token: Token): Tree =
+    ownersMap(hash(token))
 
   /*
    * The tokens on the left hand side of Pkg
@@ -49,490 +52,506 @@ class Router(style: ScalaStyle,
     result.toSet
   }
 
-  private val leftTok2tok: Map[Token, FormatToken] = toks.map(t => t.left -> t).toMap
-  private val tok2idx: Map[FormatToken, Int] = toks.zipWithIndex.toMap
-  private val cache = mutable.Map.empty[FormatToken, List[Split]]
+  private val leftTok2tok: Map[Token, FormatToken] =
+    tokens.map(t => t.left -> t).toMap
+  private val tok2idx: Map[FormatToken, Int] = tokens.zipWithIndex.toMap
+  private val cache = mutable.Map.empty[FormatToken, Seq[Split]]
   // TODO(olafur) move into function, store owners(left/right), etc.
-  private val RouteRun: PartialFunction[FormatToken, List[Split]] = {
-    case FormatToken(_: BOF, _, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_, _: EOF, _) => List(
-      Split(Newline, 0) // End files with trailing newline
-    )
-    case tok if tok.left.name.startsWith("xml") &&
-      tok.right.name.startsWith("xml") => List(
-      Split(NoSplit, 0)
-    )
-    case tok if // TODO(olafur) DRY.
-    (owners(tok.left).isInstanceOf[Term.Interpolate] &&
-      owners(tok.right).isInstanceOf[Term.Interpolate]) ||
-      (owners(tok.left).isInstanceOf[Pat.Interpolate] &&
-        owners(tok.right).isInstanceOf[Pat.Interpolate]) =>
-      List(
+
+  def getSplits(formatToken: FormatToken): Seq[Split] = {
+    val leftOwner = owners(formatToken.left)
+    val rightOwner = owners(formatToken.right)
+    formatToken match {
+      case FormatToken(_: BOF, _, _) => Seq(
         Split(NoSplit, 0)
       )
-    case FormatToken(_: `{`, _: `}`, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_: `]`, _: `(`, _) => List(
-      Split(NoSplit, 0)
-    )
-    // Import
-    case FormatToken(_: `.`, open: `{`, _) if parents(owners(open)).exists(_.isInstanceOf[Import]) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(open: `{`, _, _) if parents(owners(open)).exists(_.isInstanceOf[Import]) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_, close: `}`, _) if parents(owners(close)).exists(_.isInstanceOf[Import]) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_: `.`, underscore: `_ `, _) if parents(owners(underscore)).exists(_.isInstanceOf[Import]) => List(
-      Split(NoSplit, 0)
-    )
-    // { ... } Blocks
-    case tok @ FormatToken(open: `{`, right, between) =>
-      val startsLambda = statementStarts.get(right)
-        .exists(_.isInstanceOf[Term.Function])
-      val nl = Newline(gets2x(nextNonComment(tok)), rhsIsCommentedOut(tok))
-      val close = matching(open)
-      val blockSize = close.start - open.end
-      val ignore = blockSize > style.maxColumn || isInlineComment(right)
-      val newlineBeforeClosingCurly: Policy = {
-        case Decision(t @ FormatToken(_, `close`, _), s) =>
-          Decision(t, List(Split(Newline, 0)))
-      }
-      val skipSingleLineBlock = ignore || startsLambda ||
-        newlinesBetween(between) > 0
-      List(
-        Split(Space, 0, ignoreIf = skipSingleLineBlock)
-          .withPolicy(SingleLineBlock(close)),
-        Split(Space, 0, ignoreIf = !startsLambda)
-          .withPolicy(newlineBeforeClosingCurly),
-        Split(nl, 1).withPolicy(newlineBeforeClosingCurly)
-          .withIndent(2, close, Right)
+      case FormatToken(_, _: EOF, _) => Seq(
+        Split(Newline, 0) // End files with trailing newline
       )
-    case FormatToken(_: `(`, _: `(` | _: `{`, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_, _: `{`, _) => List(
-      Split(Space, 0)
-    )
-    case tok: FormatToken if !isDocstring(tok.left) && gets2x(tok) => List(
-      Split(Newline2x, 0)
-    )
-    case FormatToken(arrow: `=>`, right, _) if statementStarts.contains(right) &&
-      owners(arrow).isInstanceOf[Term.Function] =>
-      val endOfFunction = owners(arrow).tokens.last
-      List(
-        Split(Newline, 0).withIndent(2, endOfFunction, Left)
+      case tok if tok.left.name.startsWith("xml") &&
+        tok.right.name.startsWith("xml") => Seq(
+        Split(NoSplit, 0)
       )
-    // New statement
-    case tok @ FormatToken(left, right, between) if statementStarts.contains(right) =>
-      val newline: Modification =
-        if ((gets2x(tok) ||
-          newlinesBetween(tok.between) > 1) &&
-          !(isDocstring(left) && newlinesBetween(between) < 2)) Newline2x
-        else Newline
-      List(
-        Split(newline, 0)
+      case tok if // TODO(olafur) DRY.
+      (leftOwner.isInstanceOf[Term.Interpolate] &&
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
+        (leftOwner.isInstanceOf[Pat.Interpolate] &&
+          rightOwner.isInstanceOf[Pat.Interpolate]) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      case FormatToken(_: `{`, _: `}`, _) => Seq(
+        Split(NoSplit, 0)
       )
-
-    case FormatToken(_, _: `}`, _) => List(
-      Split(Space, 0),
-      Split(Newline, 0)
-    )
-    case FormatToken(left: `package `, _, _) if owners(left).isInstanceOf[Pkg] =>
-      List(
+      case FormatToken(_: `]`, _: `(`, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      // Import
+      case FormatToken(_: `.`, open: `{`, _)
+        if parents(rightOwner).exists(_.isInstanceOf[Import]) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(open: `{`, _, _)
+        if parents(leftOwner).exists(_.isInstanceOf[Import]) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_, close: `}`, _)
+        if parents(rightOwner).exists(_.isInstanceOf[Import]) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_: `.`, underscore: `_ `, _)
+        if parents(rightOwner).exists(_.isInstanceOf[Import]) => Seq(
+        Split(NoSplit, 0)
+      )
+      // { ... } Blocks
+      case tok@FormatToken(open: `{`, right, between) =>
+        val startsLambda = statementStarts.get(hash(right))
+          .exists(_.isInstanceOf[Term.Function])
+        val nl = Newline(gets2x(nextNonComment(tok)), rhsIsCommentedOut(tok))
+        val close = matchingParentheses(hash(open))
+        val blockSize = close.start - open.end
+        val ignore = blockSize > style.maxColumn || isInlineComment(right)
+        val newlineBeforeClosingCurly = Policy({
+          case Decision(t@FormatToken(_, `close`, _), s) =>
+            Decision(t, Seq(Split(Newline, 0)))
+        }, close.end)
+        val skipSingleLineBlock = ignore || startsLambda ||
+          newlinesBetween(between) > 0
+        Seq(
+          Split(Space, 0, ignoreIf = skipSingleLineBlock)
+            .withPolicy(SingleLineBlock(close)),
+          Split(Space, 0, ignoreIf = !startsLambda)
+            .withPolicy(newlineBeforeClosingCurly),
+          Split(nl, 1).withPolicy(newlineBeforeClosingCurly)
+            .withIndent(2, close, Right)
+        )
+      case FormatToken(_: `(`, _: `(` | _: `{`, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_, _: `{`, _) => Seq(
         Split(Space, 0)
       )
-    // Opening [ with no leading space.
-    case FormatToken(left, open: `[`, _) if owners(open).isInstanceOf[Term.ApplyType] ||
-      owners(left).isInstanceOf[Type.Name] => List(
-      Split(NoSplit, 0)
-    )
-    // Opening ( with no leading space.
-    case FormatToken(left, open: `(`, _) if owners(open).isInstanceOf[Term.Apply] ||
-      owners(left).parent.exists(_.isInstanceOf[Defn.Def]) ||
-      owners(left).parent.exists(_.isInstanceOf[Defn.Class]) =>
-      List(
-        Split(NoSplit, 0)
+      case tok: FormatToken if !isDocstring(tok.left) && gets2x(tok) => Seq(
+        Split(Newline2x, 0)
       )
-    // NOTE. && and || are infix applications, this case is before ApplyInfix.
-    case FormatToken(cond: Ident, _, _) if cond.code == "&&" || cond.code == "||" =>
-      List(
+      case FormatToken(arrow: `=>`, right, _)
+        if statementStarts.contains(hash(right)) &&
+        leftOwner.isInstanceOf[Term.Function] =>
+        val endOfFunction = leftOwner.tokens.last
+        Seq(
+          Split(Newline, 0).withIndent(2, endOfFunction, Left)
+        )
+      // New statement
+      case tok@FormatToken(left, right, between)
+        if statementStarts.contains(hash(right)) =>
+        val newline: Modification =
+          if ((gets2x(tok) ||
+            newlinesBetween(tok.between) > 1) &&
+            !(isDocstring(left) && newlinesBetween(between) < 2)) Newline2x
+          else Newline
+        Seq(
+          Split(newline, 0)
+        )
+
+      case FormatToken(_, _: `}`, _) => Seq(
         Split(Space, 0),
-        Split(Newline, 1)
-      )
-
-    // Defn.{Object, Class, Trait}
-    case tok @ FormatToken(_: `object` | _: `class ` | _: `trait`, _, _) =>
-      val owner = owners(tok.left)
-      val expire = defnTemplate(owner).flatMap { templ =>
-        templ.tokens.find(_.isInstanceOf[`{`])
-      }.getOrElse(owner.tokens.last)
-      List(
-        Split(Space, 0).withIndent(4, expire, Left)
-      )
-    // DefDef
-    //     TODO(olafur) Naive match, can be 1) comment between 2) abstract decl.
-    case tok @ FormatToken(d: `def`, name: Ident, _) =>
-      val owner = owners(d)
-      val expire = owner.tokens.
-        find(t => t.isInstanceOf[`=`] && owners(t) == owner)
-        .getOrElse(owner.tokens.last)
-      List(
-        Split(Space, 0).withIndent(4, expire, Left)
-      )
-    case FormatToken(e: `=`, _, _) if owners(e).isInstanceOf[Defn.Def] =>
-      val expire = owners(e).asInstanceOf[Defn.Def].body.tokens.last
-      List(
-        Split(Space, 0, policy = SingleLineBlock(expire)),
-        Split(Newline, 0).withIndent(2, expire, Left)
-      )
-    case tok @ FormatToken(_, open: `[`, _) if owners(open).isInstanceOf[Defn.Def] =>
-      List(
-        Split(NoSplit, 0)
-      )
-    case tok @ FormatToken(open: `(`, _, _) if owners(open).isInstanceOf[Defn] ||
-      owners(open).parent.exists(_.isInstanceOf[Defn.Class]) =>
-      List(
-        Split(NoSplit, 0)
-      )
-    // TODO(olafur) Split this up.
-    case tok @ FormatToken(_: `(` | _: `[`, right, between) if owners(tok.left).isInstanceOf[Term.Apply] ||
-      owners(tok.left).isInstanceOf[Pat.Extract] ||
-      owners(tok.left).isInstanceOf[Pat.Tuple] ||
-      owners(tok.left).isInstanceOf[Term.Tuple] ||
-      owners(tok.left).isInstanceOf[Term.ApplyType] ||
-      owners(tok.left).isInstanceOf[Type.Apply] =>
-      val open = tok.left.asInstanceOf[Delim]
-      val (lhs, args): (Tree, Seq[Tree]) = owners(tok.left) match {
-        case t: Term.Apply => t.fun -> t.args
-        case t: Pat.Extract => t.ref -> t.args
-        case t: Pat.Tuple => t -> t.elements
-        case t: Term.ApplyType => t -> t.targs
-        case t: Term.Tuple => t -> t.elements
-        case t: Type.Apply => t.tpe -> t.args
-      }
-      val close = matching(open)
-      val expire = matching(open)
-      // TODO(olafur) recursively?
-      val optimalTok: Token = rhsOptimalToken(leftTok2tok(close))
-      // In long sequence of select/apply, we penalize splitting on
-      // parens furthest to the right.
-      val lhsPenalty = lhs.tokens.length
-      val nestedPenalty = NestedApplies(owners(open))
-
-      val exclude = insideBlock(tok, close)
-      val indent = owners(open) match {
-        case _: Pat => Num(0) // Indentation already provided by case.
-        // TODO(olafur) This is an odd rule, when is it wrong?
-        case _ => Num(4)
-      }
-      val singleArgument = args.length == 1
-
-      val singleLine = // Don't force single line policy if only one argument.
-        if (singleArgument) NoPolicy
-        else SingleLineBlock(close, exclude)
-      val oneArgOneLine = OneArgOneLineSplit(open)
-      val modification =
-        if (right.isInstanceOf[Comment]) newlines2Modification(between)
-        else NoSplit
-      List(
-        Split(modification, 0, policy = singleLine)
-          .withIndent(indent, expire, Left)
-          .withOptimal(optimalTok),
-        Split(Newline, 1 + nestedPenalty + lhsPenalty, policy = singleLine)
-          .withIndent(indent, expire, Left)
-          .withOptimal(optimalTok),
-        Split(modification, 2 + lhsPenalty, policy = oneArgOneLine, ignoreIf = singleArgument)
-          .withIndent(StateColumn, expire, Right)
-          .withOptimal(optimalTok),
-        Split(Newline,
-          3 + nestedPenalty + lhsPenalty,
-          policy = oneArgOneLine, ignoreIf = singleArgument)
-          .withIndent(indent, expire, Left)
-      )
-
-    // Delim
-    case FormatToken(_, _: `,`, _) => List(
-      Split(NoSplit, 0)
-    )
-    // These are mostly filtered out/modified by policies.
-    case FormatToken(_: `,`, _, _) => List(
-      Split(Space, 0),
-      Split(Newline, 0)
-    )
-    case FormatToken(_, _: `;`, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_: `;`, _, _) => List(
-      Split(Newline, 0)
-    )
-    case FormatToken(_, _: `:`, _) => List(
-      Split(NoSplit, 0)
-    )
-    // Only allow space after = in val if rhs is a single line or not
-    // an infix application or an if. For example, this is allowed:
-    // val x = function(a,
-    //                  b)
-    case FormatToken(tok: `=`, _, _) // TODO(olafur) scala.meta should have uniform api for these two
-    if owners(tok).isInstanceOf[Defn.Val] ||
-      owners(tok).isInstanceOf[Defn.Var] =>
-      val rhs: Term = owners(tok) match {
-        case l: Defn.Val => l.rhs
-        case r: Defn.Var if r.rhs.isDefined => r.rhs.get
-      }
-      val expire = owners(tok).tokens.last
-      val spacePolicy: Policy = rhs match {
-        case _: Term.ApplyInfix | _: Term.If =>
-          SingleLineBlock(expire)
-        case _ => NoPolicy
-      }
-      List(
-        Split(Space, 0, policy = spacePolicy),
-        Split(Newline, 1).withIndent(2, expire, Left)
-      )
-    case tok @ FormatToken(left, dot: `.`, _) if owners(dot).isInstanceOf[Term.Select] &&
-      // Only split if rhs is an application
-      // TODO(olafur) counterexample? For example a.b[C]
-      next(next(tok)).right.isInstanceOf[`(`] &&
-      !left.isInstanceOf[`_ `] &&
-      // TODO(olafur) optimize
-      !parents(owners(dot)).exists(_.isInstanceOf[Import]) =>
-      val nestedPenalty = NestedSelect(owners(dot))
-      val isLhsOfApply = owners(dot).parent.exists {
-        case apply: Term.Apply =>
-          apply.fun.tokens.contains(left)
-        case _ => false
-      }
-      val noApplyPenalty =
-        if (!isLhsOfApply) 1
-        else 0
-      val open = next(next(tok)).right
-      val close = matching(open)
-      val optimal = rhsOptimalToken(leftTok2tok(close))
-      List(
-        Split(NoSplit, 0).withOptimal(optimal),
-        Split(Newline, 1 + nestedPenalty + noApplyPenalty)
-          .withIndent(2, dot, Left)
-      )
-    case FormatToken(_, _: `.` | _: `#`, _) =>
-      List(
-        Split(NoSplit, 0)
-      )
-    case FormatToken(_: `.` | _: `#`, _: Ident, _) => List(
-      Split(NoSplit, 0)
-    )
-    // ApplyUnary
-    case tok @ FormatToken(_: Ident, _: Literal, _) if owners(tok.left) == owners(tok.right) =>
-      List(
-        Split(NoSplit, 0)
-      )
-    case tok @ FormatToken(_: Ident, _: Ident | _: `this`, _) if owners(tok.left).parent.exists(_.isInstanceOf[Term.ApplyUnary]) =>
-      List(
-        Split(NoSplit, 0)
-      )
-    // Annotations
-    case FormatToken(_, bind: `@`, _) if owners(bind).isInstanceOf[Pat.Bind] => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_: `@`, right, _) =>
-      // Add space if right starts with a symbol
-      if (right.code.matches("\\w.*")) List(Split(NoSplit, 0))
-      else List(Split(Space, 0))
-    // Template
-    case FormatToken(_, right: `extends`, _) =>
-      val owner = owners(right)
-      List(
-        Split(Space, 0)
-      )
-    case FormatToken(_, right: `with`, _) =>
-      val template = owners(right)
-      List(
-        Split(Space, 0),
-        Split(Newline, 1).withPolicy {
-          // Force template to be multiline.
-          case d @ Decision(FormatToken(open: `{`, _, _), splits) if childOf(template, owners(open)) =>
-            d.copy(split = splits.filter(_.modification.isNewline))
-        }
-      )
-    // If
-    case FormatToken(open: `(`, _, _) if owners(open).isInstanceOf[Term.If] =>
-      val close = matching(open)
-      List(
-        Split(NoSplit, 0)
-          .withIndent(StateColumn, close, Left)
-      )
-    case FormatToken(close: `)`, right, between) if owners(close).isInstanceOf[Term.If] =>
-      val owner = owners(close).asInstanceOf[Term.If]
-      val expire = owner.thenp.tokens.last
-      val rightIsOnNewLine = newlinesBetween(between) > 0
-      // Inline comment attached to closing `)`
-      val attachedComment = !rightIsOnNewLine && isInlineComment(right)
-      val newlineModification: Modification =
-        if (attachedComment) Space // Inline comment will force newline later.
-        else Newline
-      List(
-        Split(Space, 0, ignoreIf = rightIsOnNewLine || attachedComment)
-          .withIndent(2, expire, Left)
-          .withPolicy(SingleLineBlock(expire)),
-        Split(newlineModification, 1)
-          .withIndent(2, expire, Left)
-      )
-    case tok @ FormatToken(_: `}`, els: `else`, _) =>
-      List(
-        Split(Space, 0)
-      )
-    case tok @ FormatToken(_, els: `else`, _) =>
-      // According to scala-js style guide, no single-line if else.
-      List(
         Split(Newline, 0)
       )
-    // Last else branch
-    case tok @ FormatToken(els: `else`, _, _) if !nextNonComment(tok).right.isInstanceOf[`if`] =>
-      val expire = owners(els).asInstanceOf[Term.If].elsep.tokens.last
-      List(
-        Split(Space, 0, policy = SingleLineBlock(expire)),
-        Split(Newline, 1).withIndent(2, expire, Left)
+      case FormatToken(left: `package `, _, _) if leftOwner.isInstanceOf[Pkg] =>
+        Seq(
+          Split(Space, 0)
+        )
+      // Opening [ with no leading space.
+      case FormatToken(left, open: `[`, _) if rightOwner.isInstanceOf[Term.ApplyType] ||
+        leftOwner.isInstanceOf[Type.Name] => Seq(
+        Split(NoSplit, 0)
       )
-    // ApplyInfix.
-    case FormatToken(left: Ident, _, _) if owners(left).isInstanceOf[Term.ApplyInfix] => List(
-      Split(Space, 0),
-      Split(Newline, 1)
-    )
-    case tok @ FormatToken(_: Ident | _: Literal | _: Interpolation.End,
-      _: Ident | _: Literal | _: Xml.End, _) => List(
-      Split(Space, 0)
-    )
-    case FormatToken(open: `(`, right, _) if owners(open).isInstanceOf[Term.ApplyInfix] =>
-      val close = matching(open)
-      val policy =
-        if (right.isInstanceOf[`if`]) SingleLineBlock(close)
-        else NoPolicy
-      List(
-        Split(NoSplit, 0).withPolicy(policy).withIndent(2, matching(open), Left),
-        Split(Newline, 1).withIndent(2, matching(open), Left)
-      )
+      // Opening ( with no leading space.
+      case FormatToken(left, open: `(`, _) if rightOwner.isInstanceOf[Term.Apply] ||
+        leftOwner.parent.exists(_.isInstanceOf[Defn.Def]) ||
+        leftOwner.parent.exists(_.isInstanceOf[Defn.Class]) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      // NOTE. && and || are infix applications, this case is before ApplyInfix.
+      case FormatToken(cond: Ident, _, _) if cond.code == "&&" || cond.code == "||" =>
+        Seq(
+          Split(Space, 0),
+          Split(Newline, 1)
+        )
 
-    // Pattern matching
-    case tok @ FormatToken(_, open: `(`, _) if owners(open).isInstanceOf[Pat.Extract] => List(
-      Split(NoSplit, 0)
-    )
-    // Pat
-    case tok @ FormatToken(or: Ident, _, _) if or.code == "|" && owners(or).isInstanceOf[Pat.Alternative] => List(
-      Split(Space, 0),
-      Split(Newline, 0)
-    )
-    // Case
-    case tok @ FormatToken(_, _: `match`, _) => List(
-      Split(Space, 0)
-    )
-    case tok @ FormatToken(cs: `case`, _, _) if owners(cs).isInstanceOf[Case] =>
-      val owner = owners(cs).asInstanceOf[Case]
-      val arrow = owner.tokens.find(t => t.isInstanceOf[`=>`] && owners(t) == owner).get
-      // TODO(olafur) expire on token.end to avoid this bug.
-      val lastToken = owner.body.tokens
-        .filter {
-          case _: Whitespace | _: Comment => false
-          case _ => true
+      // Defn.{Object, Class, Trait}
+      case tok@FormatToken(_: `object` | _: `class ` | _: `trait`, _, _) =>
+        val owner = leftOwner
+        val expire = defnTemplate(owner).flatMap { templ =>
+          templ.tokens.find(_.isInstanceOf[`{`])
+        }.getOrElse(owner.tokens.last)
+        Seq(
+          Split(Space, 0).withIndent(4, expire, Left)
+        )
+      // DefDef
+      //     TODO(olafur) Naive match, can be 1) comment between 2) abstract decl.
+      case tok@FormatToken(d: `def`, name: Ident, _) =>
+        val owner = leftOwner
+        val expire = owner.tokens.
+          find(t => t.isInstanceOf[`=`] && owners(t) == owner)
+          .getOrElse(owner.tokens.last)
+        Seq(
+          Split(Space, 0).withIndent(4, expire, Left)
+        )
+      case FormatToken(e: `=`, _, _) if leftOwner.isInstanceOf[Defn.Def] =>
+        val expire = leftOwner.asInstanceOf[Defn.Def].body.tokens.last
+        Seq(
+          Split(Space, 0, policy = SingleLineBlock(expire)),
+          Split(Newline, 0).withIndent(2, expire, Left)
+        )
+      case tok@FormatToken(_, open: `[`, _) if rightOwner.isInstanceOf[Defn.Def] =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      case tok@FormatToken(open: `(`, _, _) if leftOwner.isInstanceOf[Defn] ||
+        leftOwner.parent.exists(_.isInstanceOf[Defn.Class]) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      // TODO(olafur) Split this up.
+      case tok@FormatToken(_: `(` | _: `[`, right, between) if leftOwner.isInstanceOf[Term.Apply] ||
+        leftOwner.isInstanceOf[Pat.Extract] ||
+        leftOwner.isInstanceOf[Pat.Tuple] ||
+        leftOwner.isInstanceOf[Term.Tuple] ||
+        leftOwner.isInstanceOf[Term.ApplyType] ||
+        leftOwner.isInstanceOf[Type.Apply] =>
+        val open = tok.left.asInstanceOf[Delim]
+        val (lhs, args): (Tree, Seq[Tree]) = leftOwner match {
+          case t: Term.Apply => t.fun -> t.args
+          case t: Pat.Extract => t.ref -> t.args
+          case t: Pat.Tuple => t -> t.elements
+          case t: Term.ApplyType => t -> t.targs
+          case t: Term.Tuple => t -> t.elements
+          case t: Type.Apply => t.tpe -> t.args
         }
-        // edge case, if body is empty expire on arrow.
-        .lastOption.getOrElse(arrow)
-      val breakOnArrow: Policy = {
-        case Decision(tok @ FormatToken(`arrow`, _, _), s) =>
-          Decision(tok, s.filter(_.modification.isNewline))
-      }
-      List(
-        Split(Space, 0).withPolicy {
-          case Decision(t, s) if tok.right.end <= lastToken.end =>
-            Decision(t, s.map {
-              case nl if nl.modification.isNewline =>
-                val result =
-                  if (t.right.isInstanceOf[`if`] && owners(t.right) == owner) nl
-                  else nl.withPenalty(1)
-                result.withPolicy(breakOnArrow)
-              case x => x
-            })
-        }.withIndent(2, lastToken, Left)
-          .withIndent(2, arrow, Left)
+        val close = matchingParentheses(hash(open))
+        // TODO(olafur) recursively?
+        val optimalTok: Token = rhsOptimalToken(leftTok2tok(close))
+        // In long sequence of select/apply, we penalize splitting on
+        // parens furthest to the right.
+        val lhsPenalty = lhs.tokens.length
+        val nestedPenalty = NestedApplies(leftOwner)
+
+        val exclude = insideBlock(tok, close)
+        val indent = leftOwner match {
+          case _: Pat => Num(0) // Indentation already provided by case.
+          // TODO(olafur) This is an odd rule, when is it wrong?
+          case _ => Num(4)
+        }
+        val singleArgument = args.length == 1
+
+        val singleLine = // Don't force single line policy if only one argument.
+          if (singleArgument) NoPolicy
+          else SingleLineBlock(close, exclude)
+        val oneArgOneLine = OneArgOneLineSplit(open)
+        val modification =
+          if (right.isInstanceOf[Comment]) newlines2Modification(between)
+          else NoSplit
+        Seq(
+          Split(modification, 0, policy = singleLine)
+            .withIndent(indent, close, Left)
+            .withOptimal(optimalTok),
+          Split(Newline, 1 + nestedPenalty + lhsPenalty, policy = singleLine)
+            .withIndent(indent, close, Left)
+            .withOptimal(optimalTok),
+          Split(modification, 2 + lhsPenalty, policy = oneArgOneLine, ignoreIf = singleArgument)
+            .withIndent(StateColumn, close, Right)
+            .withOptimal(optimalTok),
+          Split(Newline,
+            3 + nestedPenalty + lhsPenalty,
+            policy = oneArgOneLine, ignoreIf = singleArgument)
+            .withIndent(indent, close, Left)
+        )
+
+      // Delim
+      case FormatToken(_, _: `,`, _) => Seq(
+        Split(NoSplit, 0)
       )
-    case tok @ FormatToken(_, cond: `if`, _) if owners(cond).isInstanceOf[Case] =>
-      val favorNewlineAfter_|| : Policy = {
-        case Decision(t, s) if t.left.code != "||" =>
-          Decision(t, s.map {
-            case nl if nl.modification.isNewline =>
-              nl.withPenalty(1)
-            case x => x
-          })
-      }
-      List(
-        Split(Space, 0, policy = favorNewlineAfter_||),
-        Split(Newline, 1, policy = favorNewlineAfter_||)
+      // These are mostly filtered out/modified by policies.
+      case FormatToken(_: `,`, _, _) => Seq(
+        Split(Space, 0),
+        Split(Newline, 0)
       )
-    case tok @ FormatToken(arrow: `=>`, _, _) if owners(arrow).isInstanceOf[Case] =>
-      val owner = owners(arrow).asInstanceOf[Case]
-      val expire = owner.body.tokens
-        .filterNot(_.isInstanceOf[Whitespace])
-        .lastOption.getOrElse(arrow)
-      val bodySize = expire.start - tok.left.end
-      List(
-        Split(Space, 0, policy = SingleLineBlock(expire)),
+      case FormatToken(_, _: `;`, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_: `;`, _, _) => Seq(
+        Split(Newline, 0)
+      )
+      case FormatToken(_, _: `:`, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      // Only allow space after = in val if rhs is a single line or not
+      // an infix application or an if. For example, this is allowed:
+      // val x = function(a,
+      //                  b)
+      case FormatToken(tok: `=`, _, _) // TODO(olafur) scala.meta should have uniform api for these two
+        if leftOwner.isInstanceOf[Defn.Val] ||
+          leftOwner.isInstanceOf[Defn.Var] =>
+        val rhs: Term = leftOwner match {
+          case l: Defn.Val => l.rhs
+          case r: Defn.Var if r.rhs.isDefined => r.rhs.get
+        }
+        val expire = leftOwner.tokens.last
+        val spacePolicy: Policy = rhs match {
+          case _: Term.ApplyInfix | _: Term.If =>
+            SingleLineBlock(expire)
+          case _ => NoPolicy
+        }
+        Seq(
+          Split(Space, 0, policy = spacePolicy),
+          Split(Newline, 1).withIndent(2, expire, Left)
+        )
+      case tok@FormatToken(left, dot: `.`, _) if rightOwner.isInstanceOf[Term.Select] &&
+        // Only split if rhs is an application
+        // TODO(olafur) counterexample? For example a.b[C]
+        next(next(tok)).right.isInstanceOf[`(`] &&
+        !left.isInstanceOf[`_ `] &&
+        // TODO(olafur) optimize
+        !parents(rightOwner).exists(_.isInstanceOf[Import]) =>
+        val nestedPenalty = NestedSelect(rightOwner)
+        val isLhsOfApply = rightOwner.parent.exists {
+          case apply: Term.Apply =>
+            apply.fun.tokens.contains(left)
+          case _ => false
+        }
+        val noApplyPenalty =
+          if (!isLhsOfApply) 1
+          else 0
+        val open = next(next(tok)).right
+        val close = matchingParentheses(hash(open))
+        val optimal = rhsOptimalToken(leftTok2tok(close))
+        Seq(
+          Split(NoSplit, 0).withOptimal(optimal),
+          Split(Newline, 1 + nestedPenalty + noApplyPenalty)
+            .withIndent(2, dot, Left)
+        )
+      case FormatToken(_, _: `.` | _: `#`, _) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      case FormatToken(_: `.` | _: `#`, _: Ident, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      // ApplyUnary
+      case tok@FormatToken(_: Ident, _: Literal, _) if leftOwner == rightOwner =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      case tok@FormatToken(_: Ident, _: Ident | _: `this`, _) if leftOwner.parent.exists(_.isInstanceOf[Term.ApplyUnary]) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      // Annotations
+      case FormatToken(_, bind: `@`, _) if rightOwner.isInstanceOf[Pat.Bind] => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_: `@`, right, _) =>
+        // Add space if right starts with a symbol
+        if (right.code.matches("\\w.*")) Seq(Split(NoSplit, 0))
+        else Seq(Split(Space, 0))
+      // Template
+      case FormatToken(_, right: `extends`, _) =>
+        Seq(
+          Split(Space, 0)
+        )
+      case FormatToken(_, right: `with`, _) =>
+        val template = rightOwner.asInstanceOf[Template]
+        // TODO(olafur) is this correct?
+        val expire = for {
+          stats <- template.stats
+          headStat <- stats.headOption
+          headStatToken <- headStat.tokens.headOption
+        } yield headStatToken
+        Seq(
+          Split(Space, 0),
+          Split(Newline, 1).withPolicy(Policy({
+            // Force template to be multiline.
+            case d@Decision(FormatToken(open: `{`, _, _), splits)
+              if childOf(template, owners(open)) =>
+              d.copy(splits = splits.filter(_.modification.isNewline))
+          }, expire.getOrElse(template.tokens.last).end))
+        )
+      // If
+      case FormatToken(open: `(`, _, _) if leftOwner.isInstanceOf[Term.If] =>
+        val close = matchingParentheses(hash(open))
+        Seq(
+          Split(NoSplit, 0)
+            .withIndent(StateColumn, close, Left)
+        )
+      case FormatToken(close: `)`, right, between) if leftOwner.isInstanceOf[Term.If] =>
+        val owner = leftOwner.asInstanceOf[Term.If]
+        val expire = owner.thenp.tokens.last
+        val rightIsOnNewLine = newlinesBetween(between) > 0
+        // Inline comment attached to closing `)`
+        val attachedComment = !rightIsOnNewLine && isInlineComment(right)
+        val newlineModification: Modification =
+          if (attachedComment) Space // Inline comment will force newline later.
+          else Newline
+        Seq(
+          Split(Space, 0, ignoreIf = rightIsOnNewLine || attachedComment)
+            .withIndent(2, expire, Left)
+            .withPolicy(SingleLineBlock(expire)),
+          Split(newlineModification, 1)
+            .withIndent(2, expire, Left)
+        )
+      case tok@FormatToken(_: `}`, els: `else`, _) =>
+        Seq(
+          Split(Space, 0)
+        )
+      case tok@FormatToken(_, els: `else`, _) =>
+        // According to scala-js style guide, no single-line if else.
+        Seq(
+          Split(Newline, 0)
+        )
+      // Last else branch
+      case tok@FormatToken(els: `else`, _, _) if !nextNonComment(tok).right.isInstanceOf[`if`] =>
+        val expire = leftOwner.asInstanceOf[Term.If].elsep.tokens.last
+        Seq(
+          Split(Space, 0, policy = SingleLineBlock(expire)),
+          Split(Newline, 1).withIndent(2, expire, Left)
+        )
+      // ApplyInfix.
+      case FormatToken(left: Ident, _, _) if leftOwner.isInstanceOf[Term.ApplyInfix] => Seq(
+        Split(Space, 0),
         Split(Newline, 1)
       )
-    // Inline comment
-    case FormatToken(_, c: Comment, between) if c.code.startsWith("//") =>
-      List(Split(newlines2Modification(between), 0))
-    // Commented out code should stay to the left
-    case FormatToken(c: Comment, _, between) if c.code.startsWith("//") =>
-      List(Split(Newline, 0))
-    case tok @ FormatToken(_, c: Comment, _) =>
-      val newline: Modification =
-        if (isDocstring(c) ||
-          gets2x(next(tok)) ||
-          newlinesBetween(tok.between) > 1)
-          Newline2x
-        else Newline
-      List(
-        Split(newline, 0)
+      case tok@FormatToken(_: Ident | _: Literal | _: Interpolation.End,
+      _: Ident | _: Literal | _: Xml.End, _) => Seq(
+        Split(Space, 0)
       )
-    case FormatToken(c: Comment, _, between) =>
-      List(Split(newlines2Modification(between), 0))
-    // Interpolation
-    case FormatToken(_, _: Interpolation.Id | _: Xml.Start, _) => List(
-      Split(Space, 0)
-    )
-    case FormatToken(_: Interpolation.Id | _: Xml.Start, _, _) => List(
-      Split(NoSplit, 0)
-    )
-    // Throw exception
-    case FormatToken(_: `throw`, _, _) => List(
-      Split(Space, 0)
-    )
-    // Fallback
-    case FormatToken(_, _: `)` | _: `]`, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_, _: Keyword, _) => List(
-      Split(Space, 0)
-    )
-    case FormatToken(_: Keyword | _: Modifier, _, _) => List(
-      Split(Space, 0)
-    )
-    case FormatToken(_: `[`, _, _) => List(
-      Split(NoSplit, 0)
-    )
-    case FormatToken(_, _: Delim, _) => List(
-      Split(Space, 0)
-    )
-    case FormatToken(_: Delim, _, _) => List(
-      Split(Space, 0)
-    )
-    case tok =>
-      logger.debug("MISSING CASE:\n" + log(tok))
-      List() // No solution available, partially format tree.
+      case FormatToken(open: `(`, right, _) if leftOwner.isInstanceOf[Term.ApplyInfix] =>
+        val close = matchingParentheses(hash(open))
+        val policy =
+          if (right.isInstanceOf[`if`]) SingleLineBlock(close)
+          else NoPolicy
+        Seq(
+          Split(NoSplit, 0).withPolicy(policy).withIndent(2, matchingParentheses(hash(open)), Left),
+          Split(Newline, 1).withIndent(2, matchingParentheses(hash(open)), Left)
+        )
+
+      // Pattern matching
+      case tok@FormatToken(_, open: `(`, _) if rightOwner.isInstanceOf[Pat.Extract] => Seq(
+        Split(NoSplit, 0)
+      )
+      // Pat
+      case tok@FormatToken(or: Ident, _, _) if or.code == "|" && leftOwner.isInstanceOf[Pat.Alternative] => Seq(
+        Split(Space, 0),
+        Split(Newline, 0)
+      )
+      // Case
+      case tok@FormatToken(_, _: `match`, _) => Seq(
+        Split(Space, 0)
+      )
+      case tok@FormatToken(cs: `case`, _, _) if leftOwner.isInstanceOf[Case] =>
+        val owner = leftOwner.asInstanceOf[Case]
+        val arrow = owner.tokens.find(t => t.isInstanceOf[`=>`] && owners(t) == owner).get
+        // TODO(olafur) expire on token.end to avoid this bug.
+        val lastToken = owner.body.tokens
+          .filter {
+            case _: Whitespace | _: Comment => false
+            case _ => true
+          }
+          // edge case, if body is empty expire on arrow.
+          .lastOption.getOrElse(arrow)
+        val breakOnArrow = Policy({
+          case Decision(tok@FormatToken(`arrow`, _, _), s) =>
+            Decision(tok, s.filter(_.modification.isNewline))
+        }, arrow.end)
+        Seq(
+          Split(Space, 0).withPolicy(Policy({
+            case Decision(t, s) if tok.right.end <= lastToken.end =>
+              Decision(t, s.map {
+                case nl if nl.modification.isNewline =>
+                  val result =
+                    if (t.right.isInstanceOf[`if`] && owners(t.right) == owner) nl
+                    else nl.withPenalty(1)
+                  result.withPolicy(breakOnArrow)
+                case x => x
+              })
+          }, lastToken.end, noDequeue = true)).withIndent(2, lastToken, Left)
+            .withIndent(2, arrow, Left)
+        )
+      case tok@FormatToken(_, cond: `if`, _) if rightOwner.isInstanceOf[Case] =>
+        val favorNewlineAfter_|| = Policy({
+          case Decision(t, s) if t.left.code != "||" =>
+            Decision(t, s.map {
+              case nl if nl.modification.isNewline =>
+                nl.withPenalty(1)
+              case x => x
+            })
+        }, rightOwner.tokens.last.end, noDequeue = true)
+        Seq(
+          Split(Space, 0, policy = favorNewlineAfter_||),
+          Split(Newline, 1, policy = favorNewlineAfter_||)
+        )
+      case tok@FormatToken(arrow: `=>`, _, _) if leftOwner.isInstanceOf[Case] =>
+        val owner = leftOwner.asInstanceOf[Case]
+        val expire = owner.body.tokens
+          .filterNot(_.isInstanceOf[Whitespace])
+          .lastOption.getOrElse(arrow)
+        Seq(
+          Split(Space, 0, policy = SingleLineBlock(expire)),
+          Split(Newline, 1)
+        )
+      // Inline comment
+      case FormatToken(_, c: Comment, between) if c.code.startsWith("//") =>
+        Seq(Split(newlines2Modification(between), 0))
+      // Commented out code should stay to the left
+      case FormatToken(c: Comment, _, between) if c.code.startsWith("//") =>
+        Seq(Split(Newline, 0))
+      case tok@FormatToken(_, c: Comment, _) =>
+        val newline: Modification =
+          if (isDocstring(c) ||
+            gets2x(next(tok)) ||
+            newlinesBetween(tok.between) > 1)
+            Newline2x
+          else Newline
+        Seq(
+          Split(newline, 0)
+        )
+      case FormatToken(c: Comment, _, between) =>
+        Seq(Split(newlines2Modification(between), 0))
+      // Interpolation
+      case FormatToken(_, _: Interpolation.Id | _: Xml.Start, _) => Seq(
+        Split(Space, 0)
+      )
+      case FormatToken(_: Interpolation.Id | _: Xml.Start, _, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      // Throw exception
+      case FormatToken(_: `throw`, _, _) => Seq(
+        Split(Space, 0)
+      )
+      // Fallback
+      case FormatToken(_, _: `)` | _: `]`, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_, _: Keyword, _) => Seq(
+        Split(Space, 0)
+      )
+      case FormatToken(_: Keyword | _: Modifier, _, _) => Seq(
+        Split(Space, 0)
+      )
+      case FormatToken(_: `[`, _, _) => Seq(
+        Split(NoSplit, 0)
+      )
+      case FormatToken(_, _: Delim, _) => Seq(
+        Split(Space, 0)
+      )
+      case FormatToken(_: Delim, _, _) => Seq(
+        Split(Space, 0)
+      )
+      case tok =>
+        logger.debug("MISSING CASE:\n" + log(tok))
+        Seq() // No solution available, partially format tree.
+    }
   }
 
   /**
@@ -543,8 +562,8 @@ class Router(style: ScalaStyle,
    * determines which edges lead out from the format token.
    */
 
-  def Route(formatToken: FormatToken): List[Split] =
-    cache.getOrElseUpdate(formatToken, RouteRun(formatToken))
+  def Route(formatToken: FormatToken): Seq[Split] =
+    cache.getOrElseUpdate(formatToken, getSplits(formatToken))
 
   def isDocstring(token: Token): Boolean = {
     token.isInstanceOf[Comment] && token.code.startsWith("/**")
@@ -561,11 +580,11 @@ class Router(style: ScalaStyle,
   }
 
   def gets2x(tok: FormatToken): Boolean = {
-    if (!statementStarts.contains(tok.right)) false
+    if (!statementStarts.contains(hash(tok.right))) false
     else if (packageTokens.contains(tok.left) &&
       !packageTokens.contains(tok.right)) true
     else {
-      val rightOwner = statementStarts(tok.right)
+      val rightOwner = statementStarts(hash(tok.right))
       if (!rightOwner.tokens.headOption.contains(tok.right)) false
       else rightOwner match {
         case _: Defn.Def | _: Pkg.Object |
@@ -576,13 +595,17 @@ class Router(style: ScalaStyle,
     }
   }
 
-  def OneArgOneLineSplit(open: Delim): Policy = {
-    // Newline on every comma.
-    case Decision(t @ FormatToken(comma: `,`, right, between), splits) if owners.get(open) == owners.get(comma) &&
-      // If comment is bound to comma, see unit/Comment.
-      (!right.isInstanceOf[Comment] ||
-        between.exists(_.isInstanceOf[`\n`])) =>
-      Decision(t, splits.filter(_.modification == Newline))
+  def OneArgOneLineSplit(open: Delim)(implicit line: sourcecode.Line): Policy = {
+    val expire = matchingParentheses(hash(open))
+    Policy({
+      // Newline on every comma.
+      case Decision(t @ FormatToken(comma: `,`, right, between), splits)
+        if owners(open) == owners(comma) &&
+        // If comment is bound to comma, see unit/Comment.
+        (!right.isInstanceOf[Comment] ||
+          between.exists(_.isInstanceOf[`\n`])) =>
+        Decision(t, splits.filter(_.modification == Newline))
+    }, expire.end, noDequeue = true)
   }
 
   /**
@@ -609,11 +632,11 @@ class Router(style: ScalaStyle,
   }
 
   def SingleLineBlock(expire: Token,
-    exclude: Set[Range] = Set.empty): Policy = {
+    exclude: Set[Range] = Set.empty)(implicit line: sourcecode.Line): Policy = Policy({
     case Decision(tok, splits) if exclude.forall(!_.contains(tok.left.start)) &&
       tok.right.end <= expire.end =>
       Decision(tok, splits.filterNot(_.modification.isNewline))
-  }
+  }, expire.end, noDequeue = true)
 
   def insideBlock(start: FormatToken, end: Token): Set[Range] = {
     var inside = false
@@ -622,8 +645,8 @@ class Router(style: ScalaStyle,
     while (curr.left != end) {
       if (curr.left.isInstanceOf[`{`]) {
         inside = true
-        result += Range(curr.left.start, matching(curr.left).end)
-        curr = leftTok2tok(matching(curr.left))
+        result += Range(curr.left.start, matchingParentheses(hash(curr.left)).end)
+        curr = leftTok2tok(matchingParentheses(hash(curr.left)))
       }
       else {
         curr = next(curr)
@@ -634,8 +657,8 @@ class Router(style: ScalaStyle,
 
   def next(tok: FormatToken): FormatToken = {
     val i = tok2idx(tok)
-    if (i == toks.length - 1) tok
-    else toks(i + 1)
+    if (i == tokens.length - 1) tok
+    else tokens(i + 1)
   }
 
   def isInlineComment(token: Token): Boolean = token match {

--- a/core/src/main/scala/org/scalafmt/internal/package.scala
+++ b/core/src/main/scala/org/scalafmt/internal/package.scala
@@ -5,11 +5,7 @@ import scala.meta.Tree
 import scala.meta.tokens.Token
 
 package object internal {
-  type Policy = PartialFunction[Decision, Decision]
-  val NoPolicy = PartialFunction.empty[Decision, Decision]
-  val IdentityPolicy: PartialFunction[Decision, Decision] = {
-    case d => d
-  }
+  val NoPolicy = Policy.empty
 
   // TODO(olafur) Move these elsewhere.
 
@@ -21,10 +17,28 @@ package object internal {
     })
   }
 
-  def childOf(tok: Token, tree: Tree, owners: Map[Token, Tree]): Boolean =
-    childOf(owners(tok), tree)
+  def childOf(tok: Token, tree: Tree, owners: Map[Long, Tree]): Boolean =
+    childOf(owners(hash(tok)), tree)
 
-  // TODO(olafur) Move these elsewhere.
+  /**
+    * Custom hash code for token.
+    *
+    * The default hashCode is slow because it prevents conflicts between
+    * tokens from different source files. We only care about getting a unique
+    * identifier for the token inside this source file.
+    *
+    * The hash code works like this this:
+    * Top 8 bits go to privateTag, a unique identifier for the tokens class.
+    * Next 28 bits go to the tokens **start** offset byte.
+    * Final 28 bits go to the tokens **end** offset byte.
+    *
+    * The only chance for collision is if two empty length tokens with the same
+    * type lie next to each other. @xeno-by said this should not happen.
+    */
+  def hash(token: Token): Long = {
+    (token.privateTag << (62 - 8)) |
+      (token.start << (62 - (8 + 28))) |token.end
+  }
 
   @tailrec
   final def parents(tree: Tree, accum: Seq[Tree] = Seq.empty[Tree]): Seq[Tree] = {

--- a/core/src/test/resources/standard/Apply.stat
+++ b/core/src/test/resources/standard/Apply.stat
@@ -84,3 +84,34 @@ Defn.Object(Nil, Term.Name("State"), Template(Nil, Seq(Ctor.Ref.Name("ScalaFmtLo
 >>>
 Defn.Object(Nil,
     Term.Name("State"), Template(Nil, Seq(Ctor.Ref.Name("ScalaFmtLogger")), Term.Param(Nil, Name.Anonymous(), None, None), Some(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("start"))), None, Term.Apply(Term.Name("State"), Seq(Lit(0), Term.Name("identity"), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Name("Split"))), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Name("State"))), Lit(0), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Apply(Type.Name("Indent"), Seq(Type.Name("Num"))))), Lit(0)))), Defn.Def(Nil, Term.Name("reconstructPath"), Nil, Seq(Seq(Term.Param(Nil, Term.Name("toks"), Some(Type.Apply(Type.Name("Array"), Seq(Type.Name("FormatToken")))), None), Term.Param(Nil, Term.Name("splits"), Some(Type.Apply(Type.Name("Vector"), Seq(Type.Name("Split")))), None), Term.Param(Nil, Term.Name("style"), Some(Type.Name("ScalaStyle")), None), Term.Param(Nil, Term.Name("debug"), Some(Type.Name("Boolean")), Some(Lit(false))))), Some(Type.Apply(Type.Name("Seq"), Seq(Type.Tuple(Seq(Type.Name("FormatToken"), Type.Name("String")))))), Term.Block(Seq(Defn.Var(Nil, Seq(Pat.Var.Term(Term.Name("state"))), None, Some(Term.Select(Term.Name("State"), Term.Name("start")))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("result"))), None, Term.Apply(Term.Select(Term.Apply(Term.Select(Term.Name("toks"), Term.Name("zip")), Seq(Term.Name("splits"))), Term.Name("map")), Seq(Term.PartialFunction(Seq(Case(Pat.Tuple(Seq(Pat.Var.Term(Term.Name("tok")), Pat.Var.Term(Term.Name("split")))), None, Term.Block(Seq(Term.If(Term.Name("debug"), Term.Block(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("left"))), None, Term.Apply(Term.Name("small"), Seq(Term.Select(Term.Name("tok"), Term.Name("left"))))), Term.Apply(Term.Select(Term.Name("logger"), Term.Name("debug")), Seq(Term.Interpolate(Term.Name("f"), Seq(Lit(""), Lit("%-10s "), Lit("")), Seq(Term.Name("left"), Term.Name("split"))))))), Lit()), Term.Assign(Term.Name("state"), Term.Apply(Term.Select(Term.Name("state"), Term.Name("next")), Seq(Term.Name("style"), Term.Name("split"), Term.Name("tok")))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("whitespace"))), None, Term.Match(Term.Select(Term.Name("split"), Term.Name("modification")), Seq(Case(Term.Name("Space"), None, Lit(" ")), Case(Pat.Typed(Pat.Var.Term(Term.Name("nl")), Type.Name("NewlineT")), None, Term.Block(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("newline"))), None, Term.If(Term.Select(Term.Name("nl"), Term.Name("isDouble")), Lit("\n\n"), Lit("\n"))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("indentation"))), None, Term.If(Term.Select(Term.Name("nl"), Term.Name("noIndent")), Lit(""), Term.ApplyInfix(Lit(" "), Term.Name("*"), Nil, Seq(Term.Select(Term.Name("state"), Term.Name("indentation")))))), Term.ApplyInfix(Term.Name("newline"), Term.Name("+"), Nil, Seq(Term.Name("indentation")))))), Case(Pat.Extract(Term.Name("Provided"), Nil, Seq(Pat.Var.Term(Term.Name("literal")))), None, Term.Name("literal")), Case(Term.Name("NoSplit"), None, Lit(""))))), Term.ApplyInfix(Term.Name("tok"), Term.Name("->"), Nil, Seq(Term.Name("whitespace"))))))))))), Term.If(Term.Name("debug"), Term.Apply(Term.Select(Term.Name("logger"), Term.Name("debug")), Seq(Term.Interpolate(Term.Name("s"), Seq(Lit("Total cost: "), Lit("")), Seq(Term.Select(Term.Name("state"), Term.Name("cost")))))), Lit()), Term.Name("result"))))))))
+<<< Looong
+Seq(
+  Split(modification, 0, policy = singleLine)
+    .withIndent(indent, close, Left)
+    .withOptimal(optimalTok),
+  Split(Newline, 1 + nestedPenalty + lhsPenalty, policy = singleLine)
+    .withIndent(indent, close, Left)
+    .withOptimal(optimalTok),
+  Split(modification, 2 + lhsPenalty, policy = oneArgOneLine, ignoreIf = singleArgument)
+    .withIndent(StateColumn, close, Right)
+    .withOptimal(optimalTok),
+  Split(Newline,
+    3 + nestedPenalty + lhsPenalty,
+    policy = oneArgOneLine, ignoreIf = singleArgument)
+    .withIndent(indent, close, Left)
+
+)
+>>>
+Seq(Split(modification, 0, policy = singleLine).withIndent(indent, close, Left)
+      .withOptimal(optimalTok),
+    Split(Newline, 1 + nestedPenalty + lhsPenalty, policy = singleLine)
+      .withIndent(indent, close, Left).withOptimal(optimalTok),
+    Split(modification,
+          2 + lhsPenalty,
+          policy = oneArgOneLine,
+          ignoreIf = singleArgument).withIndent(StateColumn, close, Right)
+      .withOptimal(optimalTok),
+    Split(Newline,
+          3 + nestedPenalty + lhsPenalty,
+          policy = oneArgOneLine,
+          ignoreIf = singleArgument).withIndent(indent, close, Left))

--- a/core/src/test/resources/standard/Case.stat
+++ b/core/src/test/resources/standard/Case.stat
@@ -39,3 +39,32 @@ List(Split(Space, 0).withPolicy {
               case x => x
             })
     })
+<<< router
+x match {
+  case tok if tok.left.name.startsWith("xml") &&
+      tok.right.name.startsWith("xml") =>
+    Seq(Split(NoSplit, 0))
+  case tok if // TODO(olafur) DRY.
+      (leftOwner.isInstanceOf[Term.Interpolate] &&
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
+      (leftOwner.isInstanceOf[Pat.Interpolate] &&
+        rightOwner.isInstanceOf[Pat.Interpolate]) =>
+    Seq(Split(NoSplit, 0))
+  case FormatToken(_: `{`, _: `}`, _) => Seq(Split(NoSplit, 0))
+  case FormatToken(_: `]`, _: `(`, _) =>
+    Seq(Split(NoSplit, 0))
+}
+>>>
+x match {
+  case tok
+      if tok.left.name.startsWith("xml") && tok.right.name.startsWith("xml") =>
+    Seq(Split(NoSplit, 0))
+  case tok if // TODO(olafur) DRY.
+      (leftOwner.isInstanceOf[Term.Interpolate] &&
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
+      (leftOwner.isInstanceOf[Pat.Interpolate] &&
+        rightOwner.isInstanceOf[Pat.Interpolate]) =>
+    Seq(Split(NoSplit, 0))
+  case FormatToken(_: `{`, _: `}`, _) => Seq(Split(NoSplit, 0))
+  case FormatToken(_: `]`, _: `(`, _) => Seq(Split(NoSplit, 0))
+}

--- a/core/src/test/scala/org/scalafmt/CliTest.scala
+++ b/core/src/test/scala/org/scalafmt/CliTest.scala
@@ -4,10 +4,10 @@ import java.io.File
 import java.nio.file.Files
 
 import org.scalafmt.cli.Cli
-import org.scalafmt.util.DiffUtil
+import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
-class CliTest extends FunSuite {
+class CliTest extends FunSuite with DiffAssertions {
   test("cli parses args") {
     val expected = Cli.Config(Some(new File("foo")), inPlace = true, None)
     val args = Seq("--file", "foo", "-i")
@@ -33,7 +33,7 @@ class CliTest extends FunSuite {
     val formatInPlace = Cli.Config(Some(tmpFile.toFile), inPlace = true, None)
     Cli.run(formatInPlace)
     val obtained = new String(Files.readAllBytes(tmpFile))
-    DiffUtil.assertNoDiff(obtained, expected)
+    assertNoDiff(obtained, expected)
   }
 
 }

--- a/core/src/test/scala/org/scalafmt/IntegrityTest.scala
+++ b/core/src/test/scala/org/scalafmt/IntegrityTest.scala
@@ -1,0 +1,39 @@
+package org.scalafmt
+
+import org.scalafmt.internal.ScalaFmtLogger
+import org.scalafmt.util.FilesUtil
+import org.scalafmt.util.FormatAssertions
+import org.scalatest.FunSuite
+
+/**
+  * Asserts formatter maintains integrity of original source file.
+  *
+  * Will maybe use scalacheck someday.
+  */
+class IntegrityTest extends FunSuite with FormatAssertions with ScalaFmtLogger {
+  case class Test(filename: String, code: String)
+  object Test {
+    def apply(filename: String): Test =
+      Test(filename, FilesUtil.readFile(filename))
+  }
+
+  val files =
+    Seq(
+      "benchmarks/src/resources/scalafmt/Basic.scala",
+      "benchmarks/src/resources/scala-js/SourceMapWriter.scala",
+      "benchmarks/src/resources/scala-js/Division.scala",
+      "benchmarks/src/resources/scala-js/BaseLinker.scala",
+      "benchmarks/src/resources/scala-js/JSDependency.scala")
+
+  val examples = files.map(Test.apply)
+
+  examples.foreach { example =>
+    test(example.filename) {
+      println(example.filename)
+      val formatted = ScalaFmt.format_!(
+        example.code, ScalaStyle.ManualTest)(scala.meta.parseSource)
+      assertFormatPreservesAst(example.code, formatted)(scala.meta.parseSource)
+    }
+  }
+
+}

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -1,9 +1,9 @@
 package org.scalafmt
 
-import org.scalafmt.util.DiffUtil
+import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
-class RangeTest extends FunSuite {
+class RangeTest extends FunSuite with DiffAssertions {
   test("range preserves indent") {
     val original =
       """object a {
@@ -19,7 +19,7 @@ class RangeTest extends FunSuite {
       """.stripMargin
     val obtained = ScalaFmt.format(original,
       ScalaStyle.UnitTest40, _ == 2)
-    DiffUtil.assertNoDiff(obtained, expected)
+    assertNoDiff(obtained, expected)
   }
 
 }

--- a/core/src/test/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/core/src/test/scala/org/scalafmt/util/DiffAssertions.scala
@@ -1,29 +1,42 @@
 package org.scalafmt.util
 
 import java.io.File
+
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
 
 import org.scalafmt.internal.ScalaFmtLogger
+import org.scalatest.FunSuite
 import org.scalatest.exceptions.TestFailedException
 
-object DiffUtil extends ScalaFmtLogger {
+trait DiffAssertions extends FunSuite with ScalaFmtLogger {
 
-  def assertNoDiff(obtained: String, expected: String): Boolean = {
+  def error2message(obtained: String, expected: String): String = {
+    if (expected.length > 10000)
+    s"""
+       |${header("Obtained")}
+       |${trailingSpace(obtained)}
+         """.stripMargin
+    else
+    s"""
+       |${header("Obtained")}
+       |${trailingSpace(obtained)}
+       |
+       |${header("Diff")}
+       |${trailingSpace(compareContents(obtained, expected))}
+         """.stripMargin
+
+  }
+
+  def assertNoDiff(obtained: String, expected: String, title: String = ""): Boolean = {
     val result = compareContents(obtained, expected)
     if (result.isEmpty)
       true
-    else
-      throw new TestFailedException(
-        s"""
-           |${header("Obtained")}
-           |${trailingSpace(obtained)}
-           |
-           |${header("Diff")}
-           |${trailingSpace(result)}
-         """.stripMargin,
-        1)
+    else {
+        throw new TestFailedException( title + "\n" +
+          error2message(obtained, expected), 1)
+      }
   }
 
   def trailingSpace(str: String): String = str.replaceAll(" \n", "∙\n")

--- a/core/src/test/scala/org/scalafmt/util/ErrorTest.scala
+++ b/core/src/test/scala/org/scalafmt/util/ErrorTest.scala
@@ -4,7 +4,7 @@ import org.scalafmt.ScalaFmt
 import org.scalafmt.ScalaStyle
 import org.scalatest.FunSuite
 
-class ErrorTest extends FunSuite {
+class ErrorTest extends FunSuite with DiffAssertions {
   test("errors are caught") {
     val nonSourceFile = Seq(
       "class A {",
@@ -13,7 +13,7 @@ class ErrorTest extends FunSuite {
     )
     nonSourceFile.foreach { original =>
       val obtained = ScalaFmt.format(original, ScalaStyle.UnitTest40)
-      DiffUtil.assertNoDiff(obtained, original)
+      assertNoDiff(obtained, original)
     }
   }
 }

--- a/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -1,0 +1,33 @@
+package org.scalafmt.util
+
+import org.scalatest.FunSuite
+
+import scala.meta.Tree
+import scala.meta.parsers.common.Parse
+import scala.meta.prettyprinters.Structure
+import scala.util.Try
+
+trait FormatAssertions extends FunSuite with DiffAssertions {
+  def assertFormatPreservesAst[T <: Tree](original: String,
+                                          obtained: String)
+                                         (implicit ev: Parse[T]): Unit = {
+    parses(original) match {
+      case None => // ignore
+      case Some(originalParsed) =>
+        parses(obtained) match {
+          case Some(obtainedParsed) =>
+            val originalStructure = originalParsed.show[Structure]
+            val obtainedStructure = obtainedParsed.show[Structure]
+            assertNoDiff(originalStructure, obtainedStructure,
+              "formatter changed AST!")
+          case None =>
+            fail("Formatter output does not parse!\n" +
+              error2message(obtained, original))
+        }
+    }
+  }
+  def parses[T <: Tree](code: String)(implicit parse: Parse[T]): Option[Tree] = {
+    import scala.meta._
+    Try(code.parse[T]).toOption
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,12 @@ let g:formatters_scala = ['scalafmt']
 
 <img width="513" alt="scalafmt-intellij3" src="https://cloud.githubusercontent.com/assets/1408093/12949347/9c07dda6-d007-11e5-96d4-8cd53394a52c.png">
 
+### Contributing
+
+To run main formatting tests:
+
+* `~core/testOnly org.scalafmt.FormatTest`
+
 ### Updates
 
 * Feb 16th

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -1,0 +1,1 @@
+sbt benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*


### PR DESCRIPTION
* use longs as keys instead of tokens with custom hash function.
* IntegrityTest to verify formatter doesn't break code
* WARNING: can't format formatter.scala, deeply nested trees.
* Create Policy and PolicySummary case classes.
* {Format,Diff}Assertions.

Benchmark                        Mode  Cnt     Score      Error  Units
BaseLinker.scalafmt              avgt    3  2425.039 ± 1571.470  ms/op
BaseLinker.scalametaParser       avgt    3     7.863 ±   10.407  ms/op
BaseLinker.scalariform           avgt    3    14.838 ±    5.643  ms/op
Basic.scalafmt                   avgt    3    24.927 ±   22.778  ms/op
Basic.scalametaParser            avgt    3    18.943 ±   19.701  ms/op
Basic.scalariform                avgt    3     0.569 ±    1.327  ms/op
Division.scalafmt                avgt    3  6387.953 ± 1526.262  ms/op
Division.scalametaParser         avgt    3    16.549 ±    8.543  ms/op
Division.scalariform             avgt    3    32.830 ±   12.773  ms/op
JsDependency.scalafmt            avgt    3   140.772 ±   84.705  ms/op
JsDependency.scalametaParser     avgt    3     1.725 ±    5.697  ms/op
JsDependency.scalariform         avgt    3     3.485 ±    3.549  ms/op
Semantics.scalafmt               avgt    3   179.121 ±   62.667  ms/op
Semantics.scalametaParser        avgt    3     2.046 ±    4.681  ms/op
Semantics.scalariform            avgt    3     4.044 ±    2.471  ms/op
SourceMapWriter.scalafmt         avgt    3   530.901 ±   91.888  ms/op
SourceMapWriter.scalametaParser  avgt    3     3.809 ±    9.866  ms/op
SourceMapWriter.scalariform      avgt    3     7.430 ±    6.089  ms/op
Utils.scalafmt                   avgt    3   159.386 ±   66.712  ms/op
Utils.scalametaParser            avgt    3     2.316 ±    5.005  ms/op
Utils.scalariform                avgt    3     4.769 ±    4.425  ms/op