### PR TITLE
git sVarious optimizations, 4 files to go Scala.js.

### DIFF
--- a/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -81,13 +81,17 @@ object run {
     extends FormatBenchmark("scala-js", filename)
 
 
-  class Division extends ScalaJsBenchmark("Division.scala")
-
-  class SourceMapWriter extends ScalaJsBenchmark("SourceMapWriter.scala")
-
-  class BaseLinker extends ScalaJsBenchmark("BaseLinker.scala")
+//  class Division extends ScalaJsBenchmark("Division.scala")
+//
+//  class SourceMapWriter extends ScalaJsBenchmark("SourceMapWriter.scala")
+//
+//  class BaseLinker extends ScalaJsBenchmark("BaseLinker.scala")
 
   class OptimizerCore extends ScalaJsBenchmark("OptimizerCore.scala")
+
+  class GenJsCode extends ScalaJsBenchmark("GenJsCode.scala")
+
+  class ScalaJSClassEmitter extends ScalaJsBenchmark("ScalaJSClassEmitter.scala")
 
   // These files are too small to be interesting.
   //  class Basic extends FormatBenchmark("scalafmt", "Basic.scala")
@@ -99,7 +103,6 @@ object run {
   //  class TypeKinds extends ScalaJsBenchmark("TypeKinds.scala")
   //  class Analyzer extends ScalaJsBenchmark("Analyzer.scala")
   //  class Trees extends ScalaJsBenchmark("Trees.scala")
-  //  class GenJsCode extends ScalaJsBenchmark("GenJsCode.scala")
   //  class CopyOnWriteArrayList extends ScalaJsBenchmark("CopyOnWriteArrayList.scala")
 }
 

--- a/benchmarks/src/resources/scala-js/Primality.scala
+++ b/benchmarks/src/resources/scala-js/Primality.scala
@@ -1,0 +1,284 @@
+/*
+ * Ported by Alistair Johnson from
+ * https://github.com/gwtproject/gwt/blob/master/user/super/com/google/gwt/emul/java/math/Primality.java
+ * Original license copied below:
+ */
+
+/*
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * INCLUDES MODIFICATIONS BY RICHARD ZSCHECH AS WELL AS GOOGLE.
+ */
+package java.math
+
+import java.util.Arrays
+import java.util.Random
+
+/** Provides primality probabilistic methods. */
+private[math] object Primality {
+  private val Bits = Array(
+      0, 0, 1854, 1233, 927, 747, 627, 543, 480, 431, 393, 361, 335, 314, 295,
+      279, 265, 253, 242, 232, 223, 216, 181, 169, 158, 150, 145, 140, 136,
+      132, 127, 123, 119, 114, 110, 105, 101, 96, 92, 87, 83, 78, 73, 69, 64,
+      59, 54, 49, 44, 38, 32, 26, 1)
+
+  /** All prime numbers with bit length lesser than 10 bits. */
+  private val Primes = Array[Int](2, 3, 5, 7, 11, 13, 17, 19, 23, 29,
+      31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
+      103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167,
+      173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239,
+      241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313,
+      317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397,
+      401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467,
+      479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569,
+      571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643,
+      647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733,
+      739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823,
+      827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911,
+      919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997, 1009,
+      1013, 1019, 1021)
+
+  /** Encodes how many i-bit primes there are in the table for {@code i=2,...,10}.
+   *
+   *  For example {@code offsetPrimes[6]} says that from index
+   *  {@code 11} exists {@code 7} consecutive {@code 6}-bit prime numbers in the
+   *  array.
+   */
+  private val OffsetPrimes = Array(
+      null, null, (0, 2), (2, 2), (4, 2), (6, 5), (11, 7),
+      (18, 13), (31, 23), (54, 43), (97, 75))
+
+  /** All {@code BigInteger} prime numbers with bit length lesser than 8 bits. */
+  private val BiPrimes =
+    Array.tabulate[BigInteger](Primes.length)(i => BigInteger.valueOf(Primes(i)))
+
+  /** A random number is generated until a probable prime number is found.
+   *
+   *  @see BigInteger#BigInteger(int,int,Random)
+   *  @see BigInteger#probablePrime(int,Random)
+   *  @see #isProbablePrime(BigInteger, int)
+   */
+  def consBigInteger(bitLength: Int, certainty: Int, rnd: Random): BigInteger = {
+    // PRE: bitLength >= 2
+    // For small numbers get a random prime from the prime table
+    if (bitLength <= 10) {
+      val rp = OffsetPrimes(bitLength)
+      BiPrimes(rp._1 + rnd.nextInt(rp._2))
+    } else {
+      val shiftCount = (-bitLength) & 31
+      val count = (bitLength + 31) >> 5
+      val n = new BigInteger(1, count, new Array[Int](count))
+
+      val last = count - 1
+      do {
+        // To fill the array with random integers
+        for (i <- 0 until n.numberLength) {
+          n.digits(i) = rnd.nextInt()
+        }
+        // To fix to the correct bitLength
+        n.digits(last) = (n.digits(last) | 0x80000000) >>> shiftCount
+        // To create an odd number
+        n.digits(0) |= 1
+      } while (!isProbablePrime(n, certainty))
+      n
+    }
+  }
+
+  /** Returns true if this is a prime, within the provided certainty.
+   *
+   *  @see BigInteger#isProbablePrime(int)
+   *  @see #millerRabin(BigInteger, int)
+   *  @ar.org.fitc.ref Optimizations: "A. Menezes - Handbook of applied
+   *                   Cryptography, Chapter 4".
+   */
+  def isProbablePrime(n: BigInteger, certainty: Int): Boolean = {
+    // scalastyle:off return
+    // PRE: n >= 0
+    if (certainty <= 0 || (n.numberLength == 1 && n.digits(0) == 2)) {
+      true
+    } else if (!n.testBit(0)) {
+      // To discard all even numbers
+      false
+    } else if (n.numberLength == 1 && (n.digits(0) & 0XFFFFFC00) == 0) {
+      // To check if 'n' exists in the table (it fit in 10 bits)
+      Arrays.binarySearch(Primes, n.digits(0)) >= 0
+    } else {
+      // To check if 'n' is divisible by some prime of the table
+      for (i <- 1 until Primes.length) {
+        if (Division.remainderArrayByInt(n.digits, n.numberLength, Primes(i)) == 0)
+          return false
+      }
+
+      // To set the number of iterations necessary for Miller-Rabin test
+      var i: Int = 0
+      val bitLength = n.bitLength()
+      i = 2
+      while (bitLength < Bits(i)) {
+        i += 1
+      }
+      val newCertainty = Math.min(i, 1 + ((certainty - 1) >> 1))
+      millerRabin(n, newCertainty)
+    }
+    // scalastyle:on return
+  }
+
+  /** Returns the next, probable prime number.
+   *
+   *  It uses the sieve of Eratosthenes to discard several composite numbers in
+   *  some appropriate range (at the moment {@code [this, this + 1024]}). After
+   *  this process it applies the Miller-Rabin test to the numbers that were not
+   *  discarded in the sieve.
+   *
+   *  @see BigInteger#nextProbablePrime()
+   *  @see #millerRabin(BigInteger, int)
+   */
+  def nextProbablePrime(n: BigInteger): BigInteger = {
+    // scalastyle:off return
+    // PRE: n >= 0
+    val gapSize = 1024 // for searching of the next probable prime number
+    val modules = new Array[Int](Primes.length)
+    val isDivisible = new Array[Boolean](gapSize)
+
+    // If n < "last prime of table" searches next prime in the table
+    val digitsLessPrime = (n.digits(0) < Primes(Primes.length - 1))
+    if ((n.numberLength == 1) && (n.digits(0) >= 0) && digitsLessPrime) {
+      var i = 0
+      while (n.digits(0) >= Primes(i)) {
+        i += 1
+      }
+      return BiPrimes(i)
+    }
+
+    /*
+     * Creates a "N" enough big to hold the next probable prime Note that: N <
+     * "next prime" < 2*N
+     */
+    val a = new Array[Int](n.numberLength + 1)
+    val startPoint: BigInteger = new BigInteger(1, n.numberLength, a)
+    System.arraycopy(n.digits, 0, startPoint.digits, 0, n.numberLength)
+
+    // To fix N to the "next odd number"
+    if (n.testBit(0)) Elementary.inplaceAdd(startPoint, 2)
+    else startPoint.digits(0) |= 1
+
+    // To set the improved certainty of Miller-Rabin
+    var certainty = 2
+    for (j <- startPoint.bitLength() until Bits(certainty)) {
+      certainty += 1
+    }
+
+    // To calculate modules: N mod p1, N mod p2, ... for first primes.
+    for (i <- 0 until Primes.length) {
+      modules(i) = Division.remainder(startPoint, Primes(i)) - gapSize
+    }
+
+    val probPrime: BigInteger = startPoint.copy()
+    while (true) {
+      // At this point, all numbers in the gap are initialized as probably primes
+      Arrays.fill(isDivisible, false)
+      // To discard multiples of first primes
+      for (i <-0 until Primes.length) {
+        modules(i) = (modules(i) + gapSize) % Primes(i)
+        var j =
+          if (modules(i) == 0) 0
+          else (Primes(i) - modules(i))
+        while (j < gapSize) {
+          isDivisible(j) = true
+          j += Primes(i)
+        }
+      }
+      // To execute Miller-Rabin for non-divisible numbers by all first primes
+      for (j <- 0 until gapSize) {
+        if (!isDivisible(j)) {
+          Elementary.inplaceAdd(probPrime, j)
+          if (millerRabin(probPrime, certainty)) {
+            return probPrime
+          }
+        }
+      }
+      Elementary.inplaceAdd(startPoint, gapSize)
+    }
+    throw new AssertionError("Primality.nextProbablePrime: Should not get here")
+    // scalastyle:on return
+  }
+
+  /** The Miller-Rabin primality test.
+   *
+   *  @param n the input number to be tested.
+   *  @param t the number of trials.
+   *  @return {@code false} if the number is definitely compose, otherwise
+   *          {@code true} with probability {@code 1 - 4<sup>(-t)</sup>}.
+   *  @ar.org.fitc.ref "D. Knuth, The Art of Computer Programming Vo.2, Section
+   *                   4.5.4., Algorithm P"
+   */
+  private def millerRabin(n: BigInteger, t: Int): Boolean = {
+    // scalastyle:off return
+    // PRE: n >= 0, t >= 0
+    var x: BigInteger = null
+    var y: BigInteger = null
+    val nMinus1 = n.subtract(BigInteger.ONE)
+    val bitLength = nMinus1.bitLength()
+    val k = nMinus1.getLowestSetBit
+    val q = nMinus1.shiftRight(k)
+    val rnd = new Random()
+    for (i <- 0 until t) {
+      // To generate a witness 'x', first it use the primes of table
+      if (i < Primes.length) {
+        x = BiPrimes(i)
+      } else {
+        /*
+         * It generates random witness only if it's necesssary. Note that all
+         * methods would call Miller-Rabin with t <= 50 so this part is only to
+         * do more robust the algorithm
+         */
+        do {
+          x = new BigInteger(bitLength, rnd)
+        } while ((x.compareTo(n) >= BigInteger.EQUALS) || x.sign == 0 || x.isOne)
+      }
+
+      y = x.modPow(q, n)
+      if (!(y.isOne || y == nMinus1)) {
+        for (j <- 1 until k) {
+          if (y != nMinus1) {
+            y = y.multiply(y).mod(n)
+            if (y.isOne)
+              return false
+          }
+        }
+        if (y != nMinus1)
+          return false
+      }
+    }
+    true
+    // scalastyle:on return
+  }
+}

--- a/benchmarks/src/resources/scala-js/ScalaJSClassEmitter.scala
+++ b/benchmarks/src/resources/scala-js/ScalaJSClassEmitter.scala
@@ -1,0 +1,944 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package org.scalajs.core.tools.linker.backend.emitter
+
+import org.scalajs.core.ir._
+import Position._
+import Transformers._
+import org.scalajs.core.ir.Trees._
+import Types._
+
+import org.scalajs.core.tools.sem._
+import CheckedBehavior.Unchecked
+
+import org.scalajs.core.tools.javascript.{Trees => js}
+import org.scalajs.core.tools.linker.backend.OutputMode
+import org.scalajs.core.tools.linker.{LinkedClass, LinkingUnit}
+
+/** Defines methods to emit Scala.js classes to JavaScript code.
+ *  The results are completely desugared.
+ *
+ *  The only reason this is not `private[emitter]` is because `RhinoJSEnv`
+ *  needs it.
+ */
+private[scalajs] final class ScalaJSClassEmitter(
+    private[emitter] val outputMode: OutputMode,
+    internalOptions: InternalOptions,
+    linkingUnit: LinkingUnit) {
+
+  private val jsDesugaring = new JSDesugaring(internalOptions)
+
+  import ScalaJSClassEmitter._
+  import jsDesugaring._
+
+  def this(outputMode: OutputMode, linkingUnit: LinkingUnit) =
+    this(outputMode, InternalOptions(), linkingUnit)
+
+  private[emitter] lazy val linkedClassByName: Map[String, LinkedClass] =
+    linkingUnit.classDefs.map(c => c.encodedName -> c).toMap
+
+  private[emitter] def isInterface(className: String): Boolean = {
+    /* TODO In theory, there is a flaw in the incremental behavior about this.
+     *
+     * This method is used to desugar ApplyStatically nodes. Depending on
+     * whether className is a class or an interface, the desugaring changes.
+     * This means that the result of desugaring an ApplyStatically depends on
+     * some global knowledge from the whole program (and not only of the method
+     * being desugared). If, from one run to the next, className switches from
+     * being a class to an interface or vice versa, there is nothing demanding
+     * that the IR of the call site change, yet the desugaring should change.
+     * In theory, this causes a flaw in the incremental behavior of the
+     * Emitter, which will not invalidate its cache for this.
+     *
+     * In practice, this should not happen, though. A method can only be called
+     * statically by subclasses and subtraits at the Scala *language* level.
+     * We also know that when a class/trait changes, all its subclasses and
+     * subtraits are recompiled by sbt's incremental compilation. This should
+     * mean that the input IR is always changed in that case anyway.
+     *
+     * It would be good to fix thoroughly if the Emitter/ScalaJSClassEmitter
+     * gets something for incremental whole-program updates, but for now, we
+     * live with the theoretical flaw.
+     */
+    linkedClassByName(className).kind == ClassKind.Interface
+  }
+
+  private[emitter] def semantics: Semantics = linkingUnit.semantics
+
+  private implicit def implicitOutputMode: OutputMode = outputMode
+
+  def genDeclareTypeData(tree: LinkedClass): js.Tree = {
+    implicit val pos = tree.pos
+    envFieldDef("d", tree.encodedName, js.Null(), mutable = true)
+  }
+
+  def genDeclareModule(tree: LinkedClass): js.Tree = {
+    implicit val pos = tree.pos
+    if (tree.kind.hasModuleAccessor)
+      envFieldDef("n", tree.encodedName, js.Undefined(), mutable = true)
+    else
+      js.Skip()
+  }
+
+  /** Desugar a Scala.js class into ECMAScript 5 constructs
+   *
+   *  @param tree The IR tree to emit to raw JavaScript
+   *  @param ancestors Encoded names of the ancestors of the class (not only
+   *                   parents), including the class itself.
+   */
+  def genClassDef(tree: LinkedClass): js.Tree = {
+    implicit val pos = tree.pos
+    val kind = tree.kind
+
+    var reverseParts: List[js.Tree] = Nil
+
+    reverseParts ::= genStaticMembers(tree)
+    if (kind == ClassKind.Interface)
+      reverseParts ::= genDefaultMethods(tree)
+    if (kind.isAnyScalaJSDefinedClass && tree.hasInstances)
+      reverseParts ::= genClass(tree)
+    if (needInstanceTests(tree)) {
+      reverseParts ::= genInstanceTests(tree)
+      reverseParts ::= genArrayInstanceTests(tree)
+    }
+    if (tree.hasRuntimeTypeInfo)
+      reverseParts ::= genTypeData(tree)
+    if (kind.isClass && tree.hasInstances && tree.hasRuntimeTypeInfo)
+      reverseParts ::= genSetTypeData(tree)
+    if (kind.hasModuleAccessor)
+      reverseParts ::= genModuleAccessor(tree)
+    reverseParts ::= genClassExports(tree)
+
+    js.Block(reverseParts.reverse)
+  }
+
+  def genStaticMembers(tree: LinkedClass): js.Tree = {
+    val className = tree.name.name
+    val staticMemberDefs =
+      tree.staticMethods.map(m => genMethod(className, m.tree))
+    js.Block(staticMemberDefs)(tree.pos)
+  }
+
+  def genDefaultMethods(tree: LinkedClass): js.Tree = {
+    val className = tree.name.name
+    val defaultMethodDefs =
+      tree.memberMethods.map(m => genDefaultMethod(className, m.tree))
+    js.Block(defaultMethodDefs)(tree.pos)
+  }
+
+  def genClass(tree: LinkedClass): js.Tree = {
+    val className = tree.name.name
+    val typeFunctionDef = genConstructor(tree)
+    val memberDefs =
+      tree.memberMethods.map(m => genMethod(className, m.tree))
+
+    val exportedDefs = genExportedMembers(tree)
+
+    val allDefsBlock =
+      js.Block(typeFunctionDef +: memberDefs :+ exportedDefs)(tree.pos)
+
+    outputMode match {
+      case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
+        allDefsBlock
+
+      case OutputMode.ECMAScript6 =>
+        val allDefs = allDefsBlock match {
+          case js.Block(allDefs) => allDefs
+          case js.Skip()         => Nil
+          case oneDef            => List(oneDef)
+        }
+        genES6Class(tree, allDefs)
+    }
+  }
+
+  /** Generates an ECMAScript 6 class for a linked class. */
+  def genES6Class(tree: LinkedClass, members: List[js.Tree]): js.Tree = {
+    require(outputMode == OutputMode.ECMAScript6)
+
+    val className = tree.name.name
+    val classIdent = encodeClassVar(className)(
+        outputMode, tree.name.pos).asInstanceOf[js.VarRef].ident
+
+    val parentVar = for (parentIdent <- tree.superClass) yield {
+      implicit val pos = parentIdent.pos
+      if (!tree.kind.isJSClass)
+        encodeClassVar(parentIdent.name)
+      else
+        genRawJSClassConstructor(linkedClassByName(parentIdent.name))
+    }
+
+    js.ClassDef(Some(classIdent), parentVar, members)(tree.pos)
+  }
+
+  /** Generates the JS constructor for a class. */
+  def genConstructor(tree: LinkedClass): js.Tree = {
+    assert(tree.kind.isAnyScalaJSDefinedClass)
+    assert(tree.superClass.isDefined || tree.name.name == Definitions.ObjectClass,
+        s"Class ${tree.name.name} is missing a parent class")
+
+    outputMode match {
+      case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
+        genES5Constructor(tree)
+
+      case OutputMode.ECMAScript6 =>
+        genES6Constructor(tree)
+    }
+  }
+
+  /** Generates the JS constructor for a class, ES5 style. */
+  private def genES5Constructor(tree: LinkedClass): js.Tree = {
+    implicit val pos = tree.pos
+
+    val className = tree.name.name
+    val isJSClass = tree.kind.isJSClass
+
+    def makeInheritableCtorDef(ctorToMimic: js.Tree) = {
+      js.Block(
+        js.DocComment("@constructor"),
+        envFieldDef("h", className, js.Function(Nil, js.Skip())),
+        js.Assign(envField("h", className).prototype, ctorToMimic.prototype)
+      )
+    }
+
+    val ctorFun = if (!isJSClass) {
+      val superCtorCall = tree.superClass.fold[js.Tree] {
+        js.Skip()
+      } { parentIdent =>
+        js.Apply(
+            js.DotSelect(encodeClassVar(parentIdent.name), js.Ident("call")),
+            List(js.This()))
+      }
+      val fieldDefs = genFieldDefs(tree)
+      js.Function(Nil, js.Block(superCtorCall :: fieldDefs))
+    } else {
+      genConstructorFunForJSClass(tree)
+    }
+
+    val typeVar = encodeClassVar(className)
+    val docComment = js.DocComment("@constructor")
+    val ctorDef = envFieldDef("c", className, ctorFun)
+
+    val chainProto = tree.superClass.fold[js.Tree] {
+      js.Skip()
+    } { parentIdent =>
+      val (inheritedCtorDef, inheritedCtorRef) = if (!isJSClass) {
+        (js.Skip(), envField("h", parentIdent.name))
+      } else {
+        val superCtor = genRawJSClassConstructor(
+            linkedClassByName(parentIdent.name))
+        (makeInheritableCtorDef(superCtor), envField("h", className))
+      }
+      js.Block(
+          inheritedCtorDef,
+          js.Assign(typeVar.prototype, js.New(inheritedCtorRef, Nil)),
+          genAddToPrototype(className, js.StringLiteral("constructor"), typeVar)
+      )
+    }
+
+    val inheritableCtorDef =
+      if (isJSClass) js.Skip()
+      else makeInheritableCtorDef(typeVar)
+
+    js.Block(docComment, ctorDef, chainProto, inheritableCtorDef)
+  }
+
+  /** Generates the JS constructor for a class, ES6 style. */
+  private def genES6Constructor(tree: LinkedClass): js.Tree = {
+    implicit val pos = tree.pos
+
+    if (tree.kind.isJSClass) {
+      val js.Function(params, body) = genConstructorFunForJSClass(tree)
+      js.MethodDef(static = false, js.Ident("constructor"), params, body)
+    } else {
+      val fieldDefs = genFieldDefs(tree)
+      if (fieldDefs.isEmpty && outputMode == OutputMode.ECMAScript6) {
+        js.Skip()
+      } else {
+        val superCtorCall = tree.superClass.fold[js.Tree] {
+          js.Skip()(tree.pos)
+        } { parentIdent =>
+          js.Apply(js.Super(), Nil)
+        }
+        js.MethodDef(static = false, js.Ident("constructor"), Nil,
+            js.Block(superCtorCall :: fieldDefs))
+      }
+    }
+  }
+
+  private def genConstructorFunForJSClass(tree: LinkedClass): js.Function = {
+    implicit val pos = tree.pos
+
+    require(tree.kind.isJSClass)
+
+    tree.exportedMembers.map(_.tree) collectFirst {
+      case MethodDef(false, StringLiteral("constructor"), params, _, body) =>
+        desugarToFunction(this, tree.encodedName,
+            params, body, isStat = true)
+    } getOrElse {
+      throw new IllegalArgumentException(
+          s"${tree.encodedName} does not have an exported constructor")
+    }
+  }
+
+  /** Generates the creation of fields for a class. */
+  private def genFieldDefs(tree: LinkedClass): List[js.Tree] = {
+    val tpe = ClassType(tree.encodedName)
+    for {
+      field @ FieldDef(name, ftpe, mutable) <- tree.fields
+    } yield {
+      implicit val pos = field.pos
+      val selectField = (name: @unchecked) match {
+        case name: Ident => Select(This()(tpe), name)(ftpe)
+      }
+      desugarTree(this, tree.encodedName,
+          Assign(selectField, zeroOf(ftpe)), isStat = true)
+    }
+  }
+
+  /** Generates a method. */
+  def genMethod(className: String, method: MethodDef): js.Tree = {
+    implicit val pos = method.pos
+
+    val methodFun0 = desugarToFunction(this, className,
+        method.args, method.body, method.resultType == NoType)
+
+    val methodFun = if (Definitions.isConstructorName(method.name.name)) {
+      // init methods have to return `this` so that we can chain them to `new`
+      js.Function(methodFun0.args, {
+        implicit val pos = methodFun0.body.pos
+        js.Block(
+            methodFun0.body,
+            js.Return(js.This()))
+      })(methodFun0.pos)
+    } else {
+      methodFun0
+    }
+
+    if (method.static) {
+      val Ident(methodName, origName) = method.name
+      envFieldDef(
+          "s", className + "__" + methodName, origName,
+          methodFun)
+    } else {
+      outputMode match {
+        case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
+          genAddToPrototype(className, method.name, methodFun)
+
+        case OutputMode.ECMAScript6 =>
+          js.MethodDef(static = false, genPropertyName(method.name),
+              methodFun.args, methodFun.body)
+      }
+    }
+  }
+
+  /** Generates a default method. */
+  def genDefaultMethod(className: String, method: MethodDef): js.Tree = {
+    implicit val pos = method.pos
+
+    /* TODO The identifier `$thiz` cannot be produced by 0.6.x compilers due to
+     * their name mangling, which guarantees that it is unique. We should find
+     * a better way to do this in the future, though.
+     */
+    val thisIdent = js.Ident("$thiz", Some("this"))
+
+    val methodFun0 = desugarToFunction(this, className, Some(thisIdent),
+        method.args, method.body, method.resultType == NoType)
+
+    val methodFun = js.Function(
+        js.ParamDef(thisIdent, rest = false) :: methodFun0.args,
+        methodFun0.body)(methodFun0.pos)
+
+    val Ident(methodName, origName) = method.name
+
+    envFieldDef(
+        "f", className + "__" + methodName, origName,
+        methodFun)
+  }
+
+  /** Generates a property. */
+  def genProperty(className: String, property: PropertyDef): js.Tree = {
+    outputMode match {
+      case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
+        genPropertyES5(className, property)
+      case OutputMode.ECMAScript6 =>
+        genPropertyES6(className, property)
+    }
+  }
+
+  private def genPropertyES5(className: String,
+      property: PropertyDef): js.Tree = {
+    implicit val pos = property.pos
+
+    // defineProperty method
+    val defProp =
+      genIdentBracketSelect(js.VarRef(js.Ident("Object")), "defineProperty")
+
+    // class prototype
+    val proto = encodeClassVar(className).prototype
+
+    // property name
+    val name = property.name match {
+      case StringLiteral(value) =>
+        js.StringLiteral(value)
+      case id: Ident =>
+        // We need to work around the closure compiler. Call propertyName to
+        // get a string representation of the optimized name
+        genCallHelper("propertyName",
+            js.ObjectConstr(transformIdent(id) -> js.IntLiteral(0) :: Nil))
+    }
+
+    // Options passed to the defineProperty method
+    val descriptor = js.ObjectConstr {
+      // Basic config
+      val base =
+        js.StringLiteral("enumerable") -> js.BooleanLiteral(true) :: Nil
+
+      // Optionally add getter
+      val wget = {
+        if (property.getterBody == EmptyTree) base
+        else {
+          val fun = desugarToFunction(this, className,
+              Nil, property.getterBody, isStat = false)
+          js.StringLiteral("get") -> fun :: base
+        }
+      }
+
+      // Optionally add setter
+      if (property.setterBody == EmptyTree) wget
+      else {
+        val fun = desugarToFunction(this, className,
+            property.setterArg :: Nil, property.setterBody, isStat = true)
+        js.StringLiteral("set") -> fun :: wget
+      }
+    }
+
+    js.Apply(defProp, proto :: name :: descriptor :: Nil)
+  }
+
+  private def genPropertyES6(className: String,
+      property: PropertyDef): js.Tree = {
+    implicit val pos = property.pos
+
+    val propName = genPropertyName(property.name)
+
+    val getter = {
+      if (property.getterBody == EmptyTree) js.Skip()
+      else {
+        val fun = desugarToFunction(this, className,
+            Nil, property.getterBody, isStat = false)
+        js.GetterDef(static = false, propName, fun.body)
+      }
+    }
+
+    val setter = {
+      if (property.setterBody == EmptyTree) js.Skip()
+      else {
+        val fun = desugarToFunction(this, className,
+            property.setterArg :: Nil, property.setterBody, isStat = true)
+        js.SetterDef(static = false, propName, fun.args.head, fun.body)
+      }
+    }
+
+    js.Block(getter, setter)
+  }
+
+  /** Generate `classVar.prototype.name = value` */
+  def genAddToPrototype(className: String, name: js.PropertyName,
+      value: js.Tree)(implicit pos: Position): js.Tree = {
+    val proto = encodeClassVar(className).prototype
+    val select = name match {
+      case name: js.Ident         => js.DotSelect(proto, name)
+      case name: js.StringLiteral => genBracketSelect(proto, name)
+    }
+    js.Assign(select, value)
+  }
+
+  /** Generate `classVar.prototype.name = value` */
+  def genAddToPrototype(className: String, name: PropertyName,
+      value: js.Tree)(implicit pos: Position): js.Tree = {
+    genAddToPrototype(className, genPropertyName(name), value)
+  }
+
+  def genPropertyName(name: PropertyName): js.PropertyName = name match {
+    case ident: Ident         => transformIdent(ident)
+    case StringLiteral(value) => js.StringLiteral(value)(name.pos)
+  }
+
+  private[tools] def needInstanceTests(tree: LinkedClass): Boolean = {
+    tree.hasInstanceTests || {
+      tree.hasRuntimeTypeInfo &&
+      ClassesWhoseDataReferToTheirInstanceTests.contains(tree.encodedName)
+    }
+  }
+
+  def genInstanceTests(tree: LinkedClass): js.Tree = {
+    import Definitions._
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    if (tree.kind.isClass || tree.kind == ClassKind.Interface ||
+        tree.name.name == Definitions.StringClass) {
+      val className = tree.name.name
+      val displayName = decodeClassName(className)
+
+      val isAncestorOfString =
+        AncestorsOfStringClass.contains(className)
+      val isAncestorOfHijackedNumberClass =
+        AncestorsOfHijackedNumberClasses.contains(className)
+      val isAncestorOfBoxedBooleanClass =
+        AncestorsOfBoxedBooleanClass.contains(className)
+
+      val objParam = js.ParamDef(Ident("obj"), rest = false)
+      val obj = objParam.ref
+
+      val createIsStat = {
+        envFieldDef("is", className,
+          js.Function(List(objParam), js.Return(className match {
+            case Definitions.ObjectClass =>
+              js.BinaryOp(JSBinaryOp.!==, obj, js.Null())
+
+            case Definitions.StringClass =>
+              js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("string")
+
+            case Definitions.RuntimeNothingClass =>
+              // Even null is not an instance of Nothing
+              js.BooleanLiteral(false)
+
+            case _ =>
+              var test = {
+                genIsScalaJSObject(obj) &&
+                genIsClassNameInAncestors(className,
+                    obj DOT "$classData" DOT "ancestors")
+              }
+
+              if (isAncestorOfString)
+                test = test || (
+                    js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("string"))
+              if (isAncestorOfHijackedNumberClass)
+                test = test || (
+                    js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("number"))
+              if (isAncestorOfBoxedBooleanClass)
+                test = test || (
+                    js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("boolean"))
+
+              !(!test)
+          })))
+      }
+
+      val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
+        js.Skip()
+      } else {
+        envFieldDef("as", className,
+          js.Function(List(objParam), js.Return(className match {
+            case Definitions.ObjectClass =>
+              obj
+
+            case _ =>
+              val throwError = {
+                genCallHelper("throwClassCastException",
+                    obj, js.StringLiteral(displayName))
+              }
+              if (className == RuntimeNothingClass) {
+                // Always throw for .asInstanceOf[Nothing], even for null
+                throwError
+              } else {
+                js.If(js.Apply(envField("is", className), List(obj)) ||
+                    (obj === js.Null()), {
+                  obj
+                }, {
+                  throwError
+                })
+              }
+        })))
+      }
+
+      js.Block(createIsStat, createAsStat)
+    } else {
+      js.Skip()
+    }
+  }
+
+  def genArrayInstanceTests(tree: LinkedClass): js.Tree = {
+    import Definitions._
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    val className = tree.name.name
+    val displayName = decodeClassName(className)
+
+    val objParam = js.ParamDef(Ident("obj"), rest = false)
+    val obj = objParam.ref
+
+    val depthParam = js.ParamDef(Ident("depth"), rest = false)
+    val depth = depthParam.ref
+
+    val createIsArrayOfStat = {
+      envFieldDef("isArrayOf", className,
+        js.Function(List(objParam, depthParam), className match {
+          case Definitions.ObjectClass =>
+            val dataVarDef = genLet(Ident("data"), mutable = false, {
+              obj && (obj DOT "$classData")
+            })
+            val data = dataVarDef.ref
+            js.Block(
+              dataVarDef,
+              js.If(!data, {
+                js.Return(js.BooleanLiteral(false))
+              }, {
+                val arrayDepthVarDef = genLet(Ident("arrayDepth"), mutable = false, {
+                  (data DOT "arrayDepth") || js.IntLiteral(0)
+                })
+                val arrayDepth = arrayDepthVarDef.ref
+                js.Block(
+                  arrayDepthVarDef,
+                  js.Return {
+                    // Array[A] </: Array[Array[A]]
+                    !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) && (
+                      // Array[Array[A]] <: Array[Object]
+                      js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+                      // Array[Int] </: Array[Object]
+                      !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive")
+                    )
+                  })
+              }))
+
+          case _ =>
+            js.Return(!(!({
+              genIsScalaJSObject(obj) &&
+              ((obj DOT "$classData" DOT "arrayDepth") === depth) &&
+              genIsClassNameInAncestors(className,
+                  obj DOT "$classData" DOT "arrayBase" DOT "ancestors")
+            })))
+        }))
+    }
+
+    val createAsArrayOfStat = if (semantics.asInstanceOfs == Unchecked) {
+      js.Skip()
+    } else {
+      envFieldDef("asArrayOf", className,
+        js.Function(List(objParam, depthParam), js.Return {
+          js.If(js.Apply(envField("isArrayOf", className), List(obj, depth)) ||
+              (obj === js.Null()), {
+            obj
+          }, {
+            genCallHelper("throwArrayCastException",
+                obj, js.StringLiteral("L"+displayName+";"), depth)
+          })
+        }))
+    }
+
+    js.Block(createIsArrayOfStat, createAsArrayOfStat)
+  }
+
+  private def genIsScalaJSObject(obj: js.Tree)(implicit pos: Position): js.Tree = {
+    import TreeDSL._
+    obj && (obj DOT "$classData")
+  }
+
+  private def genIsClassNameInAncestors(className: String, ancestors: js.Tree)(
+      implicit pos: Position): js.Tree = {
+    import TreeDSL._
+    ancestors DOT className
+  }
+
+  def genTypeData(tree: LinkedClass): js.Tree = {
+    import Definitions._
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    val classIdent = transformIdent(tree.name)
+    val className = classIdent.name
+    val kind = tree.kind
+
+    val isObjectClass =
+      className == ObjectClass
+    val isHijackedBoxedClass =
+      HijackedBoxedClasses.contains(className)
+    val isAncestorOfHijackedClass =
+      AncestorsOfHijackedClasses.contains(className)
+    val isRawJSType =
+      kind == ClassKind.RawJSType || kind.isJSClass
+
+    val isRawJSTypeParam =
+      if (isRawJSType) js.BooleanLiteral(true)
+      else js.Undefined()
+
+    val parentData = if (linkingUnit.globalInfo.isParentDataAccessed) {
+      tree.superClass.fold[js.Tree] {
+        if (isObjectClass) js.Null()
+        else js.Undefined()
+      } { parent =>
+        envField("d", parent.name)
+      }
+    } else {
+      js.Undefined()
+    }
+
+    val ancestorsRecord = js.ObjectConstr(
+        tree.ancestors.map(ancestor => (js.Ident(ancestor), js.IntLiteral(1))))
+
+    val (isInstanceFun, isArrayOfFun) = {
+      if (isObjectClass) {
+        /* Object has special ScalaJS.is.O *and* ScalaJS.isArrayOf.O. */
+        (envField("is", className), envField("isArrayOf", className))
+      } else if (isHijackedBoxedClass) {
+        /* Hijacked boxed classes have a special isInstanceOf test. */
+        val xParam = js.ParamDef(Ident("x"), rest = false)
+        (js.Function(List(xParam), js.Return {
+          genIsInstanceOf(xParam.ref, ClassType(className))
+        }), js.Undefined())
+      } else if (isAncestorOfHijackedClass || className == StringClass) {
+        /* java.lang.String and ancestors of hijacked classes have a normal
+         * ScalaJS.is.pack_Class test but with a non-standard behavior. */
+        (envField("is", className), js.Undefined())
+      } else if (isRawJSType) {
+        /* Raw JS types have an instanceof operator-based isInstanceOf test
+         * dictated by their jsName. If there is no jsName, the test cannot
+         * be performed and must throw.
+         * JS classes have something similar, based on their constructor.
+         */
+        if (tree.jsName.isEmpty && kind != ClassKind.JSClass) {
+          (envField("noIsInstance"), js.Undefined())
+        } else {
+          val jsCtor = genRawJSClassConstructor(tree)
+          (js.Function(List(js.ParamDef(Ident("x"), rest = false)), js.Return {
+            js.BinaryOp(JSBinaryOp.instanceof, js.VarRef(Ident("x")), jsCtor)
+          }), js.Undefined())
+        }
+      } else {
+        // For other classes, the isInstance function can be inferred.
+        (js.Undefined(), js.Undefined())
+      }
+    }
+
+    val allParams = List(
+        js.ObjectConstr(List(classIdent -> js.IntLiteral(0))),
+        js.BooleanLiteral(kind == ClassKind.Interface),
+        js.StringLiteral(semantics.runtimeClassName(tree)),
+        ancestorsRecord,
+        isRawJSTypeParam,
+        parentData,
+        isInstanceFun,
+        isArrayOfFun
+    )
+
+    val prunedParams =
+      allParams.reverse.dropWhile(_.isInstanceOf[js.Undefined]).reverse
+
+    val typeData = js.Apply(js.New(envField("TypeData"), Nil) DOT "initClass",
+        prunedParams)
+
+    envFieldDef("d", className, typeData)
+  }
+
+  def genSetTypeData(tree: LinkedClass): js.Tree = {
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    assert(tree.kind.isClass)
+
+    encodeClassVar(tree.name.name).prototype DOT "$classData" :=
+      envField("d", tree.name.name)
+  }
+
+  def genModuleAccessor(tree: LinkedClass): js.Tree = {
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    val classIdent = transformIdent(tree.name)
+    val className = classIdent.name
+    val tpe = ClassType(className)
+
+    require(tree.kind.hasModuleAccessor,
+        s"genModuleAccessor called with non-module class: $className")
+
+    val createModuleInstanceField =
+      envFieldDef("n", className, js.Undefined(), mutable = true)
+
+    val createAccessor = {
+      val moduleInstanceVar = envField("n", className)
+
+      val assignModule = {
+        val jsNew = js.New(encodeClassVar(className), Nil)
+        val instantiateModule =
+          if (tree.kind == ClassKind.JSModuleClass) jsNew
+          else js.Apply(jsNew DOT js.Ident("init___"), Nil)
+        moduleInstanceVar := instantiateModule
+      }
+
+      val initBlock = semantics.moduleInit match {
+        case CheckedBehavior.Unchecked =>
+          js.If(!(moduleInstanceVar), assignModule, js.Skip())
+        case CheckedBehavior.Compliant =>
+          js.If(moduleInstanceVar === js.Undefined(),
+            js.Block(
+                moduleInstanceVar := js.Null(),
+                assignModule
+            ),
+            js.Skip())
+        case CheckedBehavior.Fatal =>
+          js.If(moduleInstanceVar === js.Undefined(), {
+            js.Block(
+                moduleInstanceVar := js.Null(),
+                assignModule
+            )
+          }, js.If(moduleInstanceVar === js.Null(), {
+            // throw new UndefinedBehaviorError(
+            //     "Initializer of $className called before completion of its" +
+            //     "super constructor")
+            val decodedName = Definitions.decodeClassName(className).stripSuffix("$")
+            val msg = s"Initializer of $decodedName called before completion " +
+              "of its super constructor"
+            val obj = js.New(encodeClassVar("sjsr_UndefinedBehaviorError"), Nil)
+            val ctor = obj DOT js.Ident("init___T")
+            js.Throw(js.Apply(ctor, js.StringLiteral(msg) :: Nil))
+          }, js.Skip()))
+      }
+
+      val body = js.Block(initBlock, js.Return(moduleInstanceVar))
+
+      envFieldDef("m", className, js.Function(Nil, body))
+    }
+
+    js.Block(createModuleInstanceField, createAccessor)
+  }
+
+  def genExportedMembers(tree: LinkedClass): js.Tree = {
+    val exports = tree.exportedMembers map { member =>
+      member.tree match {
+        case MethodDef(false, StringLiteral("constructor"), _, _, _)
+            if tree.kind.isJSClass =>
+          js.Skip()(member.tree.pos)
+        case m: MethodDef =>
+          genMethod(tree.encodedName, m)
+        case p: PropertyDef =>
+          genProperty(tree.encodedName, p)
+        case tree =>
+          throw new AssertionError(
+              "Illegal exportedMember " + tree.getClass.getName)
+      }
+    }
+
+    js.Block(exports)(tree.pos)
+  }
+
+  def genClassExports(tree: LinkedClass): js.Tree = {
+    val exports = tree.classExports collect {
+      case e: ConstructorExportDef =>
+        genConstructorExportDef(tree, e)
+      case e: JSClassExportDef =>
+        genJSClassExportDef(tree, e)
+      case e: ModuleExportDef =>
+        genModuleExportDef(tree, e)
+    }
+
+    js.Block(exports)(tree.pos)
+  }
+
+  def genConstructorExportDef(cd: LinkedClass,
+      tree: ConstructorExportDef): js.Tree = {
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+    val classType = ClassType(cd.name.name)
+    val ConstructorExportDef(fullName, args, body) = tree
+
+    val baseCtor = envField("c", cd.name.name, cd.name.originalName)
+
+    val thisIdent = js.Ident("$thiz")
+
+    val js.Function(ctorParams, ctorBody) =
+      desugarToFunction(this, cd.encodedName,
+          Some(thisIdent), args, body, isStat = true)
+
+    val exportedCtor = js.Function(ctorParams, js.Block(
+      genLet(thisIdent, mutable = false, js.New(baseCtor, Nil)),
+      ctorBody,
+      js.Return(js.VarRef(thisIdent))
+    ))
+
+    val (createNamespace, expCtorVar) =
+      genCreateNamespaceInExports(fullName)
+    js.Block(
+      createNamespace,
+      js.DocComment("@constructor"),
+      expCtorVar := exportedCtor,
+      expCtorVar DOT "prototype" := baseCtor DOT "prototype"
+    )
+  }
+
+  def genJSClassExportDef(cd: LinkedClass, tree: JSClassExportDef): js.Tree = {
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    val classVar = envField("c", cd.name.name)
+    genClassOrModuleExportDef(cd, tree.fullName, classVar)
+  }
+
+  def genModuleExportDef(cd: LinkedClass, tree: ModuleExportDef): js.Tree = {
+    import TreeDSL._
+
+    implicit val pos = tree.pos
+
+    val baseAccessor = envField("m", cd.name.name)
+    genClassOrModuleExportDef(cd, tree.fullName, baseAccessor)
+  }
+
+  private def genClassOrModuleExportDef(cd: LinkedClass, exportFullName: String,
+      exportedValue: js.Tree)(implicit pos: Position): js.Tree = {
+    import TreeDSL._
+
+    val (createNamespace, expAccessorVar) =
+      genCreateNamespaceInExports(exportFullName)
+    js.Block(
+      createNamespace,
+      expAccessorVar := exportedValue
+    )
+  }
+
+  // Helpers
+
+  /** Gen JS code for assigning an rhs to a qualified name in the exports scope.
+   *  For example, given the qualified name "foo.bar.Something", generates:
+   *
+   *  ScalaJS.e["foo"] = ScalaJS.e["foo"] || {};
+   *  ScalaJS.e["foo"]["bar"] = ScalaJS.e["foo"]["bar"] || {};
+   *
+   *  Returns (statements, ScalaJS.e["foo"]["bar"]["Something"])
+   */
+  private def genCreateNamespaceInExports(qualName: String)(
+      implicit pos: Position): (js.Tree, js.Tree) = {
+    val parts = qualName.split("\\.")
+    val statements = List.newBuilder[js.Tree]
+    var namespace = envField("e")
+    for (i <- 0 until parts.length-1) {
+      namespace = genBracketSelect(namespace, js.StringLiteral(parts(i)))
+      statements +=
+        js.Assign(namespace, js.BinaryOp(JSBinaryOp.||,
+            namespace, js.ObjectConstr(Nil)))
+    }
+    val lhs = genBracketSelect(namespace, js.StringLiteral(parts.last))
+    (js.Block(statements.result()), lhs)
+  }
+
+}
+
+private object ScalaJSClassEmitter {
+  private val ClassesWhoseDataReferToTheirInstanceTests = {
+    Definitions.AncestorsOfHijackedClasses +
+    Definitions.ObjectClass + Definitions.StringClass
+  }
+}

