### PR TITLE
Up to ~30% performance improvements.

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -48,17 +48,18 @@ class Router(style: ScalaStyle,
    *
    */
   val packageTokens: Set[Token] = {
-    val result = mutable.Set.empty[Token]
+    val result = new mutable.SetBuilder[Token, Set[Token]](Set.empty[Token])
     tree.collect {
       case p: Pkg =>
         result ++= p.ref.tokens
     }
-    result.toSet
+    result.result()
   }
 
   private val leftTok2tok: Map[Token, FormatToken] =
     tokens.map(t => t.left -> t).toMap
   private val tok2idx: Map[FormatToken, Int] = tokens.zipWithIndex.toMap
+  // TODO(olafur) replace cache with array of list[split]
   private val cache = mutable.Map.empty[FormatToken, Seq[Split]]
 
   def getSplits(formatToken: FormatToken): Seq[Split] = {
@@ -680,7 +681,7 @@ class Router(style: ScalaStyle,
 
   def insideBlock(start: FormatToken, end: Token): Set[Range] = {
     var inside = false
-    val result = mutable.Set.empty[Range]
+    val result = new mutable.SetBuilder[Range, Set[Range]](Set.empty[Range])
     var curr = start
     while (curr.left != end) {
       if (curr.left.isInstanceOf[`{`]) {
@@ -692,7 +693,7 @@ class Router(style: ScalaStyle,
         curr = next(curr)
       }
     }
-    result.toSet
+    result.result()
   }
 
   def next(tok: FormatToken): FormatToken = {

--- a/core/src/main/scala/org/scalafmt/internal/State.scala
+++ b/core/src/main/scala/org/scalafmt/internal/State.scala
@@ -15,11 +15,18 @@ final case class State(cost: Int,
                        column: Int
                       ) extends Ordered[State] with ScalaFmtLogger {
 
-  import scala.math.Ordered.orderingToOrdered
 
-  def compare(that: State): Int =
-    (-this.cost, this.splits.length, -this.indentation) compare(-that.cost,
-      that.splits.length, -that.indentation)
+  def compare(that: State): Int = {
+    val costCompare = Integer.compare(-this.cost, -that.cost)
+    if (costCompare != 0) costCompare
+    else {
+      val splitsCompare = Integer.compare(
+        this.splits.length,
+        that.splits.length)
+      if (splitsCompare != 0) splitsCompare
+      else Integer.compare(-this.indentation, -that.indentation)
+    }
+  }
 
   /**
     * Returns True is this state will always return better formatting than other.


### PR DESCRIPTION
* no optimizations zones is now Set[Token] instead of Set[Range]
* Replaced mutable.{Set,Map} with their respective builders.
* changed State.compare from tuple comparison to if/else tree of
  Integer.compare.

```
JMH
===
Benchmark                    Mode  Cnt     Score    Error  Units
BaseLinker.scalafmt          avgt   10    72.014 ±  2.236  ms/op
BaseLinker.scalariform       avgt   10    13.491 ±  0.468  ms/op
Division.scalafmt            avgt   10   127.424 ±  4.343  ms/op
Division.scalariform         avgt   10    36.947 ±  5.346  ms/op
OptimizerCore.scalafmt       avgt   10   968.754 ± 53.008  ms/op
OptimizerCore.scalariform    avgt   10   253.146 ± 84.824  ms/op
SourceMapWriter.scalariform  avgt   10     7.059 ±  0.168  ms/op

Observe that ~400ms were shaved off OptimizerCore compared to last commit.

Scala.js
========
Timed out: 23
Success: 897
Total: 920
+-------------+--------+--------------+----------+---------+---------+----------+
|          Max|     Min|           Sum|      Mean|       Q1|       Q2|        Q3|
+-------------+--------+--------------+----------+---------+---------+----------+
|10.007,766 ms|1,781 ms|359.649,734 ms|400,947 ms|31,752 ms|85,599 ms|225,574 ms|
+-------------+--------+--------------+----------+---------+---------+----------+
```

Thank you @rorygraves for the suggestions!