### PR TITLE
Use unmanagedSourceDirectories for sourceDirectories

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -415,16 +415,7 @@
        scalafmt update.
 
      @sect{The SBT plugin doesn't format anything}
-       @ul
-         @li
-           Run @code("reload"), @code("clean") and then try again.
-         @li
-           If that doesn't work. Try adding this to your build.sbt:
-
-       @hl.scala
-         sourceDirectories in (Compile,
-                               org.scalafmt.sbt.ScalaFmtPlugin.autoImport.hasScalafmt) :=
-           (sourceDirectories in Compile).value
+       Run @code("reload"), @code("clean") and then try again.
 
   @sect{Changelog}
     @sect{0.2.3}

--- a/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
+++ b/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
@@ -84,7 +84,7 @@ object ScalaFmtPlugin extends AutoPlugin {
 
   def configScalafmtSettings: Seq[Setting[_]] =
     List(
-        (sourceDirectories in hasScalafmt) := List(scalaSource.value),
+        (sourceDirectories in hasScalafmt) := unmanagedSourceDirectories.value,
         includeFilter in Global in hasScalafmt := "*.scala",
         scalafmtConfig in Global := None,
         hasScalafmt := {


### PR DESCRIPTION
`sourceDirectories in hasScalafmt` is currently initialized with
`List(scalaSource.value)` which means that scalafmt only looks into
one source directory per project. But a typical Scala.js cross
project has at least two source directories js/ and shared/ or
jvm/ and shared/. Sometimes there are also multiple source
directories for different Scala versions.

This change initializes `sourceDirectories in hasScalafmt` with
`unmanagedSourceDirectories` which contains all source directories
with manually created sources. In my tests
`unmanagedSourceDirectories` always includes `scalaSource`.

Here are for example both settings for typelevel/cats:

> coreJVM/scalaSource
[info] cats/core/.jvm/src/main/scala

> coreJVM/unmanagedSourceDirectories
[info] List(
  cats/core/.jvm/src/main/scala-2.11,
  cats/core/.jvm/src/main/scala,
  cats/core/.jvm/src/main/java,
  cats/core/src/main/scala)

And since cats has no sources in cats/core/.jvm/src/main/scala,
scalafmt won't format anything.