### PR TITLE
Fix multiple output bugs from FormatExperiment.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val root = project.in(file("."))
   .settings(
     initialCommands in console :=
       """
-        |import org.scalameta._
+        |import scala.meta._
         |import org.scalafmt.internal._
         |import org.scalafmt._
       """.stripMargin

--- a/core/src/main/scala/org/scalafmt/Error.scala
+++ b/core/src/main/scala/org/scalafmt/Error.scala
@@ -20,8 +20,15 @@ object Error extends ScalaFmtLogger {
   case class CaseMissingArrow(tree: Case)
     extends Error(s"Missing => in case: \n$tree")
 
-  case object FormatterChangedAST
-    extends Error("Formatter changed AST")
+  case class FormatterChangedAST(diff: String, output: String) extends Error(
+    s"""Formatter changed AST
+        |=====================
+        |$diff
+        |=====================
+        |$output
+        |=====================
+        |Formatter changed AST
+      """.stripMargin)
 
   case class FormatterOutputDoesNotParse(msg: String)
     extends Error("Formatter output does not parse:\n" + msg)

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.ast.Defn
 import scala.meta.internal.ast.Pkg
 import scala.meta.internal.ast.Template
 import scala.meta.internal.ast.Term
+import scala.meta.internal.ast.Type
 import scala.meta.prettyprinters.Structure
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
@@ -297,20 +298,21 @@ object BestFirstSearch extends ScalaFmtLogger {
 
     def loop(x: Tree): Unit = {
       x match {
-        case t: scala.meta.internal.ast.Source => addAll(t.stats)
-        case t: Pkg => addAll(t.stats)
-        case t: Term.ForYield => addAll(t.enums)
-        case t: Term.For => addAll(t.enums)
-        case t: Term.Match => addAll(t.cases)
-        case t: Term.PartialFunction => addAll(t.cases)
         case b: Term.Block => addAll(b.stats)
-        case t: Defn.Object => addDefn[`object`](t.mods, t)
         case t: Defn.Class => addDefn[`class `](t.mods, t)
-        case t: Defn.Trait => addDefn[`trait`](t.mods, t)
         case t: Defn.Def => addDefn[`def`](t.mods, t)
+        case t: Defn.Object => addDefn[`object`](t.mods, t)
+        case t: Defn.Trait => addDefn[`trait`](t.mods, t)
+        case t: Defn.Type => addDefn[`type`](t.mods, t)
         case t: Defn.Val => addDefn[`val`](t.mods, t)
         case t: Defn.Var => addDefn[`var`](t.mods, t)
-        case t: Defn.Type => addDefn[`type`](t.mods, t)
+        case t: Pkg => addAll(t.stats)
+        case t: Term.For => addAll(t.enums)
+        case t: Term.ForYield => addAll(t.enums)
+        case t: Term.Match => addAll(t.cases)
+        case t: Term.PartialFunction => addAll(t.cases)
+        case t: Type.Compound => addAll(t.refinement)
+        case t: scala.meta.internal.ast.Source => addAll(t.stats)
         case t: Template if t.stats.isDefined =>
           addAll(t.stats.get)
         case _ => // Nothing

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -1,2 +1,1 @@
-SKIP core/src/test/scala/org/scalafmt/util/DiffAssertions.scala
 SKIP core/src/main/scala/org/scalafmt/internal/Router.scala

--- a/core/src/test/resources/standard/Fidelity.stat
+++ b/core/src/test/resources/standard/Fidelity.stat
@@ -1,0 +1,19 @@
+80 columns                                                                     |
+<<< statement starts get newline
+  {
+    val lhm = factory.empty[jl.Integer, String]
+    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+  }
+>>>
+{
+  val lhm = factory.empty[jl.Integer, String]
+  (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+}
+<<< negated literal inside ()
+assertEquals("-50",   (-50L).toString)
+>>>
+assertEquals("-50", (-50L).toString)
+<<< literals inside ()
+assertEquals("-50",   (50L).toString)
+>>>
+assertEquals("-50", (50L).toString)

--- a/core/src/test/resources/unit/If.stat
+++ b/core/src/test/resources/unit/If.stat
@@ -30,8 +30,16 @@ val newColumn =
   if (split == Newline) newIndent
   else column + split.length
 <<< Egyptian curlies
+if (optimalAt.contains(tok.left)) {
+println("hello") }
+>>>
+if (optimalAt.contains(tok.left)) {
+  println("hello")
+}
+<<< No-Egyptian curlies
 if (optimalAt.contains(tok.left))
-{ println("hello") }
+{
+println("hello") }
 >>>
 if (optimalAt.contains(tok.left)) {
   println("hello")

--- a/core/src/test/resources/unit/Import.source
+++ b/core/src/test/resources/unit/Import.source
@@ -50,3 +50,17 @@ import java.{util => ju}
 import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.javascript._
 import org.scalajs.core.tools.optimizer._
+<<< import block
+object a {
+  import LowPrioGenBCodeCompat.genBCode._
+  {
+  initializeCoreBTypes()
+  }
+}
+>>>
+object a {
+  import LowPrioGenBCodeCompat.genBCode._
+  {
+    initializeCoreBTypes()
+  }
+}

--- a/core/src/test/resources/unit/Symbol.stat
+++ b/core/src/test/resources/unit/Symbol.stat
@@ -1,0 +1,5 @@
+40 columns                              |
+<<< symbols get space
+def unary_!   : Boolean = !value
+>>>
+def unary_! : Boolean = !value

--- a/core/src/test/resources/unit/Type.stat
+++ b/core/src/test/resources/unit/Type.stat
@@ -1,0 +1,11 @@
+40 columns                              |
+<<< abstract defs get newline
+type ObjNotifyLike = Any {
+        def notify(): Unit
+        def notifyAll(): Unit
+      }
+>>>
+type ObjNotifyLike = Any {
+  def notify(): Unit
+  def notifyAll(): Unit
+}

--- a/core/src/test/scala/org/scalafmt/ParseExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/ParseExperiment.scala
@@ -14,17 +14,15 @@ import scala.concurrent.duration.Duration
 import scala.meta._
 
 
-object FormatExperiment extends App with ScalaProjectsExperiment with FormatAssertions {
+object ParseExperiment extends App with ScalaProjectsExperiment with FormatAssertions {
   override val verbose = false
-  override val skipProject: String => Boolean = !_.contains("scala-js/scala-js")
 
+//  override val skipProject: String => Boolean = !_.contains("intelli")
   override def runOn(filename: String): Boolean = {
     val code = FilesUtil.readFile(filename)
     if (!ScalacParser.checkParseFails(code)) {
       val startTime = System.nanoTime()
-      val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
-      val formatted = Await.result(f, Duration(10, "s"))
-      assertFormatPreservesAst[Source](code, formatted)
+      code.parse[Source]
       print("+")
       results.add(Success(filename, System.nanoTime() - startTime))
     } else {

--- a/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
+++ b/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
@@ -4,6 +4,7 @@ import scala.meta.parsers.common.ParseException
 
 sealed abstract class ExperimentResult(fileUrl: String) {
   def key: String
+  def details: String = fileUrl
 }
 object ExperimentResult {
   case class Success(fileUrl: String, nanos: Long) extends ExperimentResult(fileUrl) {
@@ -23,15 +24,14 @@ object ExperimentResult {
   }
   case class ParseErr(fileUrl: String, e: ParseException)
     extends ExperimentResult(fileUrl) {
-    override def key: String = e.getClass.getName
-
-    def err: String = e.getMessage.replaceAll(" at .*", "")
+    override def key: String =
+      e.getClass.getName + ": " + e.getMessage.replaceAll(" at .*", "")
 
     def lineNumber = e.pos.point.line
 
     def content = s"cols:${e.pos.start.column}-${e.pos.end.column}"
 
-    override def toString: String = s"$fileUrl#L${e.pos.start.line + 1} $cols"
+    override def details: String = s"$fileUrl#L${e.pos.start.line + 1} $cols"
 
     def cols = s"cols:${e.pos.start.column}-${e.pos.end.column}"
   }


### PR DESCRIPTION
* Fix cases where formatter produces unformattable code.
* Handle curly brace starting new block.
* Fixes #25.
* Space after non-alphanumeric character identifiers.
* Eliminate spaces after inline comments.
* Fix type compounds and declarations
* Fix spaces around orphan (

ParserExperiment

Formatter timed out: 41
org.scalafmt.Error$FormatterChangedAST$: 7
java.lang.ClassCastException: 11
org.scalafmt.Error$CantFormatFile$: 8
Success: 853
Total: 920
+------------+--------+--------------+----------+---------+----------+----------+
|         Max|     Min|           Sum|      Mean|       Q1|        Q2|        Q3|
+------------+--------+--------------+----------+---------+----------+----------+
|9.946,107 ms|1,072 ms|811.343,078 ms|951,164 ms|50,666 ms|213,938 ms|876,157 ms|
+------------+--------+--------------+----------+---------+----------+----------+