### PR TITLE
Remove memoization, ~100x speed improvement.

### DIFF
--- a/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -68,7 +68,7 @@ abstract class FormatBenchmark(path: String*) {
   }
 
   // No need to run same benchmark again and again.
-  //  @Benchmark
+    @Benchmark
   def scalariform(): String = {
     ScalaFormatter.format(code, scalariformPreferences)
   }
@@ -87,6 +87,8 @@ object run {
 
   class BaseLinker extends ScalaJsBenchmark("BaseLinker.scala")
 
+  class OptimizerCore extends ScalaJsBenchmark("OptimizerCore.scala")
+
   // These files are too small to be interesting.
   //  class Basic extends FormatBenchmark("scalafmt", "Basic.scala")
   //  class Utils extends ScalaJsBenchmark("Utils.scala")
@@ -97,7 +99,6 @@ object run {
   //  class TypeKinds extends ScalaJsBenchmark("TypeKinds.scala")
   //  class Analyzer extends ScalaJsBenchmark("Analyzer.scala")
   //  class Trees extends ScalaJsBenchmark("Trees.scala")
-  //  class OptimizerCore extends ScalaJsBenchmark("OptimizerCore.scala")
   //  class GenJsCode extends ScalaJsBenchmark("GenJsCode.scala")
   //  class CopyOnWriteArrayList extends ScalaJsBenchmark("CopyOnWriteArrayList.scala")
 }

--- a/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
+++ b/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
@@ -10,6 +10,7 @@ class BenchmarkOK extends FunSuite with FormatAssertions {
 
   // TODO(olafur) DRY.
   val formatBenchmarks = Seq(
+    new OptimizerCore,
     new SourceMapWriter,
     new Division,
     new BaseLinker

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ lazy val buildSettings = Seq(
   organization := "org.scalafmt",
   version := "0.1.0-SNAPSHOT",
   scalaVersion := "2.11.7",
-  resolvers +=
-    "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   updateOptions := updateOptions.value.withCachedResolution(true),
   // Many useful rules are ignored, at least they're explicitly ignored.
   wartremoverWarnings in (Compile, compile) ++=

--- a/core/src/main/scala/org/scalafmt/Error.scala
+++ b/core/src/main/scala/org/scalafmt/Error.scala
@@ -1,5 +1,6 @@
 package org.scalafmt
 
+import org.scalafmt.internal.Decision
 import org.scalafmt.internal.ScalaFmtLogger
 
 import scala.meta.Case
@@ -25,7 +26,7 @@ object Error extends ScalaFmtLogger {
         |=====================
         |$diff
         |=====================
-        |$output
+        |${output.lines.toVector.take(10).mkString("\n")}
         |=====================
         |Formatter changed AST
       """.stripMargin)
@@ -37,8 +38,10 @@ object Error extends ScalaFmtLogger {
     extends Error(
       s"Expected: ${classTag[Expected].getClass}\nObtained: ${log(obtained)}")
 
-  case object CantFormatFile
-    extends Error("scalafmt cannot format this file")
+  case class CantFormatFile(msg: String)
+    extends Error("scalafmt cannot format this file:\n"  + msg)
 
+  case class NoopDefaultPolicyApplied(decision: Decision)
+    extends Error(s"Default policy run on $decision")
 
 }

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -29,10 +29,10 @@ case class FormatToken(left: Token,
   /**
     * A format token is uniquely identified by its left token.
     */
-  override def hashCode(): Int = hash(left)
+  override def hashCode(): Int = java.lang.Long.hashCode(hash(left))
 }
 
-object FormatToken {
+object FormatToken extends ScalaFmtLogger {
 
   /**
     * Convert scala.meta Tokens to FormatTokens.
@@ -41,26 +41,18 @@ object FormatToken {
     * little memory as possible.
     */
   def formatTokens(tokens: Tokens): Array[FormatToken] = {
-    val N = tokens.length
-    require(N > 1)
-    var i = 1
     var left = tokens.head
-    val ts = tokens.toArray
     val result = mutable.ArrayBuilder.make[FormatToken]
-    result.sizeHint(N)
     val whitespace = mutable.ArrayBuilder.make[Whitespace]()
-    while (i < N) {
-      ts(i) match {
-        case t: Whitespace =>
-          whitespace += t
-        case right =>
-          // TODO(olafur) avoid result.toVector
-          val tok = FormatToken(left, right, whitespace.result.toVector)
-          result += tok
-          left = right
-          whitespace.clear()
-      }
-      i += 1
+    tokens.toArray.foreach {
+      case t: Whitespace =>
+        whitespace += t
+      case right =>
+        // TODO(olafur) avoid result.toVector
+        val tok = FormatToken(left, right, whitespace.result.toVector)
+        result += tok
+        left = right
+        whitespace.clear()
     }
     result.result
   }

--- a/core/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -1,5 +1,7 @@
 package org.scalafmt.internal
 
+import org.scalafmt.Error.NoopDefaultPolicyApplied
+
 
 /**
   * The decision made by [[Router]].
@@ -18,7 +20,8 @@ case class Policy(f: PartialFunction[Decision, Decision],
 
 object Policy {
   val IdentityPolicy: PartialFunction[Decision, Decision] = {
-    case d => d
+    case d =>
+      throw NoopDefaultPolicyApplied(d)
   }
   val empty = Policy(IdentityPolicy, Integer.MAX_VALUE)
 }

--- a/core/src/main/scala/org/scalafmt/internal/ScalaFmtLogger.scala
+++ b/core/src/main/scala/org/scalafmt/internal/ScalaFmtLogger.scala
@@ -30,12 +30,17 @@ trait ScalaFmtLogger {
   private def getTokenClass(token: Token) =
     token.getClass.getName.stripPrefix("scala.meta.tokens.Token$")
 
-  def log(t: Tree): String = {
-    s"""TYPE: ${t.getClass.getName.stripPrefix("scala.meta.")}
-        |SOURCE: $t
-        |STRUCTURE: ${t.show[Structure]}
-        |TOKENS: ${t.tokens.map(x => reveal(x.code)).mkString(",")}
-        |""".stripMargin
+  def log(t: Tree, tokensOnly: Boolean = false): String = {
+    val tokens =
+      s"TOKENS: ${t.tokens.map(x => reveal(x.code)).mkString(",")}"
+    if (tokensOnly)
+      tokens
+    else
+      s"""TYPE: ${t.getClass.getName.stripPrefix("scala.meta.")}
+          |SOURCE: $t
+          |STRUCTURE: ${t.show[Structure]}
+          |$tokens
+          |""".stripMargin
   }
 
   def reveal(s: String): String =

--- a/core/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Split.scala
@@ -17,11 +17,12 @@ import scala.meta.tokens.Token
   *             this split originates.
   *
   */
-case class Split(modification: Modification, cost: Int, ignoreIf: Boolean =
-false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
-                 policy: Policy = NoPolicy, penalty: Boolean =
-                 false,
-                 optimalAt: Option[Token] = None)(implicit val line: sourcecode.Line) {
+case class Split(modification: Modification, cost: Int,
+                 ignoreIf: Boolean = false,
+                 indents: List[Indent[Length]] = List.empty[Indent[Length]],
+                 policy: Policy = NoPolicy,
+                 penalty: Boolean = false)
+                (implicit val line: sourcecode.Line) {
 
   val indentation = indents.map(_.length match {
     case Num(x) => x.toString
@@ -39,16 +40,12 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
         else firstLine
     }
 
-  def withOptimal(token: Token): Split =
-    new Split(modification, cost, ignoreIf, indents, policy, true, Some(token))(
-      line)
-
   def withPolicy(newPolicy: Policy): Split = {
     val update =
       if (policy == NoPolicy) newPolicy
       else throw new UnsupportedOperationException(
         "Can't have two policies yet.")
-    new Split(modification, cost, ignoreIf, indents, update, true, optimalAt)(
+    new Split(modification, cost, ignoreIf, indents, update, true)(
       line)
   }
 
@@ -58,8 +55,7 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
       ignoreIf,
       indents,
       policy,
-      true,
-      optimalAt)(line)
+      true)(line)
 
   def withIndent(length: Length, expire: Token,
                  expiresOn: ExpiresOn): Split = {
@@ -71,8 +67,7 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
           ignoreIf,
           Indent(length, expire, expiresOn) +: indents,
           policy,
-          penalty,
-          optimalAt)(line)
+          penalty)(line)
     }
   }
 
@@ -81,8 +76,4 @@ false, indents: List[Indent[Length]] = List.empty[Indent[Length]],
   override def toString =
     s"""$modification:${line.value}(cost=$cost, indents=$indentation, p=$hasPolicy)"""
 
-  def sameLine(other: Split) =
-    this.line == other.line &&
-      this.cost == other.cost &&
-      this.modification == other.modification
 }

--- a/core/src/main/scala/org/scalafmt/internal/package.scala
+++ b/core/src/main/scala/org/scalafmt/internal/package.scala
@@ -23,7 +23,7 @@ package object internal {
   /**
     * For convenience when experimenting with different hashing strategies.
     */
-  type TokenHash = Int
+  type TokenHash = Long
 
   /**
     * Custom hash code for token.
@@ -40,11 +40,11 @@ package object internal {
     * The only chance for collision is if two empty length tokens with the same
     * type lie next to each other. @xeno-by said this should not happen.
     */
-  def hash(token: Token): TokenHash = {
-    val longHash =
-      (token.privateTag << (62 - 8)) |
-        (token.start << (62 - (8 + 28))) |token.end
-    java.lang.Long.hashCode(longHash)
+  @inline def hash(token: Token): TokenHash = {
+    val longHash: Long =
+      (token.privateTag.toLong << (62 - 8)) |
+        (token.start.toLong << (62 - (8 + 28))) | token.end
+    longHash
   }
 
   @tailrec
@@ -55,3 +55,4 @@ package object internal {
     }
   }
 }
+

--- a/core/src/test/resources/standard/Fidelity.source
+++ b/core/src/test/resources/standard/Fidelity.source
@@ -1,0 +1,3 @@
+80 columns                                                                     |
+<<< premature EOF
+>>>

--- a/core/src/test/scala/org/scalafmt/ManualTests.scala
+++ b/core/src/test/scala/org/scalafmt/ManualTests.scala
@@ -13,7 +13,8 @@ object ManualTests extends HasTests {
       if filename.endsWith(manual)
       test <- {
         val spec = filename.stripPrefix(testDir + "/").stripSuffix(manual)
-        readFile(filename).lines.map { name =>
+        readFile(filename).lines
+          .withFilter(_.startsWith("ONLY")).map { name =>
           val original = readFile(stripPrefix(name))
           DiffTest(spec,
             stripPrefix(name),

--- a/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
+++ b/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
@@ -4,7 +4,11 @@ import scala.meta.parsers.common.ParseException
 
 sealed abstract class ExperimentResult(fileUrl: String) {
   def key: String
-  def details: String = fileUrl
+  // TODO(olafur) abstract over whether raw or non-raw link.
+//  def details: String = fileUrl
+  def details = fileUrl
+    .replace("github.com", "raw.githubusercontent.com")
+    .replace("/blob/", "/")
 }
 object ExperimentResult {
   case class Success(fileUrl: String, nanos: Long) extends ExperimentResult(fileUrl) {
@@ -31,7 +35,7 @@ object ExperimentResult {
 
     def content = s"cols:${e.pos.start.column}-${e.pos.end.column}"
 
-    override def details: String = s"$fileUrl#L${e.pos.start.line + 1} $cols"
+    def urlWithLineHighlighted: String = s"$fileUrl#L${e.pos.start.line + 1} $cols"
 
     def cols = s"cols:${e.pos.start.column}-${e.pos.end.column}"
   }

--- a/core/src/test/scala/org/scalafmt/util/FilesUtil.scala
+++ b/core/src/test/scala/org/scalafmt/util/FilesUtil.scala
@@ -16,9 +16,17 @@ object FilesUtil {
     } yield filename
   }
 
-  def readFile(filename: String): String =
-    new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths
-      .get(filename)))
+  /**
+    * Reads file from file system or from http url.
+    */
+  def readFile(filename: String): String = {
+    if (filename.startsWith("http")) {
+      scala.io.Source.fromURL(filename).mkString
+    } else {
+      new String(java.nio.file.Files.readAllBytes(java.nio.file.Paths
+        .get(filename)))
+    }
+  }
 
   def writeFile(filename: String, content: String): Unit = {
     val path = java.nio.file.Paths.get(filename)

--- a/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
@@ -164,7 +164,7 @@ trait ScalaProjectsExperiment extends ScalaFmtLogger {
         categoryResults.foreach {
           case _: Success | _: Skipped =>
           case e =>
-            println(s"* ${e.details}")
+            println(e.details)
         }
         if (categoryResults.nonEmpty) {
           println()

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,5 +1,5 @@
 object Deps {
-  val scalameta = "0.1.0-SNAPSHOT"
+  val scalameta = "0.0.5-M4"
   val scalatest = "2.2.1"
   val scalariform = "0.1.8"
 }


### PR DESCRIPTION
Instead of memoization we dequeue all states when we enter a new
statement *after* a newline. After spaces, we are likely inside a single
line block which has long-distance effects.

JMH Benchmarks
==============
Benchmark                  Mode  Cnt     Score   Error    Units
BaseLinker.scalafmt        avgt   10    65.884 ± 2.074    ms/op
Division.scalafmt          avgt   10   134.656 ± 3.048    ms/op
SourceMapWriter.scalafmt   avgt   10    31.851 ± 0.989    ms/op
OptimizerCore.scalafmt     avgt   10  1045.331 ± 236.486  ms/op
OptimizerCore.scalariform  avgt   10   230.654 ± 8.470    ms/op

NOTE. OptimizerCore was unformattable before.

Scala.js results
================
Formatter timed out: 10
org.scalafmt.Error$FormatterChangedAST: 1
java.lang.ClassCastException: 11
Success: 891
org.scalafmt.Error$CantFormatFile: 7
Total: 920
+------------+--------+--------------+---------+---------+---------+----------+
|         Max|     Min|           Sum|     Mean|       Q1|       Q2|        Q3|
+------------+--------+--------------+---------+---------+---------+----------+
|9.958,026 ms|1,782 ms|328.591,625 ms|368,79 ms|31,157 ms|82,589 ms|241,443 ms|
+------------+--------+--------------+---------+---------+---------+----------+

Othe non-signifant changes:
* Manual tests support urls to urls instead of local files
* Removed optimal at optimization
* Removed members from Split and State classes.
* Upgrade scalameta