### PR TITLE
No newline between = {, fixes #328.

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -329,14 +329,20 @@ class Router(formatOps: FormatOps) {
         })
 
         val rhsIsJsNative = isJsNative(right)
-        Seq(
-            Split(Space,
-                  0,
-                  ignoreIf = newlines > 0 && !rhsIsJsNative,
-                  policy = SingleLineBlock(expire, exclude = exclude)),
-            Split(Newline, 1, ignoreIf = rhsIsJsNative)
-              .withIndent(2, expire, Left)
-        )
+        right match {
+          case _: `{` =>
+            // The block will take care of indenting by 2.
+            Seq(Split(Space, 0))
+          case _ =>
+            Seq(
+                Split(Space,
+                      0,
+                      ignoreIf = newlines > 0 && !rhsIsJsNative,
+                      policy = SingleLineBlock(expire, exclude = exclude)),
+                Split(Newline, 1, ignoreIf = rhsIsJsNative)
+                  .withIndent(2, expire, Left)
+            )
+        }
       // Term.Apply and friends
       case FormatToken(_: `(` | _: `[`, _, between)
           if style.configStyleArguments &&

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -1,16 +1,5 @@
 SKIP core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
 SKIP core/src/main/scala/org/scalafmt/internal/Router.scala
 SKIP core/src/main/scala/org/scalafmt/internal/Router.scala
+SKIP https://raw.githubusercontent.com/twitter/scalding/7759d9c399896fc4c54be0f2406e047e030d8586/scalding-core/src/main/scala/com/twitter/scalding/typed/LookupJoin.scala
 SKIP https://raw.githubusercontent.com/scala-eveapi/eveapi/master/xml/src/main/scala/eveapi/xml/char/ContactList/xmlprotocol.scala
-SKIP https://raw.githubusercontent.com/akka/akka/3698928fbdaa8fef8e2037fbc51887ab60addefb/project/AkkaBuild.scala
-SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/implicits/ImplicitCollector.scala
-SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/types/Conformance.scala
-SKIP https://raw.githubusercontent.com/apache/spark/2c5b18fb0fdeabd378dd97e91f72d1eac4e21cc7/project/MimaExcludes.scala
-SKIP https://raw.githubusercontent.com/scala-js/scala-js/8663c8060ca96a51bfc1f87f2f3f30babbeadbc3/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
-SKIP https://raw.githubusercontent.com/akka/akka/3698928fbdaa8fef8e2037fbc51887ab60addefb/project/AkkaBuild.scala
-SKIP https://raw.githubusercontent.com/twitter/scalding/7759d9c399896fc4c54be0f2406e047e030d8586/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
-SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/ScalaPsiUtil.scala
-SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/codeInspection/collections/MethodRepr.scala
-SKIP https://raw.githubusercontent.com/JetBrains/intellij-scala/45c86930977278eb445b6aba79ac7011bc418490/src/org/jetbrains/plugins/scala/lang/psi/types/ScProjectionType.scala
-SKIP https://raw.githubusercontent.com/apache/spark/2c5b18fb0fdeabd378dd97e91f72d1eac4e21cc7/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/FrequentItems.scala
-SKIP https://raw.githubusercontent.com/apache/spark/2c5b18fb0fdeabd378dd97e91f72d1eac4e21cc7/project/SparkBuild.scala

--- a/core/src/test/resources/default/Advanced.stat
+++ b/core/src/test/resources/default/Advanced.stat
@@ -129,10 +129,10 @@ private def scalaJSStageSettings = Seq(
 val testFilter: String => Boolean = {
   options.testFilter match {
     case UnknownTests => { absPath =>
-        !blacklistedTestFileNames.contains(absPath) &&
-        !whitelistedTestFileNames.contains(absPath) &&
-        !buglistedTestFileNames.contains(absPath)
-      }
+      !blacklistedTestFileNames.contains(absPath) &&
+      !whitelistedTestFileNames.contains(absPath) &&
+      !buglistedTestFileNames.contains(absPath)
+    }
   }
 }
 <<< testFilter inline comment

--- a/core/src/test/resources/default/DefDef.stat
+++ b/core/src/test/resources/default/DefDef.stat
@@ -245,3 +245,29 @@ def zip[C](x: A =>? C): A =>? (B, C) = 2
                             false)(implicit line: sourcecode.Line): Policy
 >>>
 x
+<<< = { no format
+{
+  def defnSiteLastToken(tree: Tree): Token = {
+    tree match {
+      // TODO(olafur) scala.meta should make this easier.
+      case procedure: Defn.Def
+          if procedure.decltpe.isDefined &&
+          procedure.decltpe.get.tokens.isEmpty =>
+        procedure.body.tokens.find(_.isInstanceOf[`{`])
+      case _ => tree.tokens.find(t => t.isInstanceOf[`=`] && owners(t) == tree)
+    }
+  }.getOrElse(tree.tokens.last)
+  }
+>>>
+{
+  def defnSiteLastToken(tree: Tree): Token = {
+    tree match {
+      // TODO(olafur) scala.meta should make this easier.
+      case procedure: Defn.Def
+          if procedure.decltpe.isDefined &&
+          procedure.decltpe.get.tokens.isEmpty =>
+        procedure.body.tokens.find(_.isInstanceOf[`{`])
+      case _ => tree.tokens.find(t => t.isInstanceOf[`=`] && owners(t) == tree)
+    }
+  }.getOrElse(tree.tokens.last)
+}

--- a/core/src/test/resources/scalajs/DefDef.stat
+++ b/core/src/test/resources/scalajs/DefDef.stat
@@ -225,3 +225,31 @@ def unwrapJavaScriptException(th: Throwable): Any = th match {
   case js.JavaScriptException(e) => e
   case _                         => th
 }
+<<< no newline before { #305
+object RTCIceCandidateInit {
+  @inline
+  def apply(
+      candidate: js.UndefOr[String] = js.undefined,
+      sdpMid: js.UndefOr[String] = js.undefined,
+      sdpMLineIndex: js.UndefOr[Double] = js.undefined): RTCIceCandidateInit = {
+    val result = js.Dynamic.literal()
+    candidate.foreach(result.candidate = _)
+    sdpMid.foreach(result.sdpMid = _)
+    sdpMLineIndex.foreach(result.sdpMLineIndex = _)
+    result.asInstanceOf[RTCIceCandidateInit]
+  }
+}
+>>>
+object RTCIceCandidateInit {
+  @inline
+  def apply(candidate: js.UndefOr[String] = js.undefined,
+      sdpMid: js.UndefOr[String] = js.undefined,
+      sdpMLineIndex: js.UndefOr[
+          Double] = js.undefined): RTCIceCandidateInit = {
+    val result = js.Dynamic.literal()
+    candidate.foreach(result.candidate = _)
+    sdpMid.foreach(result.sdpMid = _)
+    sdpMLineIndex.foreach(result.sdpMLineIndex = _)
+    result.asInstanceOf[RTCIceCandidateInit]
+  }
+}


### PR DESCRIPTION
A post-0.2.5 commit moved the case for non-statement starting blocks
further down in the Router. This commit moves that space back for defs.

The new Scala.js test case hightlights the need for a soft column limit,
as suggested by @spiewak in #317.