### PR TITLE
0.2.4 rc1

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -65,9 +65,9 @@ object Cli {
       extends InputMethod(code)
 
   implicit val styleReads: Read[ScalafmtStyle] = Read.reads { styleName =>
-    ScalafmtStyle.availableStyles.getOrElse(styleName, {
+    ScalafmtStyle.availableStyles.getOrElse(styleName.toLowerCase, {
       throw new IllegalArgumentException(
-          s"Unknown style name $styleName. Expected one of ${ScalafmtStyle.availableStyles.keys}")
+          s"Unknown style name $styleName. Expected one of ${ScalafmtStyle.activeStyles.keys}")
     })
   }
 
@@ -107,7 +107,7 @@ object Cli {
     note(s"\nStyle configuration options:")
     opt[ScalafmtStyle]('s', "style") action { (style, c) =>
       c.copy(style = style)
-    } text s"base style, must be one of: ${ScalafmtStyle.availableStyles.keys}"
+    } text s"base style, must be one of: ${ScalafmtStyle.activeStyles.keys}"
     opt[Int]("maxColumn") action { (col, c) =>
       c.copy(style = c.style.copy(maxColumn = col))
     } text s"See ScalafmtConfig scaladoc."

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -99,4 +99,8 @@ class CliTest extends FunSuite with DiffAssertions {
     val obtained = FileOps.readFile(tmpFile.toString)
     assertNoDiff(obtained, unformatted)
   }
+  test("--style Scala.js is OK") {
+    val obtained = Cli.parser.parse(Seq("--style", "Scala.js"), Cli.Config.default)
+    assert(obtained.get.style == ScalafmtStyle.scalaJs)
+  }
 }

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -108,10 +108,11 @@ object ScalafmtStyle {
         default,
         defaultWithAlign
     )
-  val availableStyles =
+  val availableStyles = {
     activeStyles ++ name2style(
         scalaJs
     )
+  }.map { case (k, v) => k.toLowerCase -> v }
 
   // TODO(olafur) move these elsewhere.
   val testing = default.copy(alignStripMarginStrings = false)

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -88,7 +88,8 @@ object ScalafmtStyle {
       noNewlinesBeforeJsNative = true,
       binPackArguments = true,
       binPackParameters = true,
-      allowNewlineBeforeColonInMassiveReturnTypes = false
+      allowNewlineBeforeColonInMassiveReturnTypes = false,
+      scalaDocs = false
   )
 
   // TODO(olafur) parameterize
@@ -99,11 +100,14 @@ object ScalafmtStyle {
   /**
     * Ready styles provided by scalafmt.
     */
-  val availableStyles = name2style(
-      default,
-      defaultWithAlign,
-      scalaJs
-  )
+  val availableStyles =
+    name2style(
+        default,
+        defaultWithAlign,
+        scalaJs // TODO(olafur) remove in 0.3, #227
+    ) ++ Map(
+        "scala.js" -> scalaJs
+    )
 
   // TODO(olafur) move these elsewhere.
   val testing = default.copy(alignStripMarginStrings = false)

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -48,7 +48,8 @@ case class ScalafmtStyle(
     spacesInImportCurlyBrackets: Boolean,
     allowNewlineBeforeColonInMassiveReturnTypes: Boolean,
     binPackParentConstructors: Boolean,
-    alignByArrowEnumeratorGenerator: Boolean
+    alignByArrowEnumeratorGenerator: Boolean,
+    alignByIfWhileOpenParen: Boolean
 ) {
   lazy val alignMap: Map[String, Regex] =
     alignTokens.map(x => x.code -> x.owner.r).toMap
@@ -74,7 +75,8 @@ object ScalafmtStyle {
       spacesInImportCurlyBrackets = false,
       allowNewlineBeforeColonInMassiveReturnTypes = true,
       binPackParentConstructors = false,
-      alignByArrowEnumeratorGenerator = true
+      alignByArrowEnumeratorGenerator = true,
+      alignByIfWhileOpenParen = true
   )
 
   val defaultWithAlign = default.copy(alignTokens = AlignToken.default)
@@ -93,7 +95,8 @@ object ScalafmtStyle {
       allowNewlineBeforeColonInMassiveReturnTypes = false,
       scalaDocs = false,
       binPackParentConstructors = true,
-      alignByArrowEnumeratorGenerator = false
+      alignByArrowEnumeratorGenerator = false,
+      alignByIfWhileOpenParen = false
   )
 
   // TODO(olafur) parameterize

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -32,8 +32,6 @@ import sourcecode.Text
   *                                   call site.
   * @param continuationIndentDefnSite Indent width for line continuation at
   *                                   definition/declaration site.
-  * @param continuationIndentDefnSite Indent width for line continuation at
-  *                                   definition/declaration site.
   */
 case class ScalafmtStyle(
     maxColumn: Int,
@@ -48,7 +46,8 @@ case class ScalafmtStyle(
     continuationIndentDefnSite: Int,
     alignTokens: Set[AlignToken],
     spacesInImportCurlyBrackets: Boolean,
-    allowNewlineBeforeColonInMassiveReturnTypes: Boolean
+    allowNewlineBeforeColonInMassiveReturnTypes: Boolean,
+    binPackParentConstructors: Boolean
 ) {
   lazy val alignMap: Map[String, Regex] =
     alignTokens.map(x => x.code -> x.owner.r).toMap
@@ -72,7 +71,8 @@ object ScalafmtStyle {
       continuationIndentDefnSite = 4,
       alignTokens = Set.empty[AlignToken],
       spacesInImportCurlyBrackets = false,
-      allowNewlineBeforeColonInMassiveReturnTypes = true
+      allowNewlineBeforeColonInMassiveReturnTypes = true,
+      binPackParentConstructors = false
   )
 
   val defaultWithAlign = default.copy(alignTokens = AlignToken.default)
@@ -89,7 +89,8 @@ object ScalafmtStyle {
       binPackArguments = true,
       binPackParameters = true,
       allowNewlineBeforeColonInMassiveReturnTypes = false,
-      scalaDocs = false
+      scalaDocs = false,
+      binPackParentConstructors = true
   )
 
   // TODO(olafur) parameterize

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -101,13 +101,16 @@ object ScalafmtStyle {
   /**
     * Ready styles provided by scalafmt.
     */
-  val availableStyles =
-    name2style(
+  val activeStyles =
+    Map(
+        "Scala.js" -> scalaJs
+    ) ++ name2style(
         default,
-        defaultWithAlign,
-        scalaJs // TODO(olafur) remove in 0.3, #227
-    ) ++ Map(
-        "scala.js" -> scalaJs
+        defaultWithAlign
+    )
+  val availableStyles =
+    activeStyles ++ name2style(
+        scalaJs
     )
 
   // TODO(olafur) move these elsewhere.

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -47,7 +47,8 @@ case class ScalafmtStyle(
     alignTokens: Set[AlignToken],
     spacesInImportCurlyBrackets: Boolean,
     allowNewlineBeforeColonInMassiveReturnTypes: Boolean,
-    binPackParentConstructors: Boolean
+    binPackParentConstructors: Boolean,
+    alignByArrowEnumeratorGenerator: Boolean
 ) {
   lazy val alignMap: Map[String, Regex] =
     alignTokens.map(x => x.code -> x.owner.r).toMap
@@ -72,7 +73,8 @@ object ScalafmtStyle {
       alignTokens = Set.empty[AlignToken],
       spacesInImportCurlyBrackets = false,
       allowNewlineBeforeColonInMassiveReturnTypes = true,
-      binPackParentConstructors = false
+      binPackParentConstructors = false,
+      alignByArrowEnumeratorGenerator = true
   )
 
   val defaultWithAlign = default.copy(alignTokens = AlignToken.default)
@@ -90,7 +92,8 @@ object ScalafmtStyle {
       binPackParameters = true,
       allowNewlineBeforeColonInMassiveReturnTypes = false,
       scalaDocs = false,
-      binPackParentConstructors = true
+      binPackParentConstructors = true,
+      alignByArrowEnumeratorGenerator = false
   )
 
   // TODO(olafur) parameterize

--- a/core/src/main/scala/org/scalafmt/Versions.scala
+++ b/core/src/main/scala/org/scalafmt/Versions.scala
@@ -5,7 +5,7 @@ package org.scalafmt
   */
 object Versions {
   // Nightly, used in CLI, build.sbt, etc.
-  val nightly = "0.2.3"
+  val nightly = "0.2.4-RC1"
   // Stable, used in official user docs.
   val stable = "0.2.3"
 }

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -285,7 +285,8 @@ class FormatOps(val tree: Tree,
     */
   def getSelectsLastToken(dot: `.`): Token = {
     var curr = next(leftTok2tok(dot))
-    while (isOpenApply(curr.right, includeCurly = true)) {
+    while (isOpenApply(curr.right, includeCurly = true) &&
+    !statementStarts.contains(hash(curr.right))) {
       curr = leftTok2tok(matchingParentheses(hash(curr.right)))
     }
     curr.left

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -135,10 +135,7 @@ class FormatWriter(formatOps: FormatOps) {
         case t => t.code
       }
       style.alignMap.get(code).map { ownerRegexp =>
-        val owner = owners(token) match {
-          case name: Term.Name if name.parent.isDefined => name.parent.get
-          case x => x
-        }
+        val owner = getAlignOwner(location.formatToken)
         ownerRegexp.findFirstIn(owner.getClass.getName).isDefined
       }
     }.getOrElse(false)
@@ -153,7 +150,13 @@ class FormatWriter(formatOps: FormatOps) {
       // TODO(olafur) should this be part of owners?
       case FormatToken(x, c: Comment, _) if isInlineComment(c) =>
         owners(x)
-      case FormatToken(_, r, _) => owners(r)
+      case FormatToken(_, r, _) =>
+        owners(r) match {
+          case name: Term.Name
+              if name.parent.exists(_.isInstanceOf[Term.ApplyInfix]) =>
+            name.parent.get
+          case x => x
+        }
     }
 
   private def columnsMatch(a: Array[FormatLocation],

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -123,7 +123,9 @@ class FormatWriter(formatOps: FormatOps) {
         }
         callback.apply(state, tok, whitespace)
     }
-    if (debug) logger.debug(s"Total cost: ${locations.last.state.cost}")
+    locations.lastOption.foreach { location =>
+      if (debug) logger.debug(s"Total cost: ${location.state.cost}")
+    }
   }
 
   private def isCandidate(

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -699,7 +699,7 @@ class Router(formatOps: FormatOps) {
             Space // Inline comment will force newline later.
           else Newline
         Seq(
-            Split(Space, 0, ignoreIf = attachedComment)
+            Split(Space, 0, ignoreIf = attachedComment || newlines > 0)
               .withIndent(2, expire, Left)
               .withPolicy(SingleLineBlock(expire)),
             Split(newlineModification, 1).withIndent(2, expire, Left)
@@ -724,7 +724,10 @@ class Router(formatOps: FormatOps) {
           case x => throw new UnexpectedTree[Term.If](x)
         }
         Seq(
-            Split(Space, 0, policy = SingleLineBlock(expire)),
+            Split(Space,
+                  0,
+                  policy = SingleLineBlock(expire),
+                  ignoreIf = newlines > 0),
             Split(Newline, 1).withIndent(2, expire, Left)
         )
 

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -448,11 +448,13 @@ class Router(formatOps: FormatOps) {
           charactersInside <= style.maxColumn
 
         val expirationToken: Token =
-          if (isDefnSite(leftOwner)) defnSiteLastToken(leftOwner)
+          if (isDefnSite(leftOwner) && !isBracket) defnSiteLastToken(leftOwner)
           else rhsOptimalToken(leftTok2tok(close))
+//          rhsOptimalToken(leftTok2tok(close))
 
         val tooManyArguments = args.length > 100
 
+//        logger.elem(formatToken, expirationToken)
         Seq(
             Split(modification,
                   0,
@@ -482,7 +484,7 @@ class Router(formatOps: FormatOps) {
           )
 
       // Closing def site ): ReturnType
-      case FormatToken(close: `)`, colon: `:`, _)
+      case FormatToken(_, colon: `:`, _)
           if style.allowNewlineBeforeColonInMassiveReturnTypes &&
           defDefReturnType(leftOwner).isDefined =>
         val expire = lastToken(defDefReturnType(rightOwner).get)

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -193,10 +193,12 @@ class Router(formatOps: FormatOps) {
           if leftOwner.isInstanceOf[Term.Function] =>
         val endOfFunction = functionExpire(
             leftOwner.asInstanceOf[Term.Function])
+        val hasBlock = nextNonComment(formatToken).right.isInstanceOf[`{`]
         Seq(
             Split(Space, 0, ignoreIf = isInlineComment(right))
               .withPolicy(SingleLineBlock(endOfFunction)),
-            Split(Newline, 1 + nestedApplies(leftOwner))
+            Split(Space, 0, ignoreIf = !hasBlock),
+            Split(Newline, 1 + nestedApplies(leftOwner), ignoreIf = hasBlock)
               .withIndent(2, endOfFunction, Right)
         )
       // Case arrow

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -543,10 +543,14 @@ class Router(formatOps: FormatOps) {
       // an infix application or an if. For example, this is allowed:
       // val x = function(a,
       //                  b)
-      case FormatToken(tok: `=`, right, between)
-          if leftOwner.isInstanceOf[Defn.Val] ||
-          leftOwner.isInstanceOf[Defn.Var] =>
+      case FormatToken(tok: `=`, right, between) if (leftOwner match {
+            case _: Defn.Val | _: Defn.Var | _: Term.Update | _: Term.Assign =>
+              true
+            case _ => false
+          }) =>
         val rhs: Tree = leftOwner match {
+          case l: Term.Assign => l.rhs
+          case l: Term.Update => l.rhs
           case l: Defn.Val => l.rhs
           case r: Defn.Var =>
             r.rhs match {

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -529,7 +529,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(left: Ident, _: `:`, _)
           if rightOwner.isInstanceOf[Type.Param] =>
         Seq(
-            Split(Space, 0)
+            Split(NoSplit, 0)
         )
       case FormatToken(left: Ident, _: `:`, _) =>
         Seq(

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -901,18 +901,18 @@ class Router(formatOps: FormatOps) {
           if rightOwner.isInstanceOf[Enumerator.Guard] =>
         Seq(
             // Either everything fits in one line or break on =>
-            Split(Space, 0),
-            Split(Newline, 1).withIndent(4, leftOwner.tokens.last, Left)
+            Split(Space, 0, ignoreIf = newlines > 0),
+            Split(Newline, 1)
         )
       case tok @ FormatToken(arrow: `<-`, _, _)
           if leftOwner.isInstanceOf[Enumerator.Generator] =>
-        val lastToken =
-          findSiblingGuard(leftOwner.asInstanceOf[Enumerator.Generator])
-            .map(_.tokens.last)
-            .getOrElse(rightOwner.tokens.last)
+        val lastToken = leftOwner.tokens.last
+        val indent: Length =
+          if (style.alignByArrowEnumeratorGenerator) StateColumn
+          else Num(0)
         Seq(
             // Either everything fits in one line or break on =>
-            Split(Space, 0).withIndent(StateColumn, lastToken, Left)
+            Split(Space, 0).withIndent(indent, lastToken, Left)
         )
       case tok @ FormatToken(_: `yield`, right, _)
           if leftOwner.isInstanceOf[Term.ForYield] &&

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -678,12 +678,18 @@ class Router(formatOps: FormatOps) {
             }, expire.end))
         )
       // If
-      case FormatToken(open: `(`, _, _) if leftOwner.isInstanceOf[Term.If] =>
+      case FormatToken(open: `(`, _, _) if (leftOwner match {
+            case _: Term.If | _: Term.While => true
+            case _ => false
+          }) =>
         val close = matchingParentheses(hash(open))
         val penalizeNewlines = penalizeNewlineByNesting(open, close)
+        val indent: Length =
+          if (style.alignByIfWhileOpenParen) StateColumn
+          else style.continuationIndentCallSite
         Seq(
             Split(NoSplit, 0)
-              .withIndent(StateColumn, close, Left)
+              .withIndent(indent, close, Left)
               .withPolicy(penalizeNewlines)
           )
       case FormatToken(close: `)`, right, between)

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -3,3 +3,6 @@ SKIP https://raw.githubusercontent.com/akka/akka/3698928fbdaa8fef8e2037fbc51887a
 SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
 SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
 SKIP https://raw.githubusercontent.com/apache/spark/2c5b18fb0fdeabd378dd97e91f72d1eac4e21cc7/project/MimaExcludes.scala
+SKIP https://raw.githubusercontent.com/scala-js/scala-js/8663c8060ca96a51bfc1f87f2f3f30babbeadbc3/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+SKIP https://raw.githubusercontent.com/akka/akka/3698928fbdaa8fef8e2037fbc51887ab60addefb/project/AkkaBuild.scala
+SKIP https://raw.githubusercontent.com/twitter/scalding/7759d9c399896fc4c54be0f2406e047e030d8586/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -320,16 +320,24 @@ val a     = function(1, b)
 val aaaaa = function(1, b)
 val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
     1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-<<< SKIP infix owner
+<<< infix owner
    Ok(Json.obj(
- -      "api" -> Json.obj(
- -        "current" -> api.currentVersion,
- -        "olds" -> api.oldVersions.map { old =>
- -          Json.obj(
- -            "version" -> old.version,
- -            "deprecatedAt" -> old.deprecatedAt,
- -            "unsupportedAt" -> old.unsupportedAt)
- -        })
- -    )) as JSON
+       "api" -> Json.obj(
+         "current" -> api.currentVersion,
+         "olds" -> api.oldVersions.map { old =>
+           Json.obj(
+             "version" -> old.version,
+             "deprecatedAt" -> old.deprecatedAt,
+             "unsupportedAt" -> old.unsupportedAt)
+         })
+     )) as JSON
 >>>
-x
+Ok(
+    Json.obj(
+        "api" -> Json.obj("current" -> api.currentVersion,
+                          "olds" -> api.oldVersions.map { old =>
+                        Json.obj("version"       -> old.version,
+                                 "deprecatedAt"  -> old.deprecatedAt,
+                                 "unsupportedAt" -> old.unsupportedAt)
+                      })
+    )) as JSON

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -320,4 +320,16 @@ val a     = function(1, b)
 val aaaaa = function(1, b)
 val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
     1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-
+<<< SKIP infix owner
+   Ok(Json.obj(
+ -      "api" -> Json.obj(
+ -        "current" -> api.currentVersion,
+ -        "olds" -> api.oldVersions.map { old =>
+ -          Json.obj(
+ -            "version" -> old.version,
+ -            "deprecatedAt" -> old.deprecatedAt,
+ -            "unsupportedAt" -> old.unsupportedAt)
+ -        })
+ -    )) as JSON
+>>>
+x

--- a/core/src/test/resources/default/Advanced.stat
+++ b/core/src/test/resources/default/Advanced.stat
@@ -216,8 +216,10 @@ callStatement = js.If(genIsInstanceOf(callTrg, rtClass.tpe), {
                                     castCallTrg :: arguments,
                                     toIRType(retTpe))
       // Box the result of the implementing method if required
-      if (isPrimitiveValueType(retTpe)) makePrimitiveBox(rawApply, retTpe)
-      else rawApply
+      if (isPrimitiveValueType(retTpe))
+        makePrimitiveBox(rawApply, retTpe)
+      else
+        rawApply
     } else {
       val reflBoxClassPatched = {
 

--- a/core/src/test/resources/default/Advanced.stat
+++ b/core/src/test/resources/default/Advanced.stat
@@ -435,11 +435,12 @@ val createIsArrayOfStat = {
 >>>
 js.Block(arrayDepthVarDef, js.Return {
   // Array[A] </: Array[Array[A]]
-  !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
-  (// Array[Array[A]] <: Array[Object]
+  !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) && (
+      // Array[Array[A]] <: Array[Object]
       js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
       // Array[Int] </: Array[Object]
-      !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
+      !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive")
+  )
 })
 <<< Js.Function
 js.Function(List(objParam, depthParam), js.Return {

--- a/core/src/test/resources/default/Apply.stat
+++ b/core/src/test/resources/default/Apply.stat
@@ -230,8 +230,7 @@ val configsWithAlternatives = Map[String, Seq[AlternateConfig]](
         translation = s => s"${s.toLong * 10}s")),
     "spark.reducer.maxSizeInFlight" -> Seq(
       AlternateConfig("spark.reducer.maxMbInFlight", "1.4")),
-    "spark.kryoserializer.buffer" ->
-        Seq(AlternateConfig("spark.kryoserializer.buffer.mb", "1.4",
+    "spark.kryoserializer.buffer" -> Seq(AlternateConfig("spark.kryoserializer.buffer.mb", "1.4",
           translation = s => s"${(s.toDouble * 1000).toInt}k")),
     "spark.yarn.jars" -> Seq(
       AlternateConfig("spark.yarn.jar", "2.0"))

--- a/core/src/test/resources/default/Apply.stat
+++ b/core/src/test/resources/default/Apply.stat
@@ -374,17 +374,20 @@ implicit class IterableW[+A](it: JSIterable[A]) {
         it.asInstanceOf[IteratorMethodAccess]
           .bracketCall[JSIterator[A]](iteratorSymbol)())
 }
-<<< SKIP => {
-+        foo.fold(
-+            err =>
-+              {
-+                logger.warn(s"Malformed request: $err\n${req.body}")
-+                BadRequest(jsonError(JsError toJson err)).fuccess
-+            },
-+            data => data)
+<<< => {, #224
+        foo.fold(
+            err =>
+              {
+                logger.warn(s"Malformed request: $err\n${req.body}")
+                BadRequest(jsonError(JsError toJson err)).fuccess
+            },
+            data => data)
 >>>
-x
->>> SKIP indent cats
+foo.fold(err => {
+  logger.warn(s"Malformed request: $err\n${req.body}")
+  BadRequest(jsonError(JsError toJson err)).fuccess
+}, data => data)
+<<< SKIP indent cats
 -    XorT(F.flatMap(fea.value) {
 -      case Xor.Left(e) => f(e).value
 -      case r @ Xor.Right(_) => F.pure(r)

--- a/core/src/test/resources/default/ApplyInfix.stat
+++ b/core/src/test/resources/default/ApplyInfix.stat
@@ -48,3 +48,48 @@ lelem + relem + "{1,4}:" + ipv4 + "|" +
 "::" + lelem + "{1,5}" + ipv4 +
 // ::2:3:4:5:10.0.0.1    ::5:10.0.0.1         ::10.0.0.1
 ")(?:%[0-9a-z]+)?"
+<<< infix should stay #219
+      inits.map(materializer.materialize(_).toString) ++
+      libs.map(dep => materializer.materialize(dep.lib).toString) :+
+      code.path
+>>>
+inits.map(materializer.materialize(_).toString) ++
+libs.map(dep => materializer.materialize(dep.lib).toString) :+
+code.path
+<<< json play parse
+implicit val locationWrites: Writes[Location] = (
+  (JsPath \ "lat").write[Double] and
+  (JsPath \ "long").write[Double]
+)(unlift(Location.unapply))
+>>>
+implicit val locationWrites: Writes[Location] = (
+    (JsPath \ "lat").write[Double] and
+    (JsPath \ "long").write[Double]
+)(unlift(Location.unapply))
+<<< lila #219
+      (granted | isGranted(_.ModerateForum)) fold (
+        a,
+        fuccess(Forbidden("You cannot post to this category"))
+      )
+>>>
+(granted | isGranted(_.ModerateForum)) fold (
+    a, fuccess(Forbidden("You cannot post to this category"))
+)
+<<< lila 2 #219
+    private[controllers] def doClose(user: UserModel) =
+     (UserRepo disable user) >>-
+       env.onlineUserIdMemo.remove(user.id) >>
+       relationEnv.api.unfollowAll(user.id) >>
+       Env.team.api.quitAll(user.id) >>-
+       Env.challenge.api.removeByUserId(user.id) >>-
+       Env.tournament.api.withdrawAll(user) >>
+       (Env.security disconnect user.id)
+>>>
+private[controllers] def doClose(user: UserModel) =
+  (UserRepo disable user) >>-
+  env.onlineUserIdMemo.remove(user.id) >>
+  relationEnv.api.unfollowAll(user.id) >>
+  Env.team.api.quitAll(user.id) >>-
+  Env.challenge.api.removeByUserId(user.id) >>-
+  Env.tournament.api.withdrawAll(user) >>
+  (Env.security disconnect user.id)

--- a/core/src/test/resources/default/Case.stat
+++ b/core/src/test/resources/default/Case.stat
@@ -21,8 +21,7 @@ List(Split(Space, 0).withPolicy {
                     case nl if nl.modification.isNewline =>
                       val result =
                         if (t.right.isInstanceOf[`if`] &&
-                            owners(t.right) == owner)
-                          nl
+                            owners(t.right) == owner) nl
                         else nl.withPenalty(1)
                       result.withPolicy(breakOnArrow)
                     case x => x

--- a/core/src/test/resources/default/Class.stat
+++ b/core/src/test/resources/default/Class.stat
@@ -22,7 +22,8 @@ case class State(cost: Int,
                  indentation: Int,
                  indents: Vector[Push],
                  column: Int)
-    extends Ordered[State] with ScalaFmtLogger
+    extends Ordered[State]
+    with ScalaFmtLogger
 <<< With targs
 case class Indent[ T <: Length] (length: T, expire: Token, expiresAt: ExpiresOn)
 >>>

--- a/core/src/test/resources/default/DefDef.stat
+++ b/core/src/test/resources/default/DefDef.stat
@@ -62,9 +62,9 @@ def groupBy[K, T, G, P](
 <<< slick groupBy 2
   def groupBy[K, T, G, P](f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G], vshape: Shape[_ <: FlatShapeLevel, E, _, P]): Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC, (T, Query[P, U, Seq]), (T, Query[P, U, Seq])]
 >>>
-def groupBy[K, T, G, P](
-    f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G],
-               vshape: Shape[_ <: FlatShapeLevel, E, _, P])
+def groupBy[K, T, G, P](f: E => K)(
+    implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G],
+    vshape: Shape[_ <: FlatShapeLevel, E, _, P])
   : Query[(G, Query[P, U, Seq]),
           (T, Query[P, U, Seq]),
           CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC,
@@ -185,4 +185,13 @@ implicit def validatedInstances[E](implicit E: Semigroup[E])
       indent: Length): PartialFunction[Decision, Decision] = {
     println("hello")
   }
+}
+<<< bad newline #198
+object a {
+  override def composeWithFunctor[G[_]: Functor]: Functor[Lambda[X => F[G[X]]]] = compose[G]
+  }
+>>>
+object a {
+  override def composeWithFunctor[G[_]: Functor]
+    : Functor[Lambda[X => F[G[X]]]] = compose[G]
 }

--- a/core/src/test/resources/default/DefDef.stat
+++ b/core/src/test/resources/default/DefDef.stat
@@ -19,7 +19,7 @@ object a {
 <<< context bound
 def addDefn[T <: Keyword: ClassTag](mods: Seq[Mod], tree: Tree): Unit
 >>>
-def addDefn[T <: Keyword : ClassTag](mods: Seq[Mod], tree: Tree): Unit
+def addDefn[T <: Keyword: ClassTag](mods: Seq[Mod], tree: Tree): Unit
 <<< crazy signature
 private def withNewLocalDefs(bindings: List[Binding]) (buildInner:(List[
         LocalDef],

--- a/core/src/test/resources/default/If.stat
+++ b/core/src/test/resources/default/If.stat
@@ -106,17 +106,15 @@ object a {
     }
   }
 }
-<<< SKIP while condition is like if
+<<< while condition is like if
     while (!hasReachedEof(curr) &&
     !statementStarts.contains(hash(tokens(curr.splits.length).left))) {
-      val tok = tokens(curr.splits.length)
-      curr = State.next(curr, style, provided(tok), tok)
+      foo
     }
 >>>
 while (!hasReachedEof(curr) &&
        !statementStarts.contains(hash(tokens(curr.splits.length).left))) {
-  val tok = tokens(curr.splits.length)
-  curr = State.next(curr, style, provided(tok), tok)
+  foo
 }
 <<< return
       if (fullInfo)

--- a/core/src/test/resources/default/If.stat
+++ b/core/src/test/resources/default/If.stat
@@ -113,7 +113,11 @@ object a {
       curr = State.next(curr, style, provided(tok), tok)
     }
 >>>
-x
+while (!hasReachedEof(curr) &&
+       !statementStarts.contains(hash(tokens(curr.splits.length).left))) {
+  val tok = tokens(curr.splits.length)
+  curr = State.next(curr, style, provided(tok), tok)
+}
 <<< return
       if (fullInfo)
         return (candidates.toSeq.map(c => forMap(c, withLocalTypeInference = false, checkFast = false)) ++
@@ -121,9 +125,10 @@ x
           flatMap(_.toSeq).map(_._1).toSet
 >>>
 if (fullInfo)
-  return (candidates.toSeq.map(c =>
-            forMap(c, withLocalTypeInference = false, checkFast = false)) ++ candidates.toSeq
-        .map(c => forMap(c, withLocalTypeInference = true, checkFast = false)))
+  return (candidates.toSeq.map(
+          c => forMap(c, withLocalTypeInference = false, checkFast = false)) ++
+      candidates.toSeq.map(
+          c => forMap(c, withLocalTypeInference = true, checkFast = false)))
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet

--- a/core/src/test/resources/default/Lambda.stat
+++ b/core/src/test/resources/default/Lambda.stat
@@ -44,3 +44,27 @@ def withDedicatedVar: Unit = {
     }
   }
 }
+<<< nested lambdas #195
+(excty, { focus: Focus =>
+      val enter = symopt.map { sym =>
+        val cast = focus withOp Op.As(excty, exc.value)
+        curEnv.enter(sym, cast.value)
+        cast
+      }.getOrElse(focus)
+      val begin = enter withOp Nrt.call(Nrt.begin_catch, excwrap.value)
+      val res   = genExpr(body, begin)
+      val end   = res withOp Nrt.call(Nrt.end_catch)
+      end withValue res.value
+    })
+>>>
+(excty, { focus: Focus =>
+  val enter = symopt.map { sym =>
+    val cast = focus withOp Op.As(excty, exc.value)
+    curEnv.enter(sym, cast.value)
+    cast
+  }.getOrElse(focus)
+  val begin = enter withOp Nrt.call(Nrt.begin_catch, excwrap.value)
+  val res = genExpr(body, begin)
+  val end = res withOp Nrt.call(Nrt.end_catch)
+  end withValue res.value
+})

--- a/core/src/test/resources/default/Lambda.stat
+++ b/core/src/test/resources/default/Lambda.stat
@@ -25,3 +25,22 @@ def withDedicatedVar: Unit = {
     })
   }
 }
+<<< missing 2 indent #209
+{{ {
+ preloads.foreach{p =>
+      cache.getOrElseUpdate(p,
+        futureStreams.map{r => r.streams.get(p)})
+    }
+    }}}
+>>>
+{
+  {
+    {
+      preloads.foreach { p =>
+        cache.getOrElseUpdate(p, futureStreams.map { r =>
+          r.streams.get(p)
+        })
+      }
+    }
+  }
+}

--- a/core/src/test/resources/default/Select.stat
+++ b/core/src/test/resources/default/Select.stat
@@ -213,3 +213,21 @@ class TypedPipeJoinWithDescriptionJob {
     .values
     .write(TypedTsv[((Int, String), Option[Boolean])]("output"))
 }
+<<< chain indent expire #194
+{
+ (playerStore
+      .updatePlayer(_: String, _: PlayerUpdate))
+      .expects("123", PlayerUpdate(active = Some(true)))
+      .returning(Future.value(Unit))
+    (cache.delete _).expects("123")
+  Await.result(service.setActive("123", active = true))
+}
+>>>
+{
+  (playerStore
+    .updatePlayer(_: String, _: PlayerUpdate))
+    .expects("123", PlayerUpdate(active = Some(true)))
+    .returning(Future.value(Unit))
+  (cache.delete _).expects("123")
+  Await.result(service.setActive("123", active = true))
+}

--- a/core/src/test/resources/default/Trait.stat
+++ b/core/src/test/resources/default/Trait.stat
@@ -54,3 +54,21 @@ trait AllSyntax
     with ContravariantSyntax
     with EitherSyntax
     with EqSyntax
+<<< nested with
+trait Grouped[K, +V]
+  extends KeyedListLike[K, V, UnsortedGrouped]
+  with HashJoinable[K, V]
+  with Sortable[V, ({ type t[+x] = SortedGrouped[K, x] with Reversable[SortedGrouped[K, x]] })#t]
+  with WithReducers[Grouped[K, V]]
+  with WithDescription[Grouped[K, V]]
+>>>
+trait Grouped[K, +V]
+    extends KeyedListLike[K, V, UnsortedGrouped]
+    with HashJoinable[K, V]
+    with Sortable[V,
+                  ({
+                    type t[+x] =
+                      SortedGrouped[K, x] with Reversable[SortedGrouped[K, x]]
+                  })#t]
+    with WithReducers[Grouped[K, V]]
+    with WithDescription[Grouped[K, V]]

--- a/core/src/test/resources/default/Trait.stat
+++ b/core/src/test/resources/default/Trait.stat
@@ -3,18 +3,54 @@
 trait WorkerNavigator extends NavigatorID with NavigatorOnLine with NavigatorLanguage
 >>>
 trait WorkerNavigator
-    extends NavigatorID with NavigatorOnLine with NavigatorLanguage
+    extends NavigatorID
+    with NavigatorOnLine
+    with NavigatorLanguage
 <<< break on extends object #109
 object WorkerNavigator extends NavigatorID with NavigatorOnLine with NavigatorLanguage
 >>>
 object WorkerNavigator
-    extends NavigatorID with NavigatorOnLine with NavigatorLanguage
+    extends NavigatorID
+    with NavigatorOnLine
+    with NavigatorLanguage
 <<< break on extends object with curlies #109
 object WorkerNavigator extends NavigatorID with NavigatorOnLine with NavigatorLanguage {
   val x = 1
 }
 >>>
 object WorkerNavigator
-    extends NavigatorID with NavigatorOnLine with NavigatorLanguage {
+    extends NavigatorID
+    with NavigatorOnLine
+    with NavigatorLanguage {
   val x = 1
 }
+<<< parent constructors align #200
+trait AllSyntax
+    extends ApplicativeSyntax
+    with ApplicativeErrorSyntax
+    with ApplySyntax
+    with BifunctorSyntax
+    with BifoldableSyntax
+    with BitraverseSyntax
+    with CartesianSyntax
+    with CoflatMapSyntax
+    with ComonadSyntax
+    with ComposeSyntax
+    with ContravariantSyntax
+    with EitherSyntax
+    with EqSyntax
+>>>
+trait AllSyntax
+    extends ApplicativeSyntax
+    with ApplicativeErrorSyntax
+    with ApplySyntax
+    with BifunctorSyntax
+    with BifoldableSyntax
+    with BitraverseSyntax
+    with CartesianSyntax
+    with CoflatMapSyntax
+    with ComonadSyntax
+    with ComposeSyntax
+    with ContravariantSyntax
+    with EitherSyntax
+    with EqSyntax

--- a/core/src/test/resources/default/TypeArguments.stat
+++ b/core/src/test/resources/default/TypeArguments.stat
@@ -14,9 +14,9 @@ def myMethod[F[_]:Functor, G[_]:Applicative, A:DecodeJson:TypeTag:Meta, B:Decode
 >>>
 def myMethod[F[_]: Functor,
              G[_]: Applicative,
-             A : DecodeJson : TypeTag : Meta,
-             B : DecodeJson : TypeTag : Meta,
-             C : Meta : TypeTag : UrlParameterEncode](gfa: G[F[A]], b: B)(
+             A: DecodeJson: TypeTag: Meta,
+             B: DecodeJson: TypeTag: Meta,
+             C: Meta: TypeTag: UrlParameterEncode](gfa: G[F[A]], b: B)(
     f: (A, B) => C): Foo[C]
 <<< directembedding slick mega types
 def compile[T, T2, C[_]](e: lifted.BaseJoinQuery[AbstractTable[T], AbstractTable[T2], AbstractTable[T]#TableElementType, AbstractTable[T2]#TableElementType, C, _, _]): direct.BaseJoinQuery[T, T2, T, T2, C]

--- a/core/src/test/resources/scalajs/For.stat
+++ b/core/src/test/resources/scalajs/For.stat
@@ -1,0 +1,12 @@
+80 columns                                                                     |
+<<< no align by <- #226
+val k = for {
+    _ <- FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb, cccccccc) if one
+  _ <- Future(2)
+} yield ()
+>>>
+val k = for {
+  _ <- FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb,
+      cccccccc) if one
+  _ <- Future(2)
+} yield ()

--- a/core/src/test/resources/scalajs/If.stat
+++ b/core/src/test/resources/scalajs/If.stat
@@ -1,0 +1,11 @@
+80 columns                                                                     |
+<<< while condition is like if
+    while (!hasReachedEof(curr) &&
+    !statementStarts.contains(hash(tokens(curr.splits.length).left))) {
+      foo
+    }
+>>>
+while (!hasReachedEof(curr) &&
+    !statementStarts.contains(hash(tokens(curr.splits.length).left))) {
+  foo
+}

--- a/core/src/test/resources/unit/Advanced.source
+++ b/core/src/test/resources/unit/Advanced.source
@@ -29,7 +29,7 @@
 })
 object a extends b with c {
 
-  def foo[T : Int#Double#Triple,
+  def foo[T: Int#Double#Triple,
           R <% String](
       @annot1 x: Int @annot2 = 2,
       y: Int = 3): Int = {

--- a/core/src/test/resources/unit/For.stat
+++ b/core/src/test/resources/unit/For.stat
@@ -45,7 +45,7 @@ val k = for {
 >>>
 val k = for {
   _ <- Future(aaaaaaaaaaaaaa)
-          if !onlyOne
+  if !onlyOne
   _ <- Future(2)
 } yield ()
 <<< if multiline, split before If?
@@ -72,3 +72,23 @@ for {
   normSrcDir = normPath(srcDir)
   src <- (srcDir ** "*.scala").get
 } Unit
+<<< If gets a line #176
+   for {
+  parent <- sym.info.parents
+   psym = parent.typeS
+  if psym.isInt
+  foo <- barOpt
+  if foo.isBar
+} yield {
+  genClassName(psym)
+}
+>>>
+for {
+  parent <- sym.info.parents
+  psym = parent.typeS
+  if psym.isInt
+  foo <- barOpt
+  if foo.isBar
+} yield {
+  genClassName(psym)
+}

--- a/core/src/test/resources/unit/If.stat
+++ b/core/src/test/resources/unit/If.stat
@@ -51,12 +51,14 @@ else throw new TestFailedException("")
 <<< assignment with paren
 val newColumn = tok.length + (
 if(split == Newline) newIndent
-else column + split.length)
+else column + split.length
+)
 >>>
 val newColumn =
-  tok.length +
-  (if (split == Newline) newIndent
-   else column + split.length)
+  tok.length + (
+      if (split == Newline) newIndent
+      else column + split.length
+  )
 <<< no newline
 val policy =
  if (right) SingleLineBlock(close)

--- a/core/src/test/resources/unit/If.stat
+++ b/core/src/test/resources/unit/If.stat
@@ -12,7 +12,8 @@ if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && bbbbbbbbbbbbbbbbbb)
   println("a")
 >>>
 if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
-    bbbbbbbbbbbbbbbbbb) println("a")
+    bbbbbbbbbbbbbbbbbb)
+  println("a")
 <<< Long if condition with inline comment
 if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
       bbbbbbbbbbbbbbbbbb) // comment
@@ -62,8 +63,7 @@ val newColumn =
 <<< no newline
 val policy =
  if (right) SingleLineBlock(close)
- else
-   NoPolicy
+ else   NoPolicy
 >>>
 val policy =
   if (right) SingleLineBlock(close)
@@ -81,8 +81,7 @@ if   (firstNewline == -1) tokLength
 >>>
 if (firstNewline == -1) tokLength
 <<< Gimme newline
-  if (isBracket)
-    Constants.BracketPenalty
+  if (isBracket)   Constants.BracketPenalty
   else 0
 >>>
 if (isBracket) Constants.BracketPenalty

--- a/core/src/test/resources/unit/Template.source
+++ b/core/src/test/resources/unit/Template.source
@@ -16,14 +16,18 @@ class A(b: B) extends C with D
 class A(b: B) extends C___________ with D
 >>>
 class A(b: B)
-    extends C___________ with D
-<<< SKIP Looong extends, no inline
+    extends C___________
+    with D
+<<< Looong extends, no inline
 class A(b: B) extends C with D with E with F with G {
   def x = 2
 }
 >>>
 class A(b: B)
-    extends C with D with E with F
+    extends C
+    with D
+    with E
+    with F
     with G {
   def x = 2
 }

--- a/core/src/test/resources/unit/TermUpdate.stat
+++ b/core/src/test/resources/unit/TermUpdate.stat
@@ -15,3 +15,19 @@ sieve(1, // aaaaaaaaaaaaaaaaaa
 sieve(1, // aaaaaaaaaaaaaaaaaa
       2,
       3) = false
+<<< it's like assignment #204
+  property("EndsWith") = checkArbitraryRefType[Refined, String, EndsWith[W.`"abc"`.T]]
+>>>
+property("EndsWith") =
+  checkArbitraryRefType[
+      Refined,
+      String,
+      EndsWith[W.`"abc"`.T]]
+<<< term.assign #204
+  property = checkArbitraryRefTypeaaaaaaaaaaaaaa[Refined, String, EndsWith[W.`"abc"`.T]]
+>>>
+property =
+  checkArbitraryRefTypeaaaaaaaaaaaaaa[
+      Refined,
+      String,
+      EndsWith[W.`"abc"`.T]]

--- a/core/src/test/resources/unit/Type.stat
+++ b/core/src/test/resources/unit/Type.stat
@@ -47,3 +47,11 @@ type Type = Class[F, E, M] forSome {
 type Sequence [T] = js.Array[T]
 >>>
 type Sequence[T] = js.Array[T]
+<<< no space before colon #180
+def map[T : Class](f: N => T): S[T]
+>>>
+def map[T: Class](f: N => T): S[T]
+<<< no space before colon 2 #180
+def orderLaws[A : Eq : Arbitrary] = O
+>>>
+def orderLaws[A: Eq: Arbitrary] = O


### PR DESCRIPTION
There are some bugs that need fixing before 0.2.4, but will merge this now.

```
-          compileInputs in (It, compile) <<= (compileInputs in (It, compile)) dependsOn
 +          compileInputs in (It, compile) <<= (compileInputs in (It,
 +                  compile)) dependsOn


 -          if style.configStyleArguments &&
 -          (isDefnSite(leftOwner) || isCallSite(leftOwner)) &&
 -          opensConfigStyle(formatToken) =>
 +          if style.configStyleArguments && (isDefnSite(leftOwner) ||
 +              isCallSite(leftOwner)) && opensConfigStyle(formatToken) =>

 -      newlines > 1 ||
 -      (isDocstring(tok.right) && !tok.left.isInstanceOf[Comment])
 +      newlines > 1 || (isDocstring(tok.right) &&
 +          !tok.left.isInstanceOf[Comment])

             for (result <- results.sortBy(-_.maxVisitsOnSingleToken)
 -                              if result.test.name != "Warmup") yield {
 +            if result.test.name != "Warmup") yield {

```