### PR TITLE
Find optimal tokens 3x faster, pay with memory.

### DIFF
--- a/core/src/main/scala/org/scalafmt/ScalaStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalaStyle.scala
@@ -20,13 +20,6 @@ sealed trait ScalaStyle {
   def maxDuration: Duration = Duration(400, "ms")
 
   /**
-    * Debugging only. Maximum number of states that the formatter may visit.
-    *
-    * @return
-    */
-  def maxStateVisits = 10000
-
-  /**
     * Debugging only. Should scalafmt create a diagnostics report.
     */
   def debug: Boolean = false
@@ -51,8 +44,6 @@ object ScalaStyle {
 
   protected[scalafmt] case object ManualTest extends ScalaStyle {
     override val debug = true
-
-    override def maxStateVisits = 50000
 
     override def maxDuration = Duration(10, "min")
   }

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -1,6 +1,7 @@
 package org.scalafmt
 
 import org.scalafmt.util.FilesUtil
+import org.scalafmt.util.FormatAssertions
 import org.scalafmt.util.ScalaProjectsExperiment
 import org.scalafmt.util.ScalacParser
 
@@ -10,7 +11,7 @@ import scala.concurrent.Future
 import scala.meta._
 
 
-object FormatExperiment extends App with ScalaProjectsExperiment {
+object FormatExperiment extends App with ScalaProjectsExperiment with FormatAssertions {
   override val verbose = false
   override val globalFilter: String => Boolean = !_.contains("scala-js/scala-js")
 
@@ -19,7 +20,8 @@ object FormatExperiment extends App with ScalaProjectsExperiment {
     if (!ScalacParser.checkParseFails(code)) {
       val startTime = System.nanoTime()
       val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
-      Await.result(f, ScalaStyle.Standard.maxDuration)
+      val formatted = Await.result(f, ScalaStyle.Standard.maxDuration)
+      assertFormatPreservesAst[Source](code, formatted)
       print("+")
       formatSuccesses.add(FormatSuccess(filename, System.nanoTime() - startTime))
     } else {

--- a/core/src/test/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/core/src/test/scala/org/scalafmt/util/DiffAssertions.scala
@@ -7,10 +7,10 @@ import java.util.Date
 import java.util.TimeZone
 
 import org.scalafmt.internal.ScalaFmtLogger
-import org.scalatest.FunSuite
+import org.scalatest.FunSuiteLike
 import org.scalatest.exceptions.TestFailedException
 
-trait DiffAssertions extends FunSuite with ScalaFmtLogger {
+trait DiffAssertions extends FunSuiteLike with ScalaFmtLogger {
 
   def error2message(obtained: String, expected: String): String = {
     if (expected.length > 10000)

--- a/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -1,13 +1,14 @@
 package org.scalafmt.util
 
 import org.scalatest.FunSuite
+import org.scalatest.FunSuiteLike
 
 import scala.meta.Tree
 import scala.meta.parsers.common.Parse
 import scala.meta.prettyprinters.Structure
 import scala.util.Try
 
-trait FormatAssertions extends FunSuite with DiffAssertions {
+trait FormatAssertions extends FunSuiteLike with DiffAssertions {
   def assertFormatPreservesAst[T <: Tree](original: String,
                                           obtained: String)
                                          (implicit ev: Parse[T]): Unit = {

--- a/readme.md
+++ b/readme.md
@@ -94,27 +94,63 @@ To run main formatting tests:
 
 ### Updates
 
+* Feb 18th
+  * Ran `scalafmt` on  Scala.js repo with 200ms timeout.
+```
+Unknown Failures: 48
+Timeout Failures: 268
+Parse exceptions: 13
+Format successes: 592
+```
+  * Updated benchmark:
+
+```
+Benchmark                        Mode  Cnt     Score     Error  Units
+BaseLinker.scalafmt              avgt    3   707.864 ±  87.023  ms/op
+BaseLinker.scalametaParser       avgt    3    10.876 ±  49.694  ms/op
+BaseLinker.scalariform           avgt    3    15.764 ±   3.908  ms/op
+Basic.scalafmt                   avgt    3    25.363 ±  46.914  ms/op
+Basic.scalametaParser            avgt    3    19.608 ±  18.905  ms/op
+Basic.scalariform                avgt    3     0.659 ±   1.250  ms/op
+Division.scalafmt                avgt    3  2253.869 ± 556.383  ms/op
+Division.scalametaParser         avgt    3    16.818 ±  11.662  ms/op
+Division.scalariform             avgt    3    35.331 ±  42.856  ms/op
+JsDependency.scalafmt            avgt    3    51.908 ±  21.290  ms/op
+JsDependency.scalametaParser     avgt    3     1.810 ±   5.086  ms/op
+JsDependency.scalariform         avgt    3     3.741 ±   8.991  ms/op
+Semantics.scalafmt               avgt    3    64.453 ± 107.310  ms/op
+Semantics.scalametaParser        avgt    3     2.105 ±   4.223  ms/op
+Semantics.scalariform            avgt    3     4.192 ±   4.279  ms/op
+SourceMapWriter.scalafmt         avgt    3   203.994 ± 146.662  ms/op
+SourceMapWriter.scalametaParser  avgt    3     4.099 ±  11.523  ms/op
+SourceMapWriter.scalariform      avgt    3     9.539 ±  14.685  ms/op
+Utils.scalafmt                   avgt    3    71.421 ± 123.586  ms/op
+Utils.scalametaParser            avgt    3     2.414 ±   4.647  ms/op
+Utils.scalariform                avgt    3     4.779 ±   2.180  ms/op
+```
+  
 * Feb 16th
   * `scalafmt` can format 235 out of 917 files from Scala.js in under 200ms.
   * Ran benchmarks against Scalariform. I'm not surprised `scalafmt` is
     **significantly** slower since 1. I've done little optimizations and 2.
     `scalafmt` supports column-width limit which introduces a huge overhead.
+    
 ```
-    [info] # Run complete. Total time: 00:10:29
-    [info]
-    [info] Benchmark                    Mode  Cnt     Score     Error  Units
-    [info] BaseLinker.scalafmt          avgt   10  6226.143 ±  97.964  ms/op
-    [info] BaseLinker.scalariform       avgt   10    13.604 ±   0.273  ms/op
-    [info] Basic.scalafmt               avgt   10    20.116 ±   0.723  ms/op
-    [info] Basic.scalariform            avgt   10     0.481 ±   0.087  ms/op
-    [info] Division.scalafmt            avgt   10  6792.488 ± 519.506  ms/op
-    [info] Division.scalariform         avgt   10    34.708 ±   8.885  ms/op
-    [info] JsDependency.scalafmt        avgt   10   127.133 ±   6.151  ms/op
-    [info] JsDependency.scalariform     avgt   10     3.395 ±   0.171  ms/op
-    [info] SourceMapWriter.scalafmt     avgt   10   494.667 ±  45.247  ms/op
-    [info] SourceMapWriter.scalariform  avgt   10     6.887 ±   0.078  ms/op
-    [info] Utils.scalafmt               avgt   10   156.653 ±   2.729  ms/op
-    [info] Utils.scalariform            avgt   10     4.214 ±   0.096  ms/op
+# Run complete. Total time: 00:10:29
+
+Benchmark                    Mode  Cnt     Score     Error  Units
+BaseLinker.scalafmt          avgt   10  6226.143 ±  97.964  ms/op
+BaseLinker.scalariform       avgt   10    13.604 ±   0.273  ms/op
+Basic.scalafmt               avgt   10    20.116 ±   0.723  ms/op
+Basic.scalariform            avgt   10     0.481 ±   0.087  ms/op
+Division.scalafmt            avgt   10  6792.488 ± 519.506  ms/op
+Division.scalariform         avgt   10    34.708 ±   8.885  ms/op
+JsDependency.scalafmt        avgt   10   127.133 ±   6.151  ms/op
+JsDependency.scalariform     avgt   10     3.395 ±   0.171  ms/op
+SourceMapWriter.scalafmt     avgt   10   494.667 ±  45.247  ms/op
+SourceMapWriter.scalariform  avgt   10     6.887 ±   0.078  ms/op
+Utils.scalafmt               avgt   10   156.653 ±   2.729  ms/op
+Utils.scalariform            avgt   10     4.214 ±   0.096  ms/op
 ```
 * Feb 12th
   * Ran scalafmt on all [scala-js][scalajs] files with a 200ms timeout.


### PR DESCRIPTION
Still, expected more gains.

```
[info] Benchmark                        Mode  Cnt     Score     Error  Units
[info] BaseLinker.scalafmt              avgt    3   707.864 ±  87.023  ms/op
[info] BaseLinker.scalametaParser       avgt    3    10.876 ±  49.694  ms/op
[info] BaseLinker.scalariform           avgt    3    15.764 ±   3.908  ms/op
[info] Basic.scalafmt                   avgt    3    25.363 ±  46.914  ms/op
[info] Basic.scalametaParser            avgt    3    19.608 ±  18.905  ms/op
[info] Basic.scalariform                avgt    3     0.659 ±   1.250  ms/op
[info] Division.scalafmt                avgt    3  2253.869 ± 556.383  ms/op
[info] Division.scalametaParser         avgt    3    16.818 ±  11.662  ms/op
[info] Division.scalariform             avgt    3    35.331 ±  42.856  ms/op
[info] JsDependency.scalafmt            avgt    3    51.908 ±  21.290  ms/op
[info] JsDependency.scalametaParser     avgt    3     1.810 ±   5.086  ms/op
[info] JsDependency.scalariform         avgt    3     3.741 ±   8.991  ms/op
[info] Semantics.scalafmt               avgt    3    64.453 ± 107.310  ms/op
[info] Semantics.scalametaParser        avgt    3     2.105 ±   4.223  ms/op
[info] Semantics.scalariform            avgt    3     4.192 ±   4.279  ms/op
[info] SourceMapWriter.scalafmt         avgt    3   203.994 ± 146.662  ms/op
[info] SourceMapWriter.scalametaParser  avgt    3     4.099 ±  11.523  ms/op
[info] SourceMapWriter.scalariform      avgt    3     9.539 ±  14.685  ms/op
[info] Utils.scalafmt                   avgt    3    71.421 ± 123.586  ms/op
[info] Utils.scalametaParser            avgt    3     2.414 ±   4.647  ms/op
[info] Utils.scalariform                avgt    3     4.779 ±   2.180  ms/op
```