### PR TITLE
Increase control over infix operator indentation, fixes #367.

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -204,6 +204,27 @@ object Cli {
           c.copy(style = c.style.copy(
                   allowNewlineBeforeColonInMassiveReturnTypes = bool))
       } text s"See ScalafmtStyle scaladoc."
+      opt[Boolean]("unindentAllOperators") action { (bool, c) =>
+        c.copy(style = c.style.copy(unindentAllOperators = bool))
+      } text s"See ScalafmtConfig scaladoc."
+      opt[String]("indentOperatorsIncludeFilter") action { (str, c) =>
+        c.copy(style = c.style.copy(indentOperatorsIncludeFilter = str.r))
+      } text s"See ScalafmtConfig scaladoc."
+      opt[String]("indentOperatorsExcludeFilter") action { (str, c) =>
+        c.copy(style = c.style.copy(indentOperatorsExcludeFilter = str.r))
+      } text s"See ScalafmtConfig scaladoc."
+      opt[Boolean]("indentOperators") action { (bool, c) =>
+        val (include, exclude) = {
+          if (bool)
+            (ScalafmtStyle.indentOperatorsIncludeDefault,
+             ScalafmtStyle.indentOperatorsExcludeDefault)
+          else
+            (ScalafmtStyle.indentOperatorsIncludeAkka,
+             ScalafmtStyle.indentOperatorsExcludeAkka)
+        }
+        c.copy(style = c.style.copy(indentOperatorsIncludeFilter = include,
+                                    indentOperatorsExcludeFilter = exclude))
+      } text s"See ScalafmtConfig scaladoc."
       opt[Seq[String]]("rewriteTokens") action { (str, c) =>
         val rewriteTokens = Map(gimmeStrPairs(str): _*)
         c.copy(style = c.style.copy(rewriteTokens = rewriteTokens))

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -31,8 +31,11 @@ class CliTest extends FunSuite with DiffAssertions {
           "=>" -> "⇒",
           "<-" -> "←"
       ),
+      indentOperatorsIncludeFilter = ScalafmtStyle.indentOperatorsIncludeAkka,
+      indentOperatorsExcludeFilter = ScalafmtStyle.indentOperatorsExcludeAkka,
       reformatDocstrings = false,
       maxColumn = 99,
+      unindentAllOperators = true,
       continuationIndentCallSite = 2,
       continuationIndentDefnSite = 3,
       scalaDocs = false,
@@ -45,6 +48,10 @@ class CliTest extends FunSuite with DiffAssertions {
       files = Seq(new File("foo")),
       inPlace = true)
   val args = Array(
+      "--unindentAllOperators",
+      "true",
+      "--indentOperators",
+      "false",
       "--rewriteTokens",
       "=>;⇒,<-;←",
       "--reformatDocstrings",

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -339,8 +339,13 @@ class FormatOps(val tree: Tree,
         formatToken.between,
         rightIsComment = formatToken.right.isInstanceOf[Comment])
     val indent = {
-      if (isTopLevelInfixApplication(owner) &&
-          isBoolOperator(owner.op.tokens.head)) 0
+      if ((style.unindentAllOperators || isTopLevelInfixApplication(owner)) &&
+          (style.indentOperatorsIncludeFilter
+                .findFirstIn(owner.op.tokens.head.code)
+                .isEmpty ||
+              style.indentOperatorsExcludeFilter
+                .findFirstIn(owner.op.tokens.head.code)
+                .isDefined)) 0
       else if (!modification.isNewline &&
                !isAttachedComment(formatToken.right, formatToken.between)) 0
       else 2

--- a/core/src/test/resources/noIndentOperators/Indent.stat
+++ b/core/src/test/resources/noIndentOperators/Indent.stat
@@ -1,0 +1,95 @@
+80 columns                                                                     |
+<<< Indent operators
+object TestRoutes {
+  def routes = {
+    pathPrefix("foo") {
+      ???
+    } ~
+      pathPrefix("bar") {
+        ???
+      }
+      1 +
+      2 -
+      2 *
+      3 \
+      4
+
+      a >
+      b
+
+      a &&
+        b
+
+      a &&
+        b
+
+      a <
+      b
+
+      a +=
+      b
+
+      a ++=
+      b
+
+      a >>=
+      b
+  }
+}
+>>>
+object TestRoutes {
+  def routes = {
+    pathPrefix("foo") {
+      ???
+    } ~
+    pathPrefix("bar") {
+      ???
+    }
+    1 +
+    2 -
+    2 *
+    3 \
+    4
+
+    a >
+    b
+
+    a &&
+    b
+
+    a &&
+    b
+
+    a <
+    b
+
+    a +=
+      b
+
+    a ++=
+      b
+
+    a >>=
+      b
+  }
+}
+<<< Without braces
+object TestRoutes {
+  def routes =
+    pathPrefix("foo") {
+      ???
+    } ~
+      pathPrefix("bar") {
+        ???
+      }
+      }
+>>>
+object TestRoutes {
+  def routes =
+    pathPrefix("foo") {
+      ???
+    } ~
+    pathPrefix("bar") {
+      ???
+    }
+}

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -112,6 +112,12 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
                                    spaceAfterTripleEquals = true)
       case "align" =>
         ScalafmtStyle.default.copy(alignTokens = AlignToken.default)
+      case "noIndentOperators" =>
+        ScalafmtStyle.default.copy(unindentAllOperators = true,
+                                   indentOperatorsIncludeFilter =
+                                     ScalafmtStyle.indentOperatorsIncludeAkka,
+                                   indentOperatorsExcludeFilter =
+                                     ScalafmtStyle.indentOperatorsExcludeAkka)
       case "unicode" =>
         ScalafmtStyle.default.copy(
             rewriteTokens = Map(


### PR DESCRIPTION
This commit adds three new flags to control how infix operators play
with indentation.