### PR TITLE
Fix output bugs, find new ones.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ lazy val compilerOptions = Seq(
 lazy val commonSettings = Seq(
   triggeredMessage in ThisBuild := Watched.clearWhenTriggered,
   scalacOptions in (Compile, console) := compilerOptions :+ "-Yrepl-class-based",
+  mainClass in assembly := Some("org.scalafmt.cli.Cli"),
+  assemblyJarName in assembly := "scalafmt.jar",
   testOptions in Test += Tests.Argument("-oD")
 )
 
@@ -87,8 +89,6 @@ lazy val core = project
   .settings(allSettings)
   .settings(
     moduleName := "scalafmt-core",
-    mainClass in assembly := Some("org.scalafmt.Cli"),
-    assemblyJarName in assembly := "scalafmt.jar",
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.1.3",
       "com.github.scopt" %% "scopt" % "3.3.0",

--- a/core/src/main/scala/org/scalafmt/Error.scala
+++ b/core/src/main/scala/org/scalafmt/Error.scala
@@ -1,5 +1,6 @@
 package org.scalafmt
 
+import scala.meta.Case
 import scala.meta.Tree
 import scala.meta.tokens.Token.Keyword
 import scala.reflect.ClassTag
@@ -14,6 +15,9 @@ object Error {
 
     case object TooManyIndentPops extends Error("Too many Indent Pop.")
 
-    case object CantFormatFile
-      extends Error("scalafmt cannot format this file")
+  case class CaseMissingArrow(tree: Case)
+    extends Error(s"Missing => in case: \n$tree")
+
+  case object CantFormatFile
+    extends Error("scalafmt cannot format this file")
 }

--- a/core/src/main/scala/org/scalafmt/ScalaStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalaStyle.scala
@@ -14,12 +14,6 @@ sealed trait ScalaStyle {
   def maxColumn: Int = 80
 
   /**
-    * The maximum duration the formatter is allowed to run before giving up.
-    * If the formatter times out, the original source code is returned.
-    */
-  def maxDuration: Duration = Duration(400, "ms")
-
-  /**
     * Debugging only. Should scalafmt create a diagnostics report.
     */
   def debug: Boolean = false
@@ -31,8 +25,6 @@ sealed trait ScalaStyle {
   */
 protected[scalafmt] sealed trait UnitTestStyle extends ScalaStyle {
   override val debug = true
-
-  override def maxDuration = Duration(10, "s")
 }
 
 object ScalaStyle {
@@ -41,12 +33,6 @@ object ScalaStyle {
     * Recommended style if you are not sure which one to pick.
     */
   case object Standard extends ScalaStyle
-
-  protected[scalafmt] case object ManualTest extends ScalaStyle {
-    override val debug = true
-
-    override def maxDuration = Duration(10, "min")
-  }
 
   protected[scalafmt] case object UnitTest80 extends UnitTestStyle
 

--- a/core/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/core/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -6,9 +6,14 @@ import org.scalafmt.ScalaFmt
 import org.scalafmt.ScalaStyle
 import org.scalafmt.internal.ScalaFmtLogger
 
+import scala.concurrent.duration.Duration
+
 
 object Cli extends ScalaFmtLogger {
-  case class Config(file: Option[File], inPlace: Boolean, range: Option[Range]) {
+  case class Config(file: Option[File],
+                    inPlace: Boolean,
+                    range: Option[Range],
+                    maxDuration: Duration = Duration(10, "s")) {
     def rangeLambda: Int => Boolean = range.map { r =>
       x: Int => x >= r.head && x <= r.last
     }.getOrElse(_ => true)
@@ -41,9 +46,9 @@ object Cli extends ScalaFmtLogger {
 
   def run(config: Config): Unit = {
     val code = getCode(config)
-    val output = ScalaFmt.format(code, ScalaStyle.Standard, config.rangeLambda)
+    val output = ScalaFmt.format(code, ScalaStyle.Standard, config.rangeLambda, config.maxDuration)
     config match {
-      case Config(Some(filename), true, _) =>
+      case Config(Some(filename), true, _, _) =>
         val path = java.nio.file.Paths.get(filename.toURI)
         java.nio.file.Files.write(path, output.getBytes)
       case _ => println(output)

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -18,7 +18,7 @@ import scala.meta.tokens.Tokens
   */
 case class FormatToken(left: Token,
                        right: Token,
-                       between: Vector[Whitespace]) {
+                       between: Vector[Whitespace]) extends ScalaFmtLogger {
   override def toString = s"${left.code}∙${right.code}"
 
   def inside(range: Int => Boolean): Boolean = {

--- a/core/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -12,13 +12,6 @@ package org.scalafmt.internal
 case class Policy(f: PartialFunction[Decision, Decision],
                   expire: Int, noDequeue: Boolean = false)(implicit val line: sourcecode.Line) {
 
-  def apply(decision: Decision): Decision = f(decision)
-
-  def orElse(other: Policy): Policy =
-    Policy(f orElse other.f, Math.max(expire, other.expire),
-      // TODO(olafur) wrong in some corner cases
-      noDequeue || other.noDequeue )
-
   override def toString = s"P:${line.value}(D=$noDequeue)"
 
 }

--- a/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -1,20 +1,27 @@
 package org.scalafmt.internal
 
-class PolicySummary(val policies: Seq[Policy]) {
+class PolicySummary(val policies: Vector[Policy]) extends ScalaFmtLogger {
 
   val noDequeue = policies.exists(_.noDequeue)
 
   def combine(other: Policy, position: Int): PolicySummary = {
     // TODO(olafur) filter policies by expiration date
-//    val activePolicies = policies.filter(_.expire >= position)
-      new PolicySummary(policies :+ other)
+    val activePolicies = policies.filter(_.expire >= position)
+      new PolicySummary(other +: policies)
     }
 
-  def execute(decision: Decision): Decision = {
+  def execute(decision: Decision, debug: Boolean = false): Decision = {
+    var last = decision
     var result = decision
     policies.foreach { policy =>
       if (policy.f.isDefinedAt(result)) {
+        last = result
         result = policy.f(result)
+        // TODO(olafur Would be nice to enforce this at compile time.
+        assert(result.formatToken == last.formatToken)
+        if (debug) {
+          logger.debug(s"$policy defined at $result")
+        }
       }
     }
     result
@@ -23,5 +30,5 @@ class PolicySummary(val policies: Seq[Policy]) {
 
 
 object PolicySummary {
-  val empty = new PolicySummary(Seq.empty[Policy])
+  val empty = new PolicySummary(Vector.empty[Policy])
 }

--- a/core/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Split.scala
@@ -46,7 +46,8 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
   def withPolicy(newPolicy: Policy): Split = {
     val update =
       if (policy == NoPolicy) newPolicy
-      else newPolicy orElse policy
+      else throw new UnsupportedOperationException(
+        "Can't have two policies yet.")
     new Split(modification, cost, ignoreIf, indents, update, true, optimalAt)(
       line)
   }
@@ -80,9 +81,8 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
   override def toString =
     s"""$modification:${line.value}(cost=$cost, indents=$indentation, p=$hasPolicy)"""
 
-  // TODO(olafur) come with better concept of split equality.
-
-  // For example update line in withOptimal.
-
-  def sameLine(other: Split) = this.line == other.line
+  def sameLine(other: Split) =
+    this.line == other.line &&
+      this.cost == other.cost &&
+      this.modification == other.modification
 }

--- a/core/src/main/scala/org/scalafmt/internal/State.scala
+++ b/core/src/main/scala/org/scalafmt/internal/State.scala
@@ -47,8 +47,8 @@ final case class State(cost: Int,
     val KILL = 10000
     val nonExpiredIndents = pushes.filterNot {
       push =>
-        if (push.expiresAt == Left) push.expire == tok.left
-        else push.expire == tok.right
+        if (push.expiresAt == Left) push.expire.end <= tok.left.end
+        else push.expire.end <= tok.right.end
     }
     val newIndents: Vector[Indent[Num]] =
       nonExpiredIndents ++ split.indents.map(_.withNum(column, indentation))
@@ -101,7 +101,7 @@ object State extends ScalaFmtLogger {
     val result = toks.zip(splits).map {
       case (tok, split) =>
         // TIP. Use the following line to debug origin of splits.
-        if (debug && toks.length < 100) {
+        if (debug && toks.length < 1000) {
           val left = small(tok.left)
           logger.debug(f"$left%-10s $split")
         }

--- a/core/src/main/scala/org/scalafmt/internal/package.scala
+++ b/core/src/main/scala/org/scalafmt/internal/package.scala
@@ -17,10 +17,23 @@ package object internal {
     })
   }
 
-  def childOf(tok: Token, tree: Tree, owners: Map[Long, Tree]): Boolean =
+  def childOf(tok: Token, tree: Tree, owners: Map[TokenHash, Tree]): Boolean =
     childOf(owners(hash(tok)), tree)
 
   /**
+    * TODO(olafur) Temporary hack until
+    *
+    * https://github.com/scalameta/scalameta/issues/332
+    *
+    * is fixed.
+    * @param token
+    */
+  case class TokenHash(token: Token)
+
+
+  /**
+    * IGNORE, see [[TokenHash]].
+    *
     * Custom hash code for token.
     *
     * The default hashCode is slow because it prevents conflicts between
@@ -35,9 +48,10 @@ package object internal {
     * The only chance for collision is if two empty length tokens with the same
     * type lie next to each other. @xeno-by said this should not happen.
     */
-  def hash(token: Token): Long = {
-    (token.privateTag << (62 - 8)) |
-      (token.start << (62 - (8 + 28))) |token.end
+  def hash(token: Token): TokenHash = {
+//    (token.privateTag << (62 - 8)) |
+//      (token.start << (62 - (8 + 28))) |token.end
+    new TokenHash(token)
   }
 
   @tailrec

--- a/core/src/test/resources/standard/Case.case
+++ b/core/src/test/resources/standard/Case.case
@@ -10,8 +10,8 @@ case FormatToken(
 <<< Long if
 case tok if tok.left.name.startsWith("xml") && tok.right.name.startsWith("xml") => List( NoSplit0 )
 >>>
-case tok
-    if tok.left.name.startsWith("xml") && tok.right.name.startsWith("xml") =>
+case tok if tok.left.name.startsWith("xml") &&
+    tok.right.name.startsWith("xml") =>
   List(NoSplit0)
 <<< Pathological if
 case FormatToken(left, open: `(`, _)
@@ -41,3 +41,24 @@ case Decision(t@FormatToken(comma: `,`, right, between), splits)
     // If comment is bound to comma, see unit/Comment.
     (!right.isInstanceOf[Comment] || between.exists(_.isInstanceOf[`\n`])) =>
   Decision(t, splits.filter(_.modification == Newline))
+<<< Bug
+case FormatToken(open: `(`, right, _) if leftOwner.isInstanceOf[Term.ApplyInfix] =>
+val close = matchingParentheses(hash(open))
+val policy =
+  if (right.isInstanceOf[`if`]) SingleLineBlock(close)
+  else NoPolicy
+Seq(
+  Split(NoSplit, 0).withPolicy(policy).withIndent(2, matchingParentheses(hash(open)), Left),
+  Split(Newline, 1).withIndent(2, matchingParentheses(hash(open)), Left)
+)
+>>>
+case FormatToken(open: `(`, right, _)
+    if leftOwner.isInstanceOf[Term.ApplyInfix] =>
+  val close = matchingParentheses(hash(open))
+  val policy =
+    if (right.isInstanceOf[`if`]) SingleLineBlock(close)
+    else NoPolicy
+  Seq(Split(NoSplit, 0).withPolicy(policy)
+        .withIndent(2, matchingParentheses(hash(open)), Left),
+      Split(Newline, 1).withIndent(2, matchingParentheses(hash(open)), Left))
+

--- a/core/src/test/resources/standard/Case.stat
+++ b/core/src/test/resources/standard/Case.stat
@@ -39,32 +39,21 @@ List(Split(Space, 0).withPolicy {
               case x => x
             })
     })
-<<< router
+<<< chain of || and &&
 x match {
-  case tok if tok.left.name.startsWith("xml") &&
-      tok.right.name.startsWith("xml") =>
-    Seq(Split(NoSplit, 0))
   case tok if // TODO(olafur) DRY.
       (leftOwner.isInstanceOf[Term.Interpolate] &&
         rightOwner.isInstanceOf[Term.Interpolate]) ||
       (leftOwner.isInstanceOf[Pat.Interpolate] &&
         rightOwner.isInstanceOf[Pat.Interpolate]) =>
-    Seq(Split(NoSplit, 0))
-  case FormatToken(_: `{`, _: `}`, _) => Seq(Split(NoSplit, 0))
-  case FormatToken(_: `]`, _: `(`, _) =>
     Seq(Split(NoSplit, 0))
 }
 >>>
 x match {
-  case tok
-      if tok.left.name.startsWith("xml") && tok.right.name.startsWith("xml") =>
-    Seq(Split(NoSplit, 0))
   case tok if // TODO(olafur) DRY.
       (leftOwner.isInstanceOf[Term.Interpolate] &&
         rightOwner.isInstanceOf[Term.Interpolate]) ||
       (leftOwner.isInstanceOf[Pat.Interpolate] &&
         rightOwner.isInstanceOf[Pat.Interpolate]) =>
     Seq(Split(NoSplit, 0))
-  case FormatToken(_: `{`, _: `}`, _) => Seq(Split(NoSplit, 0))
-  case FormatToken(_: `]`, _: `(`, _) => Seq(Split(NoSplit, 0))
 }

--- a/core/src/test/resources/standard/Select.stat
+++ b/core/src/test/resources/standard/Select.stat
@@ -49,3 +49,16 @@ a.b(c).d(e).f(g).h(i).j(k) {
 a.b(c).d(e).f(g).h(i).j(k) {
   // Crazy comment =================================================================>
 }
+<<< Crazy comment
+val lastToken = owner.body.tokens
+    .filter {
+        case _: Whitespace | _: Comment => false
+        case _ => true
+    } // edge case, if body is empty expire on arrow.
+    .lastOption.getOrElse(arrow)
+>>>
+val lastToken = owner.body.tokens.filter {
+  case _: Whitespace | _: Comment => false
+  case _ => true
+} // edge case, if body is empty expire on arrow.
+.lastOption.getOrElse(arrow)

--- a/core/src/test/resources/standard/Val.stat
+++ b/core/src/test/resources/standard/Val.stat
@@ -10,3 +10,7 @@ var inside =
     false
 >>>
 var inside = false
+<<< SKIP underscore assignment
+var inside: Int   = _
+>>>
+var inside: Int = _

--- a/core/src/test/resources/unit/If.stat
+++ b/core/src/test/resources/unit/If.stat
@@ -30,10 +30,10 @@ val newColumn =
   if (split == Newline) newIndent
   else column + split.length
 <<< Egyptian curlies
-if (split.optimalAt.contains(tok.left))
+if (optimalAt.contains(tok.left))
 { println("hello") }
 >>>
-if (split.optimalAt.contains(tok.left)) {
+if (optimalAt.contains(tok.left)) {
   println("hello")
 }
 <<< if else throw

--- a/core/src/test/resources/unit/Interpolate.stat
+++ b/core/src/test/resources/unit/Interpolate.stat
@@ -25,3 +25,8 @@ s"""${a.foo[Bar]}
   val line = s"=" * 4
   s"$line\n=> $t\n$line"
 }
+<<< SKIP new inside expr
+def shortInfo: String = s"created=${new Date()}"
+>>>
+def shortInfo: String =
+  s"created=${new Date()}"

--- a/core/src/test/scala/org/scalafmt/CliTest.scala
+++ b/core/src/test/scala/org/scalafmt/CliTest.scala
@@ -7,6 +7,8 @@ import org.scalafmt.cli.Cli
 import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
+import scala.concurrent.duration.Duration
+
 class CliTest extends FunSuite with DiffAssertions {
   test("cli parses args") {
     val expected = Cli.Config(Some(new File("foo")), inPlace = true, None)
@@ -30,7 +32,9 @@ class CliTest extends FunSuite with DiffAssertions {
         |}
       """.stripMargin
     Files.write(tmpFile, unformatted.getBytes)
-    val formatInPlace = Cli.Config(Some(tmpFile.toFile), inPlace = true, None)
+    val formatInPlace = Cli.Config(Some(tmpFile.toFile),
+      inPlace = true,
+      None, Duration(10, "s"))
     Cli.run(formatInPlace)
     val obtained = new String(Files.readAllBytes(tmpFile))
     assertNoDiff(obtained, expected)

--- a/core/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/core/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -6,33 +6,42 @@ import org.scalafmt.util.FormatAssertions
 import org.scalatest.FunSuite
 
 /**
-  * Asserts formatter maintains integrity of original source file.
+  * Asserts formatter does not alter original source file's AST.
   *
   * Will maybe use scalacheck someday.
   */
-class IntegrityTest extends FunSuite with FormatAssertions with ScalaFmtLogger {
+class FidelityTest extends FunSuite with FormatAssertions with ScalaFmtLogger {
   case class Test(filename: String, code: String)
   object Test {
     def apply(filename: String): Test =
       Test(filename, FilesUtil.readFile(filename))
   }
 
+
+  // TODO(olafur) append to [[files]]
+  val thisProject = FilesUtil.listFiles(".")
+    .filter(_.endsWith(".scala"))
+    .filterNot(_.contains("/target/"))
+    .filterNot(_.contains("/resources/"))
+
   val files =
     Seq(
+      "core/src/test/resources/standard/Router.scala",
       "benchmarks/src/resources/scalafmt/Basic.scala",
       "benchmarks/src/resources/scala-js/SourceMapWriter.scala",
       "benchmarks/src/resources/scala-js/Division.scala",
       "benchmarks/src/resources/scala-js/BaseLinker.scala",
       "benchmarks/src/resources/scala-js/JSDependency.scala")
 
+
   val examples = files.map(Test.apply)
 
   examples.foreach { example =>
     test(example.filename) {
-      println(example.filename)
       val formatted = ScalaFmt.format_!(
-        example.code, ScalaStyle.ManualTest)(scala.meta.parseSource)
+        example.code, ScalaStyle.UnitTest80)(scala.meta.parseSource)
       assertFormatPreservesAst(example.code, formatted)(scala.meta.parseSource)
+      println(example.filename)
     }
   }
 

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -8,6 +8,7 @@ import org.scalafmt.util.ScalacParser
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.meta._
 
 
@@ -20,7 +21,7 @@ object FormatExperiment extends App with ScalaProjectsExperiment with FormatAsse
     if (!ScalacParser.checkParseFails(code)) {
       val startTime = System.nanoTime()
       val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
-      val formatted = Await.result(f, ScalaStyle.Standard.maxDuration)
+      val formatted = Await.result(f, Duration(400, "ms"))
       assertFormatPreservesAst[Source](code, formatted)
       print("+")
       formatSuccesses.add(FormatSuccess(filename, System.nanoTime() - startTime))

--- a/core/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/core/src/test/scala/org/scalafmt/FormatTests.scala
@@ -60,7 +60,7 @@ class FormatTests
           case Some(parse) =>
             val obtained = ScalaFmt.format_!(t.original, t.style)(parse)
             saveResult(t, obtained)
-            assertFormatPreservesAst(obtained, t.original)(parse)
+            assertFormatPreservesAst(t.original, obtained)(parse)
             assertNoDiff(obtained, t.expected)
           case None =>
             logger.warn(s"Found no parse for filename ${t.filename}")

--- a/core/src/test/scala/org/scalafmt/ManualTests.scala
+++ b/core/src/test/scala/org/scalafmt/ManualTests.scala
@@ -36,6 +36,6 @@ object ManualTests extends HasTests {
     }
     manualFiles ++ scalaFiles
   }
-  val style = ScalaStyle.ManualTest
+  val style = ScalaStyle.UnitTest80
   val manual = ".manual"
 }

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -17,8 +17,8 @@ class RangeTest extends FunSuite with DiffAssertions {
         |  val y = 2
         |}
       """.stripMargin
-    val obtained = ScalaFmt.format(original,
-      ScalaStyle.UnitTest40, _ == 2)
+    val obtained = ScalaFmt.format_!(original,
+      ScalaStyle.UnitTest40, _ == 2)(scala.meta.parseSource)
     assertNoDiff(obtained, expected)
   }
 

--- a/core/src/test/scala/org/scalafmt/stats/TestStats.scala
+++ b/core/src/test/scala/org/scalafmt/stats/TestStats.scala
@@ -4,21 +4,18 @@ import java.util.Date
 
 import org.scalafmt.util.Result
 
-case class TestStats(createdAt: Long,
-                     results: Seq[Result],
-                     javaInfo: JavaInfo,
-                     osInfo: OsInfo,
-                     runtimeInfo: RuntimeInfo,
-                     gitInfo: GitInfo) {
+case class TestStats(createdAt: Long, results: Seq[Result], javaInfo: JavaInfo,
+    osInfo: OsInfo, runtimeInfo: RuntimeInfo,
+    gitInfo: GitInfo) {
 
   // TODO: remove machineStats
+
   def shortInfo: String =
-    s"TestStats(created=${new Date(createdAt)}," +
-      s"commit=${gitInfo.commit})"
+    s"TestStats(created=${new Date(createdAt)}," + s"commit=${gitInfo.commit})"
 
   def shortCommit: String = gitInfo.commit.take(6)
 
-  def intersectResults(other: TestStats): Seq[(Result, Result)] = {
+  def intersectResults(other: TestStats): Seq[( Result, Result)] = {
     val resultByName = other.results.map(x => x.test.fullName -> x).toMap
     results.collect {
       case r if resultByName.contains(r.test.fullName) =>
@@ -28,12 +25,12 @@ case class TestStats(createdAt: Long,
 }
 
 object TestStats {
+
   def apply(results: Seq[Result]): TestStats =
-    TestStats(
-      System.currentTimeMillis(), results,
-      JavaInfo(),
-      OsInfo(),
-      RuntimeInfo(),
-      GitInfo()
-    )
+    TestStats(System.currentTimeMillis(),
+              results,
+              JavaInfo(),
+              OsInfo(),
+              RuntimeInfo(),
+              GitInfo())
 }

--- a/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/core/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -19,8 +19,9 @@ trait FormatAssertions extends FunSuiteLike with DiffAssertions {
           case Some(obtainedParsed) =>
             val originalStructure = originalParsed.show[Structure]
             val obtainedStructure = obtainedParsed.show[Structure]
-            assertNoDiff(originalStructure, obtainedStructure,
-              "formatter changed AST!")
+            if (originalStructure != obtainedStructure) {
+              fail("formatter changed AST!\n" + obtained)
+            }
           case None =>
             fail("Formatter output does not parse!\n" +
               error2message(obtained, original))

--- a/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
@@ -6,6 +6,7 @@ import java.text.DecimalFormat
 import java.util.concurrent.CopyOnWriteArrayList
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
+import org.scalafmt.internal.Debug
 import org.scalafmt.internal.ScalaFmtLogger
 
 import scala.collection.JavaConversions._
@@ -25,7 +26,7 @@ trait ScalaProjectsExperiment extends ScalaFmtLogger {
   val verbose = false
   val globalFilter: String => Boolean = _ => true
   val colLength = 10
-  val decimalFormat = new DecimalFormat("0.##E0")
+  val decimalFormat = new DecimalFormat("#.##")
   private val timeoutFailures: java.util.List[TimeoutErr] = new CopyOnWriteArrayList
   private val parseFailures: java.util.List[ParseErr] = new CopyOnWriteArrayList
   private val otherFailures: java.util.List[UnknownFailure] = new CopyOnWriteArrayList
@@ -33,6 +34,7 @@ trait ScalaProjectsExperiment extends ScalaFmtLogger {
 
   /**
     * Run
+    *
     * @param filename
     */
   def runOn(filename: String): Boolean
@@ -183,7 +185,7 @@ trait ScalaProjectsExperiment extends ScalaFmtLogger {
     ))
 
   private def formatNumber(x: Any): String = x match {
-    case d: Double => decimalFormat.format(d)
+    case d: Double => decimalFormat.format(Debug.ns2ms(d.asInstanceOf[Long])) + "ms"
     case _ => x.toString
   }
 

--- a/readme.md
+++ b/readme.md
@@ -92,8 +92,48 @@ To run main formatting tests:
 
 * `~core/testOnly org.scalafmt.FormatTest`
 
-### Updates
+### Updates (mostly for myself)
 
+* Feb 19th
+  * Ran `scalafmt` on  Scala.js repo with 10s timeout. Performance is slower
+  than yesterday since 
+  I fixed some formatting bugs which made the performance slightly worse.
+```
+Unknown Failures: 60
+Timeout Failures: 21
+Parse exceptions: 19
+Format successes: 821
+Summary of running times (in ms, 1E8 is 100ms):
+Q1=25th percentile, Q2=median, Q3=75th percentile
++------+------+-------+------+------+------+------+
+|   Max|   Min|    Sum|  Mean|    Q1|    Q2|    Q3|
++------+------+-------+------+------+------+------+
+|9.79E9|1.65E6|5.41E11|6.58E8|3.45E7|1.19E8|5.18E8|
++------+------+-------+------+------+------+------+
+
+Benchmark                        Mode  Cnt     Score     Error  Units
+BaseLinker.scalafmt              avgt    3   749.977 ± 289.092  ms/op
+BaseLinker.scalametaParser       avgt    3     8.171 ±   8.260  ms/op
+BaseLinker.scalariform           avgt    3    15.634 ±  22.799  ms/op
+Basic.scalafmt                   avgt    3    25.089 ±  29.384  ms/op
+Basic.scalametaParser            avgt    3    18.783 ±  23.687  ms/op
+Basic.scalariform                avgt    3     0.666 ±   1.207  ms/op
+Division.scalafmt                avgt    3  2765.606 ± 521.940  ms/op
+Division.scalametaParser         avgt    3    16.796 ±   9.724  ms/op
+Division.scalariform             avgt    3    35.425 ±   9.046  ms/op
+JsDependency.scalafmt            avgt    3    57.497 ±  41.198  ms/op
+JsDependency.scalametaParser     avgt    3     1.792 ±   5.853  ms/op
+JsDependency.scalariform         avgt    3     3.828 ±  10.027  ms/op
+Semantics.scalafmt               avgt    3    60.998 ±  72.010  ms/op
+Semantics.scalametaParser        avgt    3     2.053 ±   4.469  ms/op
+Semantics.scalariform            avgt    3     3.954 ±   2.780  ms/op
+SourceMapWriter.scalafmt         avgt    3   218.982 ±  82.800  ms/op
+SourceMapWriter.scalametaParser  avgt    3     3.997 ±  11.506  ms/op
+SourceMapWriter.scalariform      avgt    3     7.576 ±   7.467  ms/op
+Utils.scalafmt                   avgt    3    74.701 ±  76.110  ms/op
+Utils.scalametaParser            avgt    3     2.364 ±   4.006  ms/op
+Utils.scalariform                avgt    3     4.812 ±   6.279  ms/op
+```
 * Feb 18th
   * Ran `scalafmt` on  Scala.js repo with 200ms timeout.
 ```


### PR DESCRIPTION
* add test for bug in var assignment to underscore
* add test for bug in interpolate with expr
* add router.scala to integrity test, no more surprises!
* fix bug in expiring indents
* apply policies in correct order.
* rename GraphSearch to BestFirstSearch because it's more correct.
* improve (?) newline handling in case statements.
* Revert hashCode because of collision, use HashToken until
  https://github.com/scalameta/scalameta/issues/332 gets response.
* Fix bug in state column keys.