### PR TITLE
Limit calls to token.position.end.line.

### DIFF
--- a/core/src/main/scala/org/scalafmt/ScalaFmt.scala
+++ b/core/src/main/scala/org/scalafmt/ScalaFmt.scala
@@ -38,7 +38,7 @@ object ScalaFmt extends ScalaFmtLogger {
     */
   def format(code: String,
              style: ScalaStyle = ScalaStyle.Standard,
-             range: Int => Boolean = _ => true,
+             range: Set[Range] = Set.empty[Range],
              maxDuration: Duration = Duration(400, "ms")): String = {
     try {
       val formatted = Future(format_![Source](code, style, range)(parseSource))
@@ -74,7 +74,7 @@ object ScalaFmt extends ScalaFmtLogger {
     */
   def format_![T <: Tree](code: String,
                           style: ScalaStyle,
-                          range: Int => Boolean = _ => true)
+                          range: Set[Range] = Set.empty[Range])
                          (implicit ev: Parse[T]): String = {
     import scala.meta._
     val source = code.parse[T]

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -19,7 +19,7 @@ import scala.reflect.classTag
 /**
   * Implements best first search to find optimal formatting.
   */
-class BestFirstSearch(style: ScalaStyle, tree: Tree, range: Int => Boolean)
+class BestFirstSearch(style: ScalaStyle, tree: Tree, range: Set[Range])
   extends ScalaFmtLogger {
 
   import BestFirstSearch._

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -21,8 +21,9 @@ case class FormatToken(left: Token,
                        between: Vector[Whitespace]) extends ScalaFmtLogger {
   override def toString = s"${left.code}∙${right.code}"
 
-  def inside(range: Int => Boolean): Boolean = {
-    range(right.position.end.line)
+  def inside(range: Set[Range]): Boolean = {
+    if (range.isEmpty) true
+    else range.exists(_.contains(right.position.end.line))
   }
 }
 

--- a/core/src/test/scala/org/scalafmt/CliTest.scala
+++ b/core/src/test/scala/org/scalafmt/CliTest.scala
@@ -11,9 +11,9 @@ import scala.concurrent.duration.Duration
 
 class CliTest extends FunSuite with DiffAssertions {
   test("cli parses args") {
-    val expected = Cli.Config(Some(new File("foo")), inPlace = true, None)
+    val expected = Cli.Config(Some(new File("foo")), inPlace = true)
     val args = Seq("--file", "foo", "-i")
-    val init = Cli.Config(None, inPlace = false, None)
+    val init = Cli.Config(None, inPlace = false)
     val obtained = Cli.parser.parse(args, init)
     assert(obtained.contains(expected))
   }
@@ -33,8 +33,7 @@ class CliTest extends FunSuite with DiffAssertions {
       """.stripMargin
     Files.write(tmpFile, unformatted.getBytes)
     val formatInPlace = Cli.Config(Some(tmpFile.toFile),
-      inPlace = true,
-      None, Duration(10, "s"))
+      inPlace = true, maxDuration = Duration(10, "s"))
     Cli.run(formatInPlace)
     val obtained = new String(Files.readAllBytes(tmpFile))
     assertNoDiff(obtained, expected)

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -21,7 +21,7 @@ object FormatExperiment extends App with ScalaProjectsExperiment with FormatAsse
     if (!ScalacParser.checkParseFails(code)) {
       val startTime = System.nanoTime()
       val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
-      val formatted = Await.result(f, Duration(400, "ms"))
+      val formatted = Await.result(f, Duration(10, "s"))
       assertFormatPreservesAst[Source](code, formatted)
       print("+")
       formatSuccesses.add(FormatSuccess(filename, System.nanoTime() - startTime))

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -18,7 +18,7 @@ class RangeTest extends FunSuite with DiffAssertions {
         |}
       """.stripMargin
     val obtained = ScalaFmt.format_!(original,
-      ScalaStyle.UnitTest40, _ == 2)(scala.meta.parseSource)
+      ScalaStyle.UnitTest40, Set(Range(2, 2).inclusive))(scala.meta.parseSource)
     assertNoDiff(obtained, expected)
   }
 


### PR DESCRIPTION
See https://github.com/scalameta/scalameta/issues/334.
The there is no need to format a range of lines then we call
position.end.line.

Scala.js
========
Unknown Failures: 62
Timeout Failures: 9
Parse exceptions: 19
Format successes: 830

Benchmark
=========
```
[info] Benchmark                        Mode  Cnt     Score    Error  Units
[info] BaseLinker.scalafmt              avgt    5   538.260 ± 86.656  ms/op
[info] BaseLinker.scalametaParser       avgt    5     6.433 ±  2.844  ms/op
[info] BaseLinker.scalariform           avgt    5    14.185 ±  1.416  ms/op
[info] Basic.scalafmt                   avgt    5    21.574 ±  3.126  ms/op
[info] Basic.scalametaParser            avgt    5    17.294 ±  2.465  ms/op
[info] Basic.scalariform                avgt    5     0.486 ±  0.094  ms/op
[info] Division.scalafmt                avgt    5  1997.131 ± 98.516  ms/op
[info] Division.scalametaParser         avgt    5    17.151 ± 10.015  ms/op
[info] Division.scalariform             avgt    5    31.963 ±  4.127  ms/op
[info] JsDependency.scalafmt            avgt    5    48.036 ±  5.574  ms/op
[info] JsDependency.scalametaParser     avgt    5     1.382 ±  0.216  ms/op
[info] JsDependency.scalariform         avgt    5     3.247 ±  0.464  ms/op
[info] Semantics.scalafmt               avgt    5    41.882 ±  3.945  ms/op
[info] Semantics.scalametaParser        avgt    5     1.738 ±  0.373  ms/op
[info] Semantics.scalariform            avgt    5     3.703 ±  0.225  ms/op
[info] SourceMapWriter.scalafmt         avgt    5   173.634 ± 32.379  ms/op
[info] SourceMapWriter.scalametaParser  avgt    5     3.330 ±  0.272  ms/op
[info] SourceMapWriter.scalariform      avgt    5     7.100 ±  0.486  ms/op
[info] Utils.scalafmt                   avgt    5    60.520 ± 17.482  ms/op
[info] Utils.scalametaParser            avgt    5     1.992 ±  0.295  ms/op
[info] Utils.scalariform                avgt    5     4.490 ±  0.172  ms/op
```