### PR TITLE
update sbt-scoverage from 1.0.1 to 1.3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting
+import scoverage.ScoverageKeys.coverageHighlighting
 
 lazy val buildSettings = Seq(
   organization := "com.geirsson",
@@ -48,7 +48,7 @@ lazy val commonSettings = Seq(
   triggeredMessage in ThisBuild := Watched.clearWhenTriggered,
   scalacOptions in (Compile, console) := compilerOptions :+ "-Yrepl-class-based",
   assemblyJarName in assembly := "scalafmt.jar",
-  ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages :=
+  scoverage.ScoverageKeys.coverageExcludedPackages :=
       ".*Debug;.*ScalaFmtLogger;.*Versions",
   testOptions in Test += Tests.Argument("-oD")
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")


### PR DESCRIPTION
While scalafmt 0.2.13 isn't released yet, I'm doing local builds with a source-level SBT project dependency; this led to finding that scalafmt's dependency on sbt-scoverage is out-of-date.