### PR TITLE
Minor optimizations.

### DIFF
--- a/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -30,8 +30,8 @@ import scalariform.formatter.preferences.IndentSpaces
   * > benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*
   */
 @org.openjdk.jmh.annotations.State(Scope.Benchmark)
-@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 abstract class FormatBenchmark(path: String*) {
@@ -56,7 +56,6 @@ abstract class FormatBenchmark(path: String*) {
     else Paths.get("benchmarks", "src", "resources", filename)
   }
 
-  @Benchmark
   def scalametaParser(): Unit = {
     import scala.meta._
     code.parse[Source]
@@ -68,7 +67,8 @@ abstract class FormatBenchmark(path: String*) {
       ScalaStyle.Standard)(scala.meta.parsers.parseSource)
   }
 
-  @Benchmark
+  // No need to run same benchmark again and again.
+  //  @Benchmark
   def scalariform(): String = {
     ScalaFormatter.format(code, scalariformPreferences)
   }
@@ -80,19 +80,18 @@ object run {
   abstract class ScalaJsBenchmark(filename: String)
     extends FormatBenchmark("scala-js", filename)
 
-  class Basic extends FormatBenchmark("scalafmt", "Basic.scala")
-
-  class Utils extends ScalaJsBenchmark("Utils.scala")
 
   class Division extends ScalaJsBenchmark("Division.scala")
-
-  class JsDependency extends ScalaJsBenchmark("JSDependency.scala")
 
   class SourceMapWriter extends ScalaJsBenchmark("SourceMapWriter.scala")
 
   class BaseLinker extends ScalaJsBenchmark("BaseLinker.scala")
 
-  class Semantics extends ScalaJsBenchmark("Semantics.scala")
+  // These files are too small to be interesting.
+  //  class Basic extends FormatBenchmark("scalafmt", "Basic.scala")
+  //  class Utils extends ScalaJsBenchmark("Utils.scala")
+  //  class JsDependency extends ScalaJsBenchmark("JSDependency.scala")
+  //  class Semantics extends ScalaJsBenchmark("Semantics.scala")
 
   // Scalafmt can't format these, yet.
   //  class TypeKinds extends ScalaJsBenchmark("TypeKinds.scala")

--- a/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
+++ b/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
@@ -10,18 +10,15 @@ class BenchmarkOK extends FunSuite with FormatAssertions {
 
   // TODO(olafur) DRY.
   val formatBenchmarks = Seq(
-    new Basic,
-    new Utils,
     new SourceMapWriter,
-   // TODO(olafur) make larger files integration tests.
     new Division,
-    new BaseLinker,
-    new JsDependency
+    new BaseLinker
   )
   formatBenchmarks.foreach { formatBenchmark =>
     val name = formatBenchmark.getClass.getSimpleName
     test(s"$name: runs without exception.") {
       formatBenchmark.setup()
+      formatBenchmark.scalametaParser()
       formatBenchmark.scalafmt()
       formatBenchmark.scalariform()
       println(name)

--- a/build.sbt
+++ b/build.sbt
@@ -112,11 +112,6 @@ lazy val benchmarks = project
   .settings(
     libraryDependencies ++= Seq(
       "org.scalariform" %% "scalariform" % Deps.scalariform,
-      // For some odd reason, the logging deps from core are not found, but
-      // when I include these it finds multiple SLF4J bindings.
-      // TODO(olafur) solve this mess.
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0" % "test",
-      "org.slf4j" % "slf4j-log4j12" % "1.7.10" % "test",
       "org.scalatest" %% "scalatest" % Deps.scalatest % "test"
     ),
     javaOptions in run ++= Seq(

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -25,6 +25,11 @@ case class FormatToken(left: Token,
     if (range.isEmpty) true
     else range.exists(_.contains(right.position.end.line))
   }
+
+  /**
+    * A format token is uniquely identified by its left token.
+    */
+  override def hashCode(): Int = hash(left)
 }
 
 object FormatToken {

--- a/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/core/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -7,8 +7,11 @@ class PolicySummary(val policies: Vector[Policy]) extends ScalaFmtLogger {
   def combine(other: Policy, position: Int): PolicySummary = {
     // TODO(olafur) filter policies by expiration date
     val activePolicies = policies.filter(_.expire >= position)
-      new PolicySummary(other +: policies)
-    }
+    val newPolicies =
+      if (other == NoPolicy) activePolicies
+      else other +: activePolicies
+    new PolicySummary(newPolicies)
+  }
 
   def execute(decision: Decision, debug: Boolean = false): Decision = {
     var last = decision

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -66,9 +66,10 @@ class Router(style: ScalaStyle,
       case FormatToken(_: BOF, _, _) => Seq(
         Split(NoSplit, 0)
       )
-      case FormatToken(_, _: EOF, _) => Seq(
-        Split(Newline, 0) // End files with trailing newline
-      )
+      case FormatToken(_, _: EOF, _) =>
+        Seq(
+          Split(Newline, 0) // End files with trailing newline
+        )
       case tok if tok.left.name.startsWith("xml") &&
         tok.right.name.startsWith("xml") => Seq(
         Split(NoSplit, 0)

--- a/core/src/main/scala/org/scalafmt/internal/package.scala
+++ b/core/src/main/scala/org/scalafmt/internal/package.scala
@@ -21,19 +21,11 @@ package object internal {
     childOf(owners(hash(tok)), tree)
 
   /**
-    * TODO(olafur) Temporary hack until
-    *
-    * https://github.com/scalameta/scalameta/issues/332
-    *
-    * is fixed.
-    * @param token
+    * For convenience when experimenting with different hashing strategies.
     */
-  case class TokenHash(token: Token)
-
+  type TokenHash = Int
 
   /**
-    * IGNORE, see [[TokenHash]].
-    *
     * Custom hash code for token.
     *
     * The default hashCode is slow because it prevents conflicts between
@@ -49,9 +41,10 @@ package object internal {
     * type lie next to each other. @xeno-by said this should not happen.
     */
   def hash(token: Token): TokenHash = {
-//    (token.privateTag << (62 - 8)) |
-//      (token.start << (62 - (8 + 28))) |token.end
-    new TokenHash(token)
+    val longHash =
+      (token.privateTag << (62 - 8)) |
+        (token.start << (62 - (8 + 28))) |token.end
+    java.lang.Long.hashCode(longHash)
   }
 
   @tailrec

--- a/core/src/test/resources/standard/Apply.stat
+++ b/core/src/test/resources/standard/Apply.stat
@@ -115,3 +115,27 @@ Seq(Split(modification, 0, policy = singleLine).withIndent(indent, close, Left)
           3 + nestedPenalty + lhsPenalty,
           policy = oneArgOneLine,
           ignoreIf = singleArgument).withIndent(indent, close, Left))
+<<< SKIP continuation indent
+Seq(
+            // Either everything fits in one line or break on =>
+            Split(Space, 0).withPolicy(SingleLineBlock(lastToken)),
+            Split(Space, 1).withPolicy(Policy({
+                  case Decision(t@FormatToken(`arrow`, _, _), s) =>
+                    Decision(t, s.filter(_.modification.isNewline))
+                },
+                expire = lastToken.end))
+              .withIndent(2, lastToken, Left) // case body indented by 2.
+              .withIndent(2, arrow, Left) // cond body indented by 4.
+        )
+>>>
+Seq(
+    // Either everything fits in one line or break on =>
+    Split(Space, 0).withPolicy(SingleLineBlock(lastToken)),
+    Split(Space, 1).withPolicy(Policy({
+          case Decision(t@FormatToken(`arrow`, _, _), s) =>
+            Decision(t, s.filter(_.modification.isNewline))
+        },
+        expire = lastToken.end))
+      .withIndent(2, lastToken, Left) // case body indented by 2.
+      .withIndent(2, arrow, Left) // cond body indented by 4.
+)

--- a/core/src/test/resources/standard/TestingClassNameDoNotEdit.scalafmt
+++ b/core/src/test/resources/standard/TestingClassNameDoNotEdit.scalafmt
@@ -1,6 +1,8 @@
-package org.scalafmt.internal
+package standard
 
 import org.scalafmt.ScalaStyle
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.TokenHash
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -19,14 +21,10 @@ import scala.meta.tokens.Token
 // Too many to import individually.
 import scala.meta.tokens.Token._
 
-case class TokenHash(token: Token) {
-//  override def hashCode: Int = token.hashCode()
-}
-
 /**
   * Assigns splits to format tokens.
   */
-class Router(style: ScalaStyle,
+class TestingClassNameDoNotEdit(style: ScalaStyle,
              tree: Tree,
              tokens: Array[FormatToken],
              matchingParentheses: Map[TokenHash, Token],

--- a/core/src/test/resources/unit/TermApply.stat
+++ b/core/src/test/resources/unit/TermApply.stat
@@ -126,3 +126,13 @@ val result = service.something(param1, param2, param3, param4).map(transform)
 val result = service
   .something(param1, param2, param3, param4)
   .map(transform)
+<<< SKIP One arg per line
+Seq(
+  Split(Space, 0), // End files with trailing newline
+  Split(Newline, 1)
+)
+>>>
+Seq(
+    Split(Space, 0), // End files with trailing newline
+    Split(Newline, 1)
+)

--- a/core/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/core/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -26,7 +26,7 @@ class FidelityTest extends FunSuite with FormatAssertions with ScalaFmtLogger {
 
   val files =
     Seq(
-      "core/src/test/resources/standard/Router.scala",
+      "core/src/test/resources/standard/TestingClassNameDoNotEdit.scalafmt",
       "benchmarks/src/resources/scalafmt/Basic.scala",
       "benchmarks/src/resources/scala-js/SourceMapWriter.scala",
       "benchmarks/src/resources/scala-js/Division.scala",

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -15,7 +15,7 @@ trait HasTests {
 
   def filename2parse(filename: String): Option[Parse[_ <: Tree]] =
     extension(filename) match {
-      case "source" | "scala" => Some(scala.meta.parsers.parseSource)
+      case "source" | "scala" | "scalafmt" => Some(scala.meta.parsers.parseSource)
       case "stat" => Some(scala.meta.parsers.parseStat)
       case "case" => Some(scala.meta.parsers.parseCase)
       case _ => None

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -1,1 +1,1 @@
-sbt benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*
+sbt "benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*"


### PR DESCRIPTION
* custom hashcode for Token and FormatToken
* Expire policies, suprisingly little improvement.

```
[info] Benchmark                 Mode  Cnt     Score    Error  Units
[info] BaseLinker.scalafmt       avgt   10   415.639 ± 11.092  ms/op
[info] Division.scalafmt         avgt   10  1811.321 ± 43.431  ms/op
[info] SourceMapWriter.scalafmt  avgt   10   158.080 ±  3.959  ms/op
```