--- a/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
+++ b/benchmarks/src/test/scala/org/scalafmt/BenchmarkOK.scala
@@ -10,10 +10,12 @@ class BenchmarkOK extends FunSuite with FormatAssertions {
 
   // TODO(olafur) DRY.
   val formatBenchmarks = Seq(
-    new OptimizerCore,
-    new SourceMapWriter,
-    new Division,
-    new BaseLinker
+    new GenJsCode,
+    new ScalaJSClassEmitter,
+    new OptimizerCore
+//    new SourceMapWriter,
+//    new Division,
+//    new BaseLinker
   )
   formatBenchmarks.foreach { formatBenchmark =>
     val name = formatBenchmark.getClass.getSimpleName

--- a/core/src/main/scala/org/scalafmt/internal/Debug.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Debug.scala
@@ -15,6 +15,7 @@ object Debug extends ScalaFmtLogger {
   val treeExplored = mutable.Map.empty[Tree, Int]
   val tokenExplored = mutable.Map.empty[Token, Int]
   val formatTokenExplored = mutable.Map.empty[FormatToken, Int]
+  val enqueuedSplits = mutable.Set.empty[Split]
   var lastTestExplored = 0
   var explored = 0
   var state = State.start
@@ -39,8 +40,12 @@ object Debug extends ScalaFmtLogger {
     if (tokens.isEmpty) 0
     else {
       val maxTok = tokens.maxBy(x => formatTokenExplored.getOrElse(x, 0))
-      formatTokenExplored(maxTok)
+      formatTokenExplored.getOrElse(maxTok, -1)
     }
+  }
+
+  def enqueued(split: Split): Unit = {
+    enqueuedSplits += split
   }
 
   def visit(token: FormatToken): Unit = {

--- a/core/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Split.scala
@@ -19,9 +19,10 @@ import scala.meta.tokens.Token
   */
 case class Split(modification: Modification, cost: Int,
                  ignoreIf: Boolean = false,
-                 indents: List[Indent[Length]] = List.empty[Indent[Length]],
+                 indents: Vector[Indent[Length]] = Vector.empty[Indent[Length]],
                  policy: Policy = NoPolicy,
-                 penalty: Boolean = false)
+                 penalty: Boolean = false,
+                 optimalAt: Option[Token] = None)
                 (implicit val line: sourcecode.Line) {
 
   val indentation = indents.map(_.length match {
@@ -45,7 +46,7 @@ case class Split(modification: Modification, cost: Int,
       if (policy == NoPolicy) newPolicy
       else throw new UnsupportedOperationException(
         "Can't have two policies yet.")
-    new Split(modification, cost, ignoreIf, indents, update, true)(
+    new Split(modification, cost, ignoreIf, indents, update, true, optimalAt)(
       line)
   }
 
@@ -55,7 +56,7 @@ case class Split(modification: Modification, cost: Int,
       ignoreIf,
       indents,
       policy,
-      true)(line)
+      true, optimalAt)(line)
 
   def withIndent(length: Length, expire: Token,
                  expiresOn: ExpiresOn): Split = {
@@ -67,9 +68,14 @@ case class Split(modification: Modification, cost: Int,
           ignoreIf,
           Indent(length, expire, expiresOn) +: indents,
           policy,
-          penalty)(line)
+          penalty, optimalAt)(line)
     }
   }
+
+  def sameSplit(other: Split): Boolean =
+    this.modification == other.modification &&
+      this.line.value == other.line.value &&
+      this.cost == other.cost
 
   def hasPolicy = policy ne NoPolicy
 

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -1,0 +1,8 @@
+SKIP benchmarks/src/resources/scala-js/ScalaJSClassEmitter.scala
+SKIP benchmarks/src/resources/scala-js/GenJsCode.scala
+SKIP benchmarks/src/resources/scala-js/OptimizerCore.scala
+SKIP benchmarks/src/resources/scala-js/Primality.scala
+SKIP https://raw.githubusercontent.com/scala-js/scala-js/5d447c8851abcdf513605fe1f61075e83c22ebe4/project/JavaLangString.scala
+SKIP https://raw.githubusercontent.com/scala-js/scala-js/5d447c8851abcdf513605fe1f61075e83c22ebe4/project/JavaLangObject.scala
+SKIP https://raw.githubusercontent.com/scala-js/scala-js/5d447c8851abcdf513605fe1f61075e83c22ebe4/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+SKIP https://raw.githubusercontent.com/scala-js/scala-js/5d447c8851abcdf513605fe1f61075e83c22ebe4/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSDesugaring.scala

--- a/core/src/test/resources/standard/Advanced.stat
+++ b/core/src/test/resources/standard/Advanced.stat
@@ -19,7 +19,7 @@ private def genApplyForSym(minArgc: Int, hasRestParam: Boolean,
     genApplyForSymNonJSSuperCall(minArgc, sym)
   }
 }
-<<< js emitter TODO(olafur) ugly output
+<<< js emitter
 val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
         js.Skip()
       } else {
@@ -52,28 +52,26 @@ val createAsStat =
   } else {
     envFieldDef("as",
                 className,
-                js.Function(List(objParam),
-                            js.Return(className match {
-                                  case Definitions.ObjectClass => obj
-                                  case _ =>
-                                    val throwError = {
-                                      genCallHelper(
-                                          "throwClassCastException",
-                                          obj,
-                                          js.StringLiteral(displayName))
-                                    }
-                                    if (className == RuntimeNothingClass) {
-                                      // Always throw for .asInstanceOf[Nothing], even for null
-                                      throwError
-                                    } else {
-                                      js.If(
-                                          js.Apply(envField("is", className), List(obj)) || (obj === js.Null()), {
-                                            obj
-                                          }, {
-                                            throwError
-                                          })
-                                    }
-                                })))
+                js.Function(List(objParam), js.Return(className match {
+                  case Definitions.ObjectClass => obj
+                  case _ =>
+                    val throwError = {
+                      genCallHelper("throwClassCastException",
+                                    obj,
+                                    js.StringLiteral(displayName))
+                    }
+                    if (className == RuntimeNothingClass) {
+                      // Always throw for .asInstanceOf[Nothing], even for null
+                      throwError
+                    } else {
+                      js.If(js.Apply(envField("is", className), List(obj)) || (
+                              obj === js.Null()), {
+                              obj
+                            }, {
+                              throwError
+                            })
+                    }
+                })))
   }
 <<< processOptions
   def processOptions(): Unit = {
@@ -150,13 +148,339 @@ options.testFilter match {
     !blacklistedTestFileNames.contains(absPath) && !whitelistedTestFileNames
       .contains(absPath) && !buglistedTestFileNames.contains(absPath)
 }
-<<< SKIP scalatags
-  private def sbtIgnore: String => Boolean =
-    x => !Seq(
-      // Unicode escapes in weird places
-      "target/repos/sbt/main/settings/src/main/scala/sbt/std/InputWrapper.scala",
-      // uses a package called `macro`
-      "target/repos/sbt/sbt/src/sbt-test/source-dependencies/inherited-macros",
-      "target/repos/sbt/sbt/src/sbt-test/source-dependencies/macro")
-      .exists(x.startsWith)
+<<< callStatement genjscode
+          callStatement = js.If(genIsInstanceOf(callTrg, rtClass.tpe), {
+            if (implMethodSym.owner == ObjectClass) {
+              // If the method is defined on Object, we can call it normally.
+              genApplyMethod(callTrg, implMethodSym, arguments)
+            } else {
+              if (rtClass == StringClass) {
+                val (rtModuleClass, methodIdent) =
+                  encodeRTStringMethodSym(implMethodSym)
+                val retTpe = implMethodSym.tpe.resultType
+                val castCallTrg = fromAny(callTrg, StringClass.toTypeConstructor)
+                val rawApply = genApplyMethod(
+                    genLoadModule(rtModuleClass),
+                    methodIdent,
+                    castCallTrg :: arguments,
+                    toIRType(retTpe))
+                // Box the result of the implementing method if required
+                if (isPrimitiveValueType(retTpe))
+                  makePrimitiveBox(rawApply, retTpe)
+                else
+                  rawApply
+              } else {
+                val reflBoxClassPatched = {
+                  def isIntOrLongKind(kind: TypeKind) = kind match {
+                    case _:INT | LONG => true
+                    case _            => false
+                  }
+                  if (rtClass == BoxedDoubleClass &&
+                      toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&
+                      isIntOrLongKind(toTypeKind(sym.tpe.resultType))) {
+                    // This must be an Int, and not a Double
+                    IntegerReflectiveCallClass
+                  } else {
+                    reflBoxClass
+                  }
+                }
+                val castCallTrg =
+                  fromAny(callTrg,
+                      reflBoxClassPatched.primaryConstructor.tpe.params.head.tpe)
+                val reflBox = genNew(reflBoxClassPatched,
+                    reflBoxClassPatched.primaryConstructor, List(castCallTrg))
+                genApplyMethod(
+                    reflBox,
+                    proxyIdent,
+                    arguments,
+                    jstpe.AnyType)
+              }
+            }
+          }, { // else
+            callStatement
+          })(jstpe.AnyType)
 >>>
+callStatement = js.If(genIsInstanceOf(callTrg, rtClass.tpe), {
+  if (implMethodSym.owner == ObjectClass) {
+    // If the method is defined on Object, we can call it normally.
+    genApplyMethod(callTrg, implMethodSym, arguments)
+  } else {
+    if (rtClass == StringClass) {
+      val (rtModuleClass, methodIdent) = encodeRTStringMethodSym(implMethodSym)
+      val retTpe = implMethodSym.tpe.resultType
+      val castCallTrg = fromAny(callTrg, StringClass.toTypeConstructor)
+      val rawApply = genApplyMethod(genLoadModule(rtModuleClass),
+                                    methodIdent,
+                                    castCallTrg :: arguments,
+                                    toIRType(retTpe))
+      // Box the result of the implementing method if required
+      if (isPrimitiveValueType(retTpe))
+        makePrimitiveBox(rawApply, retTpe)
+      else rawApply
+    } else {
+      val reflBoxClassPatched = {
+
+        def isIntOrLongKind(kind: TypeKind) =
+          kind match {
+            case _: INT | LONG => true
+            case _ => false
+          }
+        if (rtClass == BoxedDoubleClass &&
+            toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&
+            isIntOrLongKind(toTypeKind(sym.tpe.resultType))) {
+          // This must be an Int, and not a Double
+          IntegerReflectiveCallClass
+        } else {
+          reflBoxClass
+        }
+      }
+      val castCallTrg =
+        fromAny(callTrg,
+                reflBoxClassPatched.primaryConstructor.tpe.params.head.tpe)
+      val reflBox = genNew(reflBoxClassPatched,
+                           reflBoxClassPatched.primaryConstructor,
+                           List(castCallTrg))
+      genApplyMethod(reflBox,
+                     proxyIdent,
+                     arguments,
+                     jstpe.AnyType)
+    }
+  }
+}, {
+  // else
+  callStatement
+})(jstpe.AnyType)
+<<< Infinite recursion?
+        val ctorParamDefs = usedCtorParams map { p =>
+          // in the apply method's context
+          js.ParamDef(encodeLocalSym(p)(p.pos), toIRType(p.tpe),
+              mutable = false, rest = false)(p.pos)
+        }
+>>>
+val ctorParamDefs =
+  usedCtorParams map { p =>
+  // in the apply method's context
+  js.ParamDef(encodeLocalSym(p)(p.pos),
+              toIRType(p.tpe),
+              mutable = false,
+              rest = false)(p.pos)
+  }
+<<< single arg block
+      withNewLocalNameScope {
+          if (isThisFunction) {
+            val thisParam :: actualParams = patchedParams
+            js.Closure(
+                ctorParamDefs,
+                actualParams,
+                js.Block(
+                    js.VarDef(thisParam.name, thisParam.ptpe, mutable = false,
+                        js.This()(thisParam.ptpe)(thisParam.pos))(thisParam.pos),
+                    patchedBody),
+                capturedArgs)
+          } else {
+            js.Closure(ctorParamDefs, patchedParams, patchedBody, capturedArgs)
+          }
+        }
+>>>
+withNewLocalNameScope {
+  if (isThisFunction) {
+    val thisParam :: actualParams = patchedParams
+    js.Closure(
+        ctorParamDefs,
+        actualParams,
+        js.Block(
+            js.VarDef(thisParam.name,
+                      thisParam.ptpe,
+                      mutable = false,
+                      js.This()(thisParam.ptpe)(thisParam.pos))(thisParam.pos),
+            patchedBody),
+        capturedArgs)
+  } else {
+    js.Closure(ctorParamDefs, patchedParams, patchedBody, capturedArgs)
+  }
+}
+<<< SKIP instance_of_?
+  object MaybeAsInstanceOf {
+
+      def unapply(tree: Tree): Some[Tree] =
+        tree match {
+          case Apply(TypeApply(asInstanceOf_?@Select(base, _), _), _)
+              if asInstanceOf_?.symbol == Object_asInstanceOf =>
+            Some(base)
+          case _ => Some(tree)
+        }
+    }
+>>>
+object MaybeAsInstanceOf {
+
+  def unapply(tree: Tree): Some[Tree] =
+    tree match {
+      case Apply(TypeApply(asInstanceOf_?@Select(base, _), _), _)
+          if asInstanceOf_?.symbol == Object_asInstanceOf =>
+        Some(base)
+      case _ => Some(tree)
+    }
+}
+<<< double args infinte loop?
+  private def withNewLocalDefs(bindings: List[Binding])(
+      buildInner: (List[LocalDef], PreTransCont) => TailRec[Tree])(
+      cont: PreTransCont): TailRec[Tree] = {
+    bindings match {
+      case first :: rest =>
+        withNewLocalDef(first) { (firstLocalDef, cont1) =>
+          withNewLocalDefs(rest) { (restLocalDefs, cont2) =>
+            buildInner(firstLocalDef :: restLocalDefs, cont2)
+          } (cont1)
+        } (cont)
+
+      case Nil =>
+        buildInner(Nil, cont)
+    }
+  }
+>>>
+private def withNewLocalDefs(bindings: List[Binding]) (buildInner:(List[
+        LocalDef],
+    PreTransCont) => TailRec[Tree]) (cont: PreTransCont): TailRec[Tree] = {
+  bindings match {
+    case first :: rest =>
+      withNewLocalDef(first) { (firstLocalDef, cont1) =>
+        withNewLocalDefs(rest) { (restLocalDefs, cont2) =>
+          buildInner(firstLocalDef :: restLocalDefs, cont2)
+        }(cont1)
+      }(cont)
+
+    case Nil => buildInner(Nil, cont)
+  }
+}
+<<< genArrayInstanceTests
+  val createIsArrayOfStat = {
+    envFieldDef(
+        "isArrayOf",
+        className,
+        js.Function(List(objParam, depthParam), className match {
+          case Definitions.ObjectClass =>
+            val dataVarDef = genLet(Ident("data"), mutable = false, {
+              obj && (obj DOT "$classData")
+            })
+            val data = dataVarDef.ref
+            js.Block(dataVarDef, js.If(!data, {
+              js.Return(js.BooleanLiteral(false))
+            }, {
+              val arrayDepthVarDef =
+                genLet(Ident("arrayDepth"), mutable = false, {
+                  (data DOT "arrayDepth") || js.IntLiteral(0)
+                })
+              val arrayDepth = arrayDepthVarDef.ref
+              js.Block(arrayDepthVarDef, js.Return {
+                // Array[A] </: Array[Array[A]]
+                !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
+                (// Array[Array[A]] <: Array[Object]
+                  js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+                  // Array[Int] </: Array[Object]
+                  !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
+              })
+            }))
+
+          case _ =>
+            js.Return(! (! ({
+              genIsScalaJSObject(obj) && ((
+                obj DOT "$classData" DOT "arrayDepth") === depth) &&
+              genIsClassNameInAncestors(
+                  className,
+                  obj DOT "$classData" DOT "arrayBase" DOT "ancestors")
+            })))
+        }))
+  }
+>>>
+val createIsArrayOfStat = {
+  envFieldDef(
+      "isArrayOf",
+      className,
+      js.Function(List(objParam, depthParam), className match {
+        case Definitions.ObjectClass =>
+          val dataVarDef = genLet(Ident("data"), mutable = false, {
+            obj && (obj DOT "$classData")
+          })
+          val data = dataVarDef.ref
+          js.Block(dataVarDef, js.If(!data, {
+            js.Return(js.BooleanLiteral(false))
+          }, {
+            val arrayDepthVarDef =
+              genLet(Ident("arrayDepth"), mutable = false, {
+                (data DOT "arrayDepth") || js.IntLiteral(0)
+              })
+            val arrayDepth = arrayDepthVarDef.ref
+            js.Block(arrayDepthVarDef, js.Return {
+              // Array[A] </: Array[Array[A]]
+              !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
+              (// Array[Array[A]] <: Array[Object]
+                js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+                // Array[Int] </: Array[Object]
+                !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
+            })
+          }))
+
+        case _ =>
+          js.Return(! (! ({
+            genIsScalaJSObject(obj) && ((
+              obj DOT "$classData" DOT "arrayDepth") === depth) &&
+            genIsClassNameInAncestors(
+                className,
+                obj DOT "$classData" DOT "arrayBase" DOT "ancestors")
+          })))
+      }))
+}
+<<< js.Return
+                js.Block(
+                  arrayDepthVarDef,
+                  js.Return {
+                    // Array[A] </: Array[Array[A]]
+                    !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) && (
+                      // Array[Array[A]] <: Array[Object]
+                      js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+                      // Array[Int] </: Array[Object]
+                      !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive")
+                    )
+                  })
+
+>>>
+js.Block(arrayDepthVarDef, js.Return {
+  // Array[A] </: Array[Array[A]]
+  !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
+  (// Array[Array[A]] <: Array[Object]
+    js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+    // Array[Int] </: Array[Object]
+    !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
+})
+<<< Js.Function
+js.Function(List(objParam, depthParam), js.Return {
+                    js.If(
+                    js.Apply(envField("isArrayOf", className), List(obj, depth)) || (obj === js.Null()), {
+                      obj
+                    }, {
+                      genCallHelper("throwArrayCastException",
+                                    obj,
+                                    js.StringLiteral("L" + displayName + ";"),
+                                    depth)
+                    })
+                  })
+>>>
+js.Function(List(objParam, depthParam), js.Return {
+  js.If(js.Apply(envField("isArrayOf", className), List(obj, depth)) || (
+          obj === js.Null()), {
+          obj
+        }, {
+          genCallHelper("throwArrayCastException",
+                        obj,
+                        js.StringLiteral("L" + displayName + ";"),
+                        depth)
+        })
+})
+<<< SKIP dequeue on new stat (state explosion)
+{
+  Array((1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2), (1, 2))
+
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}
+>>>
+x

--- a/core/src/test/resources/standard/Apply.stat
+++ b/core/src/test/resources/standard/Apply.stat
@@ -28,9 +28,9 @@ List(Split(Space,
            policy = SingleLineBlock(close),
            ignoreIf = blockSize > style.maxColumn),
      Split(nl, 1, policy = {
-           case Decision(t@FormatToken(_, `close`, _), s) =>
-             Decision(t, List(Split(Newline, 0)))
-         }))
+       case Decision(t@FormatToken(_, `close`, _), s) =>
+         Decision(t, List(Split(Newline, 0)))
+     }))
 <<< Massive (good API) 3
 Split(Space, 0).withPolicy {
     // Following case:
@@ -69,16 +69,16 @@ Split(Space, 0, policy = {
 })
 >>>
 Split(Space, 0, policy = {
-      // Following case:
-      // package foo // this is cool
-      //
-      // object a
-      case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
-          if !between.exists(_.isInstanceOf[`\n`]) =>
-        Decision(t, splits.map(_.withModification(Space)))
-      case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
-        Decision(t, splits.map(_.withModification(Newline2x)))
-    })
+  // Following case:
+  // package foo // this is cool
+  //
+  // object a
+  case Decision(t@FormatToken(`lastRef`, _: Comment, between), splits)
+      if !between.exists(_.isInstanceOf[`\n`]) =>
+    Decision(t, splits.map(_.withModification(Space)))
+  case Decision(t@FormatToken(`lastRef`, _, _), splits) =>
+    Decision(t, splits.map(_.withModification(Newline2x)))
+})
 <<< SKIP scala.meta tree structure
 Defn.Object(Nil, Term.Name("State"), Template(Nil, Seq(Ctor.Ref.Name("ScalaFmtLogger")), Term.Param(Nil, Name.Anonymous(), None, None), Some(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("start"))), None, Term.Apply(Term.Name("State"), Seq(Lit(0), Term.Name("identity"), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Name("Split"))), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Name("State"))), Lit(0), Term.ApplyType(Term.Select(Term.Name("Vector"), Term.Name("empty")), Seq(Type.Apply(Type.Name("Indent"), Seq(Type.Name("Num"))))), Lit(0)))), Defn.Def(Nil, Term.Name("reconstructPath"), Nil, Seq(Seq(Term.Param(Nil, Term.Name("toks"), Some(Type.Apply(Type.Name("Array"), Seq(Type.Name("FormatToken")))), None), Term.Param(Nil, Term.Name("splits"), Some(Type.Apply(Type.Name("Vector"), Seq(Type.Name("Split")))), None), Term.Param(Nil, Term.Name("style"), Some(Type.Name("ScalaStyle")), None), Term.Param(Nil, Term.Name("debug"), Some(Type.Name("Boolean")), Some(Lit(false))))), Some(Type.Apply(Type.Name("Seq"), Seq(Type.Tuple(Seq(Type.Name("FormatToken"), Type.Name("String")))))), Term.Block(Seq(Defn.Var(Nil, Seq(Pat.Var.Term(Term.Name("state"))), None, Some(Term.Select(Term.Name("State"), Term.Name("start")))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("result"))), None, Term.Apply(Term.Select(Term.Apply(Term.Select(Term.Name("toks"), Term.Name("zip")), Seq(Term.Name("splits"))), Term.Name("map")), Seq(Term.PartialFunction(Seq(Case(Pat.Tuple(Seq(Pat.Var.Term(Term.Name("tok")), Pat.Var.Term(Term.Name("split")))), None, Term.Block(Seq(Term.If(Term.Name("debug"), Term.Block(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("left"))), None, Term.Apply(Term.Name("small"), Seq(Term.Select(Term.Name("tok"), Term.Name("left"))))), Term.Apply(Term.Select(Term.Name("logger"), Term.Name("debug")), Seq(Term.Interpolate(Term.Name("f"), Seq(Lit(""), Lit("%-10s "), Lit("")), Seq(Term.Name("left"), Term.Name("split"))))))), Lit()), Term.Assign(Term.Name("state"), Term.Apply(Term.Select(Term.Name("state"), Term.Name("next")), Seq(Term.Name("style"), Term.Name("split"), Term.Name("tok")))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("whitespace"))), None, Term.Match(Term.Select(Term.Name("split"), Term.Name("modification")), Seq(Case(Term.Name("Space"), None, Lit(" ")), Case(Pat.Typed(Pat.Var.Term(Term.Name("nl")), Type.Name("NewlineT")), None, Term.Block(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("newline"))), None, Term.If(Term.Select(Term.Name("nl"), Term.Name("isDouble")), Lit("\n\n"), Lit("\n"))), Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name("indentation"))), None, Term.If(Term.Select(Term.Name("nl"), Term.Name("noIndent")), Lit(""), Term.ApplyInfix(Lit(" "), Term.Name("*"), Nil, Seq(Term.Select(Term.Name("state"), Term.Name("indentation")))))), Term.ApplyInfix(Term.Name("newline"), Term.Name("+"), Nil, Seq(Term.Name("indentation")))))), Case(Pat.Extract(Term.Name("Provided"), Nil, Seq(Pat.Var.Term(Term.Name("literal")))), None, Term.Name("literal")), Case(Term.Name("NoSplit"), None, Lit(""))))), Term.ApplyInfix(Term.Name("tok"), Term.Name("->"), Nil, Seq(Term.Name("whitespace"))))))))))), Term.If(Term.Name("debug"), Term.Apply(Term.Select(Term.Name("logger"), Term.Name("debug")), Seq(Term.Interpolate(Term.Name("s"), Seq(Lit("Total cost: "), Lit("")), Seq(Term.Select(Term.Name("state"), Term.Name("cost")))))), Lit()), Term.Name("result"))))))))
 >>>

--- a/core/src/test/resources/standard/Case.stat
+++ b/core/src/test/resources/standard/Case.stat
@@ -28,17 +28,17 @@ List(Split(Space, 0).withPolicy {
             })
 >>>
 List(Split(Space, 0).withPolicy {
-      case Decision(t, s) if tok.right.end <= lastToken.end =>
-        Decision(t, s.map {
-              case nl if nl.modification.isNewline =>
-                val result =
-                  if (t.right.isInstanceOf[`if`] && owners(t.right) == owner)
-                    nl
-                  else nl.withPenalty(1)
-                result.withPolicy(breakOnArrow)
-              case x => x
-            })
+  case Decision(t, s) if tok.right.end <= lastToken.end =>
+    Decision(t, s.map {
+      case nl if nl.modification.isNewline =>
+        val result =
+          if (t.right.isInstanceOf[`if`] && owners(t.right) == owner)
+            nl
+          else nl.withPenalty(1)
+        result.withPolicy(breakOnArrow)
+      case x => x
     })
+})
 <<< chain of || and &&
 x match {
   case tok if // TODO(olafur) DRY.

--- a/core/src/test/resources/standard/Val.stat
+++ b/core/src/test/resources/standard/Val.stat
@@ -10,7 +10,7 @@ var inside =
     false
 >>>
 var inside = false
-<<< SKIP underscore assignment
+<<< underscore assignment
 var inside: Int   = _
 >>>
 var inside: Int = _

--- a/core/src/test/resources/unit/Advanced.source
+++ b/core/src/test/resources/unit/Advanced.source
@@ -23,10 +23,10 @@
 }
 >>>
 @foobar("annot", {
-      val x = 2
-      val y = 2 // y=2
-      x + y
-    })
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
 object a extends b with c {
 
   def foo[T: Int#Double#Triple,

--- a/core/src/test/resources/unit/Argument.source
+++ b/core/src/test/resources/unit/Argument.source
@@ -61,6 +61,6 @@ object a {
 }
 >>>
 object a {
-  function(function(function(a, b),
-                    function(c, d)))
+  function(function(
+      function(a, b), function(c, d)))
 }

--- a/core/src/test/resources/unit/Comment.stat
+++ b/core/src/test/resources/unit/Comment.stat
@@ -90,3 +90,69 @@ val x = 1
 
 //  val x = 2
 }
+<<< Offset
+{
+  val OffsetPrimes = Array(
+      null, null, (0, 2), (2, 2), (4, 2), (6, 5), (11, 7),
+      (18, 13), (31, 23), (54, 43), (97, 75))
+
+  // All {@code BigInteger} prime numbers with bit length lesser than 8 bits. */
+  val x = 1
+}
+>>>
+{
+  val OffsetPrimes = Array(null,
+                           null,
+                           (0, 2),
+                           (2, 2),
+                           (4, 2),
+                           (6, 5),
+                           (11, 7),
+                           (18, 13),
+                           (31, 23),
+                           (54, 43),
+                           (97, 75))
+
+  // All {@code BigInteger} prime numbers with bit length lesser than 8 bits. */
+  val x = 1
+}
+<<< Offset comment before )
+  val OffsetPrimes = Array(
+      null, null, (0, 2), (2, 2), (4, 2), (6, 5), (11, 7),
+      (18, 13), (31, 23), (54, 43), (97, 75)
+  // All {@code BigInteger} prime numbers with bit length lesser than 8 bits. */
+      )
+>>>
+val OffsetPrimes = Array(null,
+                         null,
+                         (0, 2),
+                         (2, 2),
+                         (4, 2),
+                         (6, 5),
+                         (11, 7),
+                         (18, 13),
+                         (31, 23),
+                         (54, 43),
+                         (97, 75)
+                         // All {@code BigInteger} prime numbers with bit length lesser than 8 bits. */
+)
+<<< SKIP non comment exceeds line (state explosion).
+  val OffsetPrimes = Array(
+      null, null, (0, 2), (2, 2), (4, 2), (6, 5), (11, 7),
+      (18, 13), (31, 23), (54, 43), (97, 75),
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      )
+>>>
+  val OffsetPrimes = Array(null,
+                           null,
+                           (0, 2),
+                           (2, 2),
+                           (4, 2),
+                           (6, 5),
+                           (11, 7),
+                           (18, 13),
+                           (31, 23),
+                           (54, 43),
+                           (97, 75),
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      )

--- a/core/src/test/resources/unit/DefDef.stat
+++ b/core/src/test/resources/unit/DefDef.stat
@@ -30,3 +30,10 @@ object a {
 def identity[T](t: T): T =   t
 >>>
 def identity[T](t: T): T = t
+<<< SKIP def kill?
+      def hasExplicitJSEncoding =
+        sym.hasAnnotation(JSNameAnnotation) ||
+        sym.hasAnnotation(JSBracketAccessAnnotation) ||
+        sym.hasAnnotation(JSBracketCallAnnotation)
+>>>
+x

--- a/core/src/test/resources/unit/TermApply.stat
+++ b/core/src/test/resources/unit/TermApply.stat
@@ -73,16 +73,10 @@ var list = List( // comment
     function(a: A, b: B, c: C))
 <<< long
 var list = List(
-  function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C)
+  function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C), function(a: A, b: B, c: C)
 );
 >>>
 var list = List(
-    function(a: A, b: B, c: C),
-    function(a: A, b: B, c: C),
-    function(a: A, b: B, c: C),
-    function(a: A, b: B, c: C),
-    function(a: A, b: B, c: C),
-    function(a: A, b: B, c: C),
     function(a: A, b: B, c: C),
     function(a: A, b: B, c: C),
     function(a: A, b: B, c: C),
@@ -103,8 +97,8 @@ function(a, b, c, {
   })
 >>>
 function(a, b, c, {
-      case Foo("a", 1) => Foo("b", 2)
-    })
+  case Foo("a", 1) => Foo("b", 2)
+})
 <<< MUST NOT use automatic formatting 1 alexandru/scala-best-practices
 val dp = new DispatchPlan(Set(filteredAssets), start =
   startDate, end = endDate, product, scheduleMap, availabilityMap,

--- a/core/src/test/resources/unit/TypeArgument.source
+++ b/core/src/test/resources/unit/TypeArgument.source
@@ -61,8 +61,8 @@ object a {
 }
 >>>
 object a {
-  function[function[function[a, b],
-                    function[c, d]]]
+  function[function[
+      function[a, b], function[c, d]]]
 }
 <<< Break on higher level of nesting 3x
 object a {
@@ -71,8 +71,7 @@ object a {
 >>>
 object a {
   function[function[function[
-              function[a, b],
-              function[c, d]]]]
+      function[a, b], function[c, d]]]]
 }
 <<< Type args and args different policy
 object Object {

--- a/core/src/test/scala/org/scalafmt/UnitTests.scala
+++ b/core/src/test/scala/org/scalafmt/UnitTests.scala
@@ -9,6 +9,7 @@ object UnitTests extends HasTests with ScalaFmtLogger {
 
   import FilesUtil._
 
+  // TODO(olafur) make possible to limit states per unit test.
   override lazy val tests: Seq[DiffTest] = {
     for {
       filename <- listFiles(testDir)

--- a/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/util/ScalaProjectsExperiment.scala
@@ -111,7 +111,7 @@ trait ScalaProjectsExperiment extends ScalaFmtLogger {
   def recoverError(fileUrl: String): PartialFunction[Throwable, Boolean] = {
     case e: ParseException => results.add(ParseErr(fileUrl, e))
     case e: java.util.concurrent.TimeoutException =>
-      print("-")
+      println(s"- $fileUrl")
       results.add(Timeout(fileUrl))
     case NonFatal(e) =>
       print("X")

--- a/core/src/test/scala/org/scalafmt/util/Speed.scala
+++ b/core/src/test/scala/org/scalafmt/util/Speed.scala
@@ -5,6 +5,7 @@ import org.scalafmt.internal.Debug
 import org.scalafmt.internal.ScalaFmtLogger
 import org.scalafmt.stats.GitInfo
 import org.scalafmt.stats.TestStats
+import upickle.Invalid
 
 import scalaz.-\/
 import scalaz.\/-
@@ -19,6 +20,7 @@ object Speed extends ScalaFmtLogger {
     val startTime = System.nanoTime()
     val actions = db.docs.create(stat)
     actions.attemptRun match {
+      case -\/(e: Invalid) => logger.warn("Unable to submit to speed.scalafmt.org: Invalid data")
       case -\/(e) => logger.warn("Unable to submit to speed.scalafmt.org", e)
       case f@ \/-(a) =>
         val elapsed = Debug.ns2ms(System.nanoTime() - startTime)

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,24 @@ To run main formatting tests:
 
 ### Updates (mostly for myself)
 
+* Feb 26th
+  * Able to format 916 of 920 files in Scala.js! And 75 percentile format in
+  under 200ms.
+```
+Benchmark                        Mode  Cnt     Score    Error  Units
+GenJsCode.scalafmt               avgt   10  1283.002 ± 77.631  ms/op
+GenJsCode.scalariform            avgt   10   228.591 ± 10.815  ms/op
+OptimizerCore.scalafmt           avgt   10  1242.236 ± 46.238  ms/op
+OptimizerCore.scalariform        avgt   10   230.396 ±  8.253  ms/op
+ScalaJSClassEmitter.scalafmt     avgt   10   308.831 ± 15.678  ms/op
+ScalaJSClassEmitter.scalariform  avgt   10    35.309 ±  0.602  ms/op
+
++-------------+--------+--------------+----------+--------+---------+----------+
+|          Max|     Min|           Sum|      Mean|      Q1|       Q2|        Q3|
++-------------+--------+--------------+----------+--------+---------+----------+
+|15.362,715 ms|2,165 ms|309.145,298 ms|340,094 ms|29,87 ms|74,412 ms|197,866 ms|
++-------------+--------+--------------+----------+--------+---------+----------+
+```
 * Feb 25th
   * Can format [GenJsCode](https://github.com/scala-js/scala-js/blob/master/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala)
     in ~1.5s! Previously didn't terminate.

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -1,1 +1,3 @@
 sbt "benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*"
+sbt "core/test:runMain  org.scalafmt.FormatExperiment"
+


### PR DESCRIPTION
* Ignore singleline if obviously won't work.
* Refactor optimizations, enable by flag.
* Recurse on blocks inside no-opt zones, blocks are memoized.
* Temporary fix for comments exceeding column limit.
* Add a bunch of tests in Advanced.stat.
* Early eliminate competing solutions if there is a 0 cost solution.

```
[info] Benchmark                        Mode  Cnt     Score    Error  Units
[info] GenJsCode.scalafmt               avgt   10  1283.002 ± 77.631  ms/op
[info] GenJsCode.scalariform            avgt   10   228.591 ± 10.815  ms/op
[info] OptimizerCore.scalafmt           avgt   10  1242.236 ± 46.238  ms/op
[info] OptimizerCore.scalariform        avgt   10   230.396 ±  8.253  ms/op
[info] ScalaJSClassEmitter.scalafmt     avgt   10   308.831 ± 15.678  ms/op
[info] ScalaJSClassEmitter.scalariform  avgt   10    35.309 ±  0.602  ms/op

Success: 909
Total: 920

+-------------+--------+--------------+----------+--------+---------+----------+
|          Max|     Min|           Sum|      Mean|      Q1|       Q2|        Q3|
+-------------+--------+--------------+----------+--------+---------+----------+
|15.362,715 ms|2,165 ms|309.145,298 ms|340,094 ms|29,87 ms|74,412 ms|197,866 ms|
+-------------+--------+--------------+----------+--------+---------+----------+
```

NOTE. Only 4 files time out when formatted individually, the other 7
files probably suffer from the parallel run.