### PR TITLE
Optimizations: roughly 17% improvement

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -31,7 +31,7 @@ class BestFirstSearch(
   import formatOps.runner.optimizer._
 
   /**
-    * Precomputed
+    * Precomputed table of splits for each token.
     */
   val routes: Array[Seq[Split]] = {
     val router = new Router(formatOps)

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -30,7 +30,17 @@ class BestFirstSearch(
   import formatOps._
   import formatOps.runner.optimizer._
 
-  val router = new Router(formatOps)
+  /**
+    * Precomputed
+    */
+  val routes: Array[Seq[Split]] = {
+    val router = new Router(formatOps)
+    val result = Array.newBuilder[Seq[Split]]
+    tokens.foreach { t =>
+      result += router.getSplitsMemo(t)
+    }
+    result.result()
+  }
   val noOptimizations = noOptimizationZones(tree)
   var explored = 0
   var deepestYet = State.start
@@ -201,7 +211,7 @@ class BestFirstSearch(
 
           val splits: Seq[Split] =
             if (curr.formatOff) List(provided(splitToken))
-            else if (splitToken.inside(range)) router.getSplitsMemo(splitToken)
+            else if (splitToken.inside(range)) routes(curr.splits.length)
             else List(provided(splitToken))
 
           val actualSplit = {
@@ -254,7 +264,7 @@ class BestFirstSearch(
     if (state.splits.length == tokens.length) {
       SearchResult(state.splits, reachedEOF = true)
     } else {
-      val nextSplits = router.getSplits(tokens(deepestYet.splits.length))
+      val nextSplits = routes(deepestYet.splits.length)
       val tok = tokens(deepestYet.splits.length)
       val splitsAfterPolicy =
         deepestYet.policy.execute(Decision(tok, nextSplits))

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -44,13 +44,12 @@ object FormatToken {
     */
   def formatTokens(tokens: Tokens): Array[FormatToken] = {
     var left = tokens.head
-    val result = mutable.ArrayBuilder.make[FormatToken]
-    val whitespace = mutable.ArrayBuilder.make[Whitespace]()
+    val result = Array.newBuilder[FormatToken]
+    val whitespace = Vector.newBuilder[Whitespace]
     tokens.toArray.foreach {
       case t: Whitespace => whitespace += t
       case right =>
-        // TODO(olafur) avoid result.toVector
-        val tok = FormatToken(left, right, whitespace.result.toVector)
+        val tok = FormatToken(left, right, whitespace.result)
         result += tok
         left = right
         whitespace.clear()

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -46,7 +46,7 @@ class Router(formatOps: FormatOps) {
   import formatOps._
   import Constants._
 
-  def getSplits(formatToken: FormatToken): Seq[Split] = {
+  private def getSplits(formatToken: FormatToken): Seq[Split] = {
     val leftOwner = owners(formatToken.left)
     val rightOwner = owners(formatToken.right)
     val newlines = newlinesBetween(formatToken.between)

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -58,9 +58,7 @@ object TreeOps {
   }
 
   def getDequeueSpots(tree: Tree): Set[TokenHash] = {
-    val ret =
-      new scala.collection.mutable.SetBuilder[TokenHash, Set[TokenHash]](
-          Set[TokenHash]())
+    val ret = Set.newBuilder[TokenHash]
     tree.tokens.foreach {
       case t: `else` =>
         ret += hash(t)
@@ -70,8 +68,8 @@ object TreeOps {
   }
 
   def getStatementStarts(tree: Tree): Map[TokenHash, Tree] = {
-    val ret = new scala.collection.mutable.MapBuilder[
-        TokenHash, Tree, Map[TokenHash, Tree]](Map[TokenHash, Tree]())
+    val ret = Map.newBuilder[TokenHash, Tree]
+    ret.sizeHint(tree.tokens.length)
 
     def addAll(trees: Seq[Tree]): Unit = {
       trees.foreach { t =>
@@ -126,8 +124,7 @@ object TreeOps {
     * Contains lookup keys in both directions, opening [({ and closing })].
     */
   def getMatchingParentheses(tokens: Tokens): Map[TokenHash, Token] = {
-    val ret = new mutable.MapBuilder[TokenHash, Token, Map[TokenHash, Token]](
-        Map.empty[TokenHash, Token])
+    val ret = Map.newBuilder[TokenHash, Token]
     var stack = List.empty[Token]
     tokens.foreach {
       case open @ (_: `{` | _: `[` | _: `(` | _: Interpolation.Start) =>
@@ -159,9 +156,7 @@ object TreeOps {
     * Creates lookup table from token offset to its closest scala.meta tree.
     */
   def getOwners(tree: Tree): Map[TokenHash, Tree] = {
-    val result = new mutable.MapBuilder[TokenHash, Tree, Map[TokenHash, Tree]](
-        Map.empty[TokenHash, Tree])
-
+    val result = Map.newBuilder[TokenHash, Tree]
     def loop(x: Tree): Unit = {
       x.tokens.foreach { tok =>
         result += hash(tok) -> x

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -72,7 +72,6 @@ trait FormatExperiment extends ScalaProjectsExperiment with FormatAssertions {
             code, ScalafmtStyle.default.copy(alignStripMarginStrings = false))
         .get
       assertNoDiff(formattedSecondTime, formatted, "Idempotency")
-      print("+")
       Success(scalaFile, System.nanoTime() - startTime)
     } else {
       Skipped(scalaFile)


### PR DESCRIPTION
According to JMH micro benchmarks


```
Before:
[info] GenJsCode.scalafmt  avgt   10  1625.856 ± 100.811  ms/op
After:
[info] GenJsCode.scalafmt  avgt   10  1358.511 ± 74.241  ms/op
```