### PR TITLE
Drop %% in addSbtPlugin

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -71,7 +71,7 @@
 
     @sect{SBT}
       @hl.scala
-        addSbtPlugin("com.geirsson" %% "sbt-scalafmt" % "@org.scalafmt.Versions.stable")
+        addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "@org.scalafmt.Versions.stable")
 
       @ul
         @li


### PR DESCRIPTION
Sbt plugins aren't cross built, see:

  * https://github.com/sbt/sbt/blob/v0.13.11/main/src/main/scala/sbt/Defaults.scala#L1948-L1953
  * https://github.com/sbt/sbt/blob/v0.13.11/main/src/main/scala/sbt/Defaults.scala#L899-L900

crossVersion is disabled