### PR TITLE
Optimization: limit queue size even inside no opt zones.

### DIFF
--- a/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -76,16 +76,8 @@ abstract class FormatBenchmark(path: String*) {
 
 object run {
 
-  // Scala-js benchmarks
   abstract class ScalaJsBenchmark(filename: String)
     extends FormatBenchmark("scala-js", filename)
-
-
-//  class Division extends ScalaJsBenchmark("Division.scala")
-//
-//  class SourceMapWriter extends ScalaJsBenchmark("SourceMapWriter.scala")
-//
-//  class BaseLinker extends ScalaJsBenchmark("BaseLinker.scala")
 
   class OptimizerCore extends ScalaJsBenchmark("OptimizerCore.scala")
 
@@ -93,16 +85,7 @@ object run {
 
   class ScalaJSClassEmitter extends ScalaJsBenchmark("ScalaJSClassEmitter.scala")
 
-  // These files are too small to be interesting.
-  //  class Basic extends FormatBenchmark("scalafmt", "Basic.scala")
-  //  class Utils extends ScalaJsBenchmark("Utils.scala")
-  //  class JsDependency extends ScalaJsBenchmark("JSDependency.scala")
-  //  class Semantics extends ScalaJsBenchmark("Semantics.scala")
+  class JavaLangString extends ScalaJsBenchmark("JavaLangString.scala")
 
-  // Scalafmt can't format these, yet.
-  //  class TypeKinds extends ScalaJsBenchmark("TypeKinds.scala")
-  //  class Analyzer extends ScalaJsBenchmark("Analyzer.scala")
-  //  class Trees extends ScalaJsBenchmark("Trees.scala")
-  //  class CopyOnWriteArrayList extends ScalaJsBenchmark("CopyOnWriteArrayList.scala")
 }
 

--- a/benchmarks/src/resources/scala-js/JavaLangString.scala
+++ b/benchmarks/src/resources/scala-js/JavaLangString.scala
@@ -1,0 +1,166 @@
+/*
+ * Hard-coded IR for java.lang.String.
+ */
+
+import org.scalajs.core.ir
+import ir._
+import ir.Definitions._
+import ir.Infos._
+import ir.Trees._
+import ir.Types._
+import ir.Position.NoPosition
+
+/** Hard-coded IR for java.lang.String.
+ *  Unlike for the other hijacked classes, scalac does not like at all to
+ *  compile even a mocked version of java.lang.String. So we have to bypass
+ *  entirely the compiler to define java.lang.String.
+ */
+object JavaLangString {
+
+  val InfoAndTree = {
+    implicit val DummyPos = NoPosition
+
+    val ThisType = ClassType(StringClass)
+
+    val classDef = ClassDef(
+      Ident("T", Some("java.lang.String")),
+      ClassKind.HijackedClass,
+      Some(Ident("O", Some("java.lang.Object"))),
+      List(
+          Ident("Ljava_io_Serializable", Some("java.io.Serializable")),
+          Ident("jl_CharSequence", Some("java.lang.CharSequence")),
+          Ident("jl_Comparable", Some("java.lang.Comparable"))
+      ),
+      None,
+      List(
+        /* def equals(that: Object): Boolean = this eq that */
+        MethodDef(
+          static = false,
+          Ident("equals__O__Z", Some("equals__O__Z")),
+          List(ParamDef(Ident("that", Some("that")), AnyType,
+            mutable = false, rest = false)),
+          BooleanType,
+          {
+            BinaryOp(BinaryOp.===,
+              This()(ThisType),
+              VarRef(Ident("that", Some("that")))(AnyType))
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def hashCode(): Int = RuntimeString.hashCode(this) */
+        MethodDef(
+          static = false,
+          Ident("hashCode__I", Some("hashCode__I")),
+          Nil,
+          IntType,
+          {
+            Apply(
+              LoadModule(ClassType("sjsr_RuntimeString$")),
+              Ident("hashCode__T__I", Some("hashCode__T__I")),
+              List(This()(ThisType)))(IntType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def compareTo(that: String): Int = RuntimeString.compareTo(this, that) */
+        MethodDef(
+          static = false,
+          Ident("compareTo__T__I", Some("compareTo__T__I")),
+          List(ParamDef(Ident("that", Some("that")), ThisType,
+            mutable = false, rest = false)),
+          IntType,
+          {
+            Apply(
+              LoadModule(ClassType("sjsr_RuntimeString$")),
+              Ident("compareTo__T__T__I", Some("compareTo__T__T__I")),
+              List(
+                This()(ThisType),
+                VarRef(Ident("that", Some("that")))(ThisType)))(IntType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def compareTo(that: Object): Int = compareTo(that.asInstanceOf[String]) */
+        MethodDef(
+          static = false,
+          Ident("compareTo__O__I", Some("compareTo__O__I")),
+          List(ParamDef(Ident("that", Some("that")), AnyType,
+            mutable = false, rest = false)),
+          IntType,
+          {
+            Apply(
+              This()(ThisType),
+              Ident("compareTo__T__I", Some("compareTo__T__I")),
+              List(AsInstanceOf(
+                VarRef(Ident("that", Some("that")))(AnyType),
+                ThisType)))(IntType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def toString(): String = this */
+        MethodDef(
+          static = false,
+          Ident("toString__T", Some("toString__T")),
+          Nil,
+          ClassType(StringClass),
+          {
+            This()(ThisType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def charAt(i: Int): Char = RuntimeString.charAt(this, i) */
+        MethodDef(
+          static = false,
+          Ident("charAt__I__C", Some("charAt__I__C")),
+          List(ParamDef(Ident("i", Some("i")), IntType,
+            mutable = false, rest = false)),
+          IntType,
+          {
+            Apply(
+              LoadModule(ClassType("sjsr_RuntimeString$")),
+              Ident("charAt__T__I__C", Some("charAt__T__I__C")),
+              List(
+                This()(ThisType),
+                VarRef(Ident("i", Some("i")))(IntType)))(IntType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def length(): Int = RuntimeString.length(this) */
+        MethodDef(
+          static = false,
+          Ident("length__I", Some("length__I")),
+          Nil,
+          IntType,
+          {
+            Apply(
+              LoadModule(ClassType("sjsr_RuntimeString$")),
+              Ident("length__T__I", Some("length__T__I")),
+              List(This()(ThisType)))(IntType)
+          })(OptimizerHints.empty.withInline(true), None),
+
+        /* def subSequence(begin: Int, end: Int): CharSequence =
+         *   RuntimeString.subSequence(this, begin, end)
+         */
+        MethodDef(
+          static = false,
+          Ident("subSequence__I__I__jl_CharSequence",
+            Some("subSequence__I__I__jl_CharSequence")),
+          List(
+            ParamDef(Ident("begin", Some("begin")), IntType,
+              mutable = false, rest = false),
+            ParamDef(Ident("end", Some("end")), IntType,
+              mutable = false, rest = false)
+          ),
+          ClassType("jl_CharSequence"),
+          {
+            Apply(
+              LoadModule(ClassType("sjsr_RuntimeString$")),
+              Ident("subSequence__T__I__I__jl_CharSequence",
+                Some("subSequence__T__I__I__jl_CharSequence")),
+              List(
+                This()(ThisType),
+                VarRef(Ident("begin", Some("begin")))(IntType),
+                VarRef(Ident("end", Some("end")))(IntType)))(
+              ClassType("jl_CharSequence"))
+          })(OptimizerHints.empty.withInline(true), None)
+      ))(OptimizerHints.empty)
+
+    val hashedClassDef = Hashers.hashClassDef(classDef)
+    val info = generateClassInfo(hashedClassDef)
+
+    (info, hashedClassDef)
+  }
+
+}

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -1,6 +1,7 @@
 SKIP benchmarks/src/resources/scala-js/ScalaJSClassEmitter.scala
 SKIP benchmarks/src/resources/scala-js/GenJsCode.scala
 SKIP benchmarks/src/resources/scala-js/OptimizerCore.scala
+SKIP benchmarks/src/resources/scala-js/JavaLangString.scala
 SKIP benchmarks/src/resources/scala-js/Primality.scala
 SKIP core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
 SKIP https://raw.githubusercontent.com/scala-js/scala-js/5d447c8851abcdf513605fe1f61075e83c22ebe4/project/JavaLangString.scala

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -1,11 +1,14 @@
 package org.scalafmt
 
+import org.scalafmt.util.ExperimentResult
 import org.scalafmt.util.ExperimentResult.Skipped
 import org.scalafmt.util.ExperimentResult.Success
+import org.scalafmt.util.ExperimentResult.Timeout
 import org.scalafmt.util.FilesUtil
 import org.scalafmt.util.FormatAssertions
 import org.scalafmt.util.ScalaProjectsExperiment
 import org.scalafmt.util.ScalacParser
+import org.scalatest.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,25 +16,61 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.meta._
 
+import scala.collection.JavaConversions._
 
-object FormatExperiment extends App with ScalaProjectsExperiment with FormatAssertions {
+
+trait FormatExperiment extends ScalaProjectsExperiment with FormatAssertions {
   override val verbose = false
   override val skipProject: String => Boolean = !_.contains("scala-js/scala-js")
 
+  val awaitMaxDuration =
+    // Can't guarantee performance on Travis
+    if (sys.env.contains("TRAVIS")) Duration(1, "min")
+    // Max on @olafurpg's machine is 5.9s, 2,5 GHz Intel Core i7 Macbook Pro.
+    else Duration(20, "s")
+
+  def ignore(filename: String): Boolean = Seq(
+    "emitter/JSDesugaring.scala"
+  ).exists(filename.contains)
+
   override def runOn(filename: String): Boolean = {
-    val code = FilesUtil.readFile(filename)
-    if (!ScalacParser.checkParseFails(code)) {
-      val startTime = System.nanoTime()
-      val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
-      val formatted = Await.result(f, Duration(10, "s"))
-      assertFormatPreservesAst[Source](code, formatted)
-      print("+")
-      results.add(Success(filename, System.nanoTime() - startTime))
-    } else {
-      results.add(Skipped(filename))
+    if (!ignore(filename)) {
+      val code = FilesUtil.readFile(filename)
+      if (!ScalacParser.checkParseFails(code)) {
+        val startTime = System.nanoTime()
+        val f = Future(ScalaFmt.format_![Source](code, ScalaStyle.Standard))
+        val formatted = Await.result(f, awaitMaxDuration)
+        assertFormatPreservesAst[Source](code, formatted)
+        print("+")
+        results.add(Success(filename, System.nanoTime() - startTime))
+      } else {
+        results.add(Skipped(filename))
+      }
+    }
+    else {
+      false
     }
   }
+}
 
+// TODO(olafur) integration test?
+class FormatExperimentTest extends FunSuite with FormatExperiment {
+
+  def validate(result: ExperimentResult): Unit = result match {
+    case _: Success | _: Timeout  =>
+    case failure =>
+      fail(
+        s"""Unexpected failure:
+            |$failure""".stripMargin)
+  }
+  test("scalafmt formats all files in Scala.js") {
+    runExperiment()
+    results.toIterable.foreach(validate)
+    printResults()
+  }
+}
+
+object FormatExperimentApp extends FormatExperiment with App {
   runExperiment()
   printResults()
 }

--- a/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
+++ b/core/src/test/scala/org/scalafmt/util/ExperimentResult.scala
@@ -4,11 +4,18 @@ import scala.meta.parsers.common.ParseException
 
 sealed abstract class ExperimentResult(fileUrl: String) {
   def key: String
+
   // TODO(olafur) abstract over whether raw or non-raw link.
-//  def details: String = fileUrl
   def details = fileUrl
     .replace("github.com", "raw.githubusercontent.com")
     .replace("/blob/", "/")
+
+  override def toString: String =
+    s"""key=$key
+        |fileUrl=$fileUrl
+        |details=$details
+     """.stripMargin
+
 }
 object ExperimentResult {
   case class Success(fileUrl: String, nanos: Long) extends ExperimentResult(fileUrl) {


### PR DESCRIPTION
This change is potentially dangerous but appears to work.

[info] # Run complete. Total time: 00:03:24
[info]
[info] Benchmark                        Mode  Cnt     Score     Error  Units
[info] GenJsCode.scalafmt               avgt   10  1375.404 ± 203.097  ms/op
[info] GenJsCode.scalariform            avgt   10   238.604 ±  10.338  ms/op
[info] JavaLangString.scalafmt          avgt   10   181.791 ±   3.683  ms/op
[info] JavaLangString.scalariform       avgt   10     6.878 ±   0.769  ms/op
[info] OptimizerCore.scalafmt           avgt   10  1330.836 ±  74.754  ms/op
[info] OptimizerCore.scalariform        avgt   10   235.918 ±  10.049  ms/op
[info] ScalaJSClassEmitter.scalafmt     avgt   10   305.206 ±  44.357  ms/op
[info] ScalaJSClassEmitter.scalariform  avgt   10    37.935 ±   4.010  ms/op