### PR TITLE
Allow limited mixed owner alignment, fixes #184

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -233,6 +233,9 @@ object Cli {
               |        --rewriteTokens ⇒;=>,←;<-
               |
               |        will rewrite unicode arrows to their ascii equivalents.""".stripMargin
+      opt[Boolean]("alignMixedOwners") action { (bool, c) =>
+        c.copy(style = c.style.copy(alignMixedOwners = bool))
+      } text s"See ScalafmtConfig scaladoc."
       opt[Seq[String]]("alignTokens") action { (tokens, c) =>
         val alignsTokens =
           gimmeStrPairs(tokens).map((AlignToken.apply _).tupled)

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -35,6 +35,7 @@ class CliTest extends FunSuite with DiffAssertions {
       indentOperatorsExcludeFilter = ScalafmtStyle.indentOperatorsExcludeAkka,
       reformatDocstrings = false,
       maxColumn = 99,
+      alignMixedOwners = true,
       unindentTopLevelOperators = true,
       continuationIndentCallSite = 2,
       continuationIndentDefnSite = 3,
@@ -50,6 +51,8 @@ class CliTest extends FunSuite with DiffAssertions {
       inPlace = true)
   val args = Array(
       "--unindentTopLevelOperators",
+      "true",
+      "--alignMixedOwners",
       "true",
       "--indentOperators",
       "false",

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -119,6 +119,9 @@ import sourcecode.Text
   * @param rewriteTokens Map of tokens to rewrite. For example, Map("⇒" -> "=>")
   *                      will rewrite unicode arrows to regular ascii arrows.
   * @param spaceBeforeContextBoundColon formats [A: T] as [A : T]
+  * @param alignMixedOwners If true, aligns `=` for val/var/def and
+  *                         `extends` for def/trait/object.
+  * @param alignTokens Documented in scalafmt --help page.
   */
 case class ScalafmtStyle(
     // Note: default style is right below
@@ -137,6 +140,7 @@ case class ScalafmtStyle(
     alignByOpenParenDefnSite: Boolean,
     continuationIndentCallSite: Int,
     continuationIndentDefnSite: Int,
+    alignMixedOwners: Boolean,
     alignTokens: Set[AlignToken],
     spacesInImportCurlyBraces: Boolean,
     allowNewlineBeforeColonInMassiveReturnTypes: Boolean,
@@ -180,6 +184,7 @@ object ScalafmtStyle {
       superfluousParensIndent = 4,
       continuationIndentCallSite = 4,
       continuationIndentDefnSite = 4,
+      alignMixedOwners = false,
       alignTokens = Set.empty[AlignToken],
       spacesInImportCurlyBraces = false,
       allowNewlineBeforeColonInMassiveReturnTypes = true,
@@ -202,7 +207,10 @@ object ScalafmtStyle {
       danglingParentheses = true
   )
 
-  val defaultWithAlign = default.copy(alignTokens = AlignToken.default)
+  val defaultWithAlign = default.copy(
+      alignMixedOwners = true,
+      alignTokens = AlignToken.default
+  )
 
   val default40 = default.copy(maxColumn = 40)
   val default120 = default.copy(maxColumn = 120)

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -153,8 +153,15 @@ class FormatWriter(formatOps: FormatOps) {
     }.getOrElse(false)
   }
 
-  def key(token: Token): Int =
-    (token.getClass.getName, owners(token).getClass.getName).hashCode()
+  def key(token: Token): Int = {
+    val ownerKey = {
+      val className = owners(token).getClass.getName
+      if (style.alignMixedOwners)
+        FormatWriter.ownerCategory.getOrElse(className, className)
+      else className
+    }
+    (token.getClass.getName, ownerKey).hashCode()
+  }
 
   private def getAlignOwner(formatToken: FormatToken): Tree =
     formatToken match {
@@ -267,6 +274,15 @@ class FormatWriter(formatOps: FormatOps) {
 }
 
 object FormatWriter {
+
+  val ownerCategory: Map[String, String] = Map(
+      "scala.meta.Defn$Val$Impl" -> "val/var/def",
+      "scala.meta.Defn$Var$Impl" -> "val/var/def",
+      "scala.meta.Defn$Def$Impl" -> "val/var/def",
+      "scala.meta.Defn$Class$Impl" -> "class/object/trait",
+      "scala.meta.Defn$Object$Impl" -> "class/object/trait",
+      "scala.meta.Defn$Trait$Impl" -> "class/object/trait"
+  )
 
   case class FormatLocation(formatToken: FormatToken,
                             split: Split,

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -85,14 +85,6 @@ libraryDependencies ++= Seq(
     "org.apache.commons"             % "commons-math3"   % "3.6"              % "test",
     "org.scalatest"                  %% "scalatest"      % Deps.scalatest     % "test"
 )
-<<< conflicting columns
-val x = 1 // comment
-val noComment = 2
-def noAlign = 3
->>>
-val x         = 1 // comment
-val noComment = 2
-def noAlign = 3
 <<< slick #138
 def address = column[String]("address", O.PrimaryKey)
 def name = column[String]("name")
@@ -341,3 +333,32 @@ Ok(
                                  "unsupportedAt" -> old.unsupportedAt)
                       })
     )) as JSON
+<<< mixed val/var/def
+{
+  var x = 2 // x
+  val xx = 22 // xx
+  def xxx = 222 // xxx
+
+  def xxxx = 2222 // loner
+}
+>>>
+{
+  var x   = 2   // x
+  val xx  = 22  // xx
+  def xxx = 222 // xxx
+
+  def xxxx = 2222 // loner
+}
+<<< mixed object/class/trait
+object mixed {
+final trait False extends Val
+final case object False extends Val
+  final case class Zero(zeroty: nir.Type)                     extends Val
+}
+>>>
+object mixed {
+  final trait False                       extends Val
+  final case object False                 extends Val
+  final case class Zero(zeroty: nir.Type) extends Val
+}
+

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -110,8 +110,7 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
       case "spaces" =>
         ScalafmtStyle.default.copy(spacesInImportCurlyBraces = true,
                                    spaceAfterTripleEquals = true)
-      case "align" =>
-        ScalafmtStyle.default.copy(alignTokens = AlignToken.default)
+      case "align" => ScalafmtStyle.defaultWithAlign
       case "noIndentOperators" =>
         ScalafmtStyle.default.copy(unindentTopLevelOperators = true,
                                    indentOperatorsIncludeFilter =


### PR DESCRIPTION
Once #172 is implemented, we can add more powerful configuration
for which tokens can align together.