### PR TITLE
Add spaceBeforeContextBoundColon option

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -267,6 +267,12 @@ object Cli {
               |        It's best to play around with scala.meta in a console to
               |        understand which regexp you should use for the owner.
               |""".stripMargin
+
+
+      opt[Unit]("spaceBeforeContextBoundColon") action { (_, c) =>
+        c.copy(style = c.style.copy(spaceBeforeContextBoundColon = true))
+      } text s"See ScalafmtConfig scaladoc."
+
       note(s"""
             |Examples:
             |

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -39,7 +39,8 @@ class CliTest extends FunSuite with DiffAssertions {
       continuationIndentCallSite = 2,
       continuationIndentDefnSite = 3,
       scalaDocs = false,
-      alignStripMarginStrings = false)
+      alignStripMarginStrings = false,
+      spaceBeforeContextBoundColon = true)
   val expectedConfig = Cli.Config.default.copy(
       debug = true,
       runner = ScalafmtRunner.statement.copy(
@@ -61,6 +62,7 @@ class CliTest extends FunSuite with DiffAssertions {
       "--debug",
       "--maxColumn",
       "99",
+      "--spaceBeforeContextBoundColon",
       "--continuationIndentCallSite",
       "2",
       "--continuationIndentDefnSite",

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -118,6 +118,7 @@ import sourcecode.Text
   *                                indents by [[continuationIndentCallSite]].
   * @param rewriteTokens Map of tokens to rewrite. For example, Map("⇒" -> "=>")
   *                      will rewrite unicode arrows to regular ascii arrows.
+  * @param spaceBeforeContextBoundColon formats [A: T] as [A : T]
   */
 case class ScalafmtStyle(
     // Note: default style is right below
@@ -146,7 +147,8 @@ case class ScalafmtStyle(
     indentOperatorsExcludeFilter: Regex,
     rewriteTokens: Map[String, String],
     alignByArrowEnumeratorGenerator: Boolean,
-    alignByIfWhileOpenParen: Boolean
+    alignByIfWhileOpenParen: Boolean,
+    spaceBeforeContextBoundColon: Boolean
 ) {
   lazy val alignMap: Map[String, Regex] =
     alignTokens.map(x => x.code -> x.owner.r).toMap
@@ -188,7 +190,8 @@ object ScalafmtStyle {
       indentOperatorsExcludeFilter = indentOperatorsExcludeDefault,
       alignByArrowEnumeratorGenerator = true,
       rewriteTokens = Map.empty[String, String],
-      alignByIfWhileOpenParen = true
+      alignByIfWhileOpenParen = true,
+      spaceBeforeContextBoundColon = false
   )
 
   val intellij = default.copy(

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -679,18 +679,18 @@ class Router(formatOps: FormatOps) {
         Seq(
             Split(Space, 0)
         )
-      case FormatToken(left: Ident, _: `:`, _)
-          if rightOwner.isInstanceOf[Type.Param] =>
+      case FormatToken(left, _: `:`, _) =>
+        val mod: Modification = rightOwner match {
+          case _: Type.Param =>
+            if (style.spaceBeforeContextBoundColon) Space else NoSplit
+          case _ =>
+            left match {
+              case ident: Ident => identModification(ident)
+              case _ => NoSplit
+            }
+        }
         Seq(
-            Split(NoSplit, 0)
-        )
-      case FormatToken(left: Ident, _: `:`, _) =>
-        Seq(
-            Split(identModification(left), 0)
-        )
-      case FormatToken(_, _: `:`, _) =>
-        Seq(
-            Split(NoSplit, 0)
+            Split(mod, 0)
         )
       // Only allow space after = in val if rhs is a single line or not
       // an infix application or an if. For example, this is allowed:

--- a/core/src/test/resources/spacesBeforeContextBound/Type.stat
+++ b/core/src/test/resources/spacesBeforeContextBound/Type.stat
@@ -1,0 +1,13 @@
+40 columns                              |
+<<<  space before colon #180
+def map[T: Class](f: N => T): S[T]
+>>>
+def map[T : Class](f: N => T): S[T]
+<<< space before colon 2 #180
+def orderLaws[A:Eq:Arbitrary] = O
+>>>
+def orderLaws[A : Eq : Arbitrary] = O
+<<< non-ident before colon
+def myMethod[F[_]:Functor](): Foo
+>>>
+def myMethod[F[_] : Functor](): Foo

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -125,6 +125,8 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
                 "<-" -> "←"
             )
         )
+      case "spacesBeforeContextBound" =>
+        ScalafmtStyle.default.copy(spaceBeforeContextBoundColon = true)
       case style => throw UnknownStyle(style)
     }
 


### PR DESCRIPTION
Context bound constraints are often written with spaces surrounding the `:` , for example:

```scala
def f[T : Numeric](t: T) = ???
```
, which is consistent with other type constraint usages such as `[T <: AnyRef]`.

https://github.com/olafurpg/scalafmt/issues/180 dealt with this and explicitly dropped spaces before, but I think an option to have it (off by default) is still useful

This PR adds the `spaceBeforeContextBoundColon ` option to allow inserting a space before the `:`.