### PR TITLE
0.3.0 rc1

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -156,9 +156,6 @@ object Cli {
       opt[Int]("maxColumn") action { (col, c) =>
         c.copy(style = c.style.copy(maxColumn = col))
       } text s"See ScalafmtStyle scaladoc."
-      opt[Int]("superfluousParensIndent") action { (n, c) =>
-        c.copy(style = c.style.copy(superfluousParensIndent = n))
-      } text s"See ScalafmtStyle scaladoc."
       opt[Int]("continuationIndentCallSite") action { (n, c) =>
         c.copy(style = c.style.copy(continuationIndentCallSite = n))
       } text s"See ScalafmtStyle scaladoc."

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -16,14 +16,16 @@ class CliTest extends FunSuite with DiffAssertions {
   import org.scalafmt.util.LoggerOps._
   val unformatted = """
                       |object a    extends   App {
-                      |println("hello world!")
+                      |pr(
+                      |
+                      |"h")
                       |}
                     """.stripMargin
   // Using maxColumn 10 just to see the CLI uses the custom style.
   val expected = """object a
                    |    extends App {
-                   |  println(
-                   |      "hello world!")
+                   |  pr(
+                   |    "h")
                    |}
                  """.stripMargin
   val expectedStyle = ScalafmtStyle.default.copy(
@@ -37,7 +39,6 @@ class CliTest extends FunSuite with DiffAssertions {
       maxColumn = 99,
       alignMixedOwners = true,
       unindentTopLevelOperators = true,
-      superfluousParensIndent = 2,
       continuationIndentCallSite = 2,
       continuationIndentDefnSite = 3,
       scalaDocs = false,
@@ -73,8 +74,6 @@ class CliTest extends FunSuite with DiffAssertions {
       "99",
       "--spaceBeforeContextBoundColon",
       "true",
-      "--superfluousParensIndent",
-      "2",
       "--continuationIndentCallSite",
       "2",
       "--continuationIndentDefnSite",

--- a/core/src/main/scala/org/scalafmt/ScalaFmt.scala
+++ b/core/src/main/scala/org/scalafmt/ScalaFmt.scala
@@ -29,7 +29,7 @@ object Scalafmt {
       if (code.matches("\\s*")) FormatResult.Success("\n")
       else {
         val tree = new scala.meta.XtensionParseInputLike(code)
-          .parse(stringToInput, runner.parser, scala.meta.dialects.Scala211)
+          .parse(stringToInput, runner.parser, runner.dialect)
           .get
         val formatOps = new FormatOps(tree, style, runner)
         runner.eventCallback(CreateFormatOps(formatOps))

--- a/core/src/main/scala/org/scalafmt/ScalafmtRunner.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtRunner.scala
@@ -1,5 +1,6 @@
 package org.scalafmt
 
+import scala.meta.Dialect
 import scala.meta.Tree
 import scala.meta.parsers.Parse
 
@@ -21,7 +22,8 @@ case class ScalafmtRunner(debug: Boolean,
                           eventCallback: FormatEvent => Unit,
                           parser: Parse[_ <: Tree],
                           optimizer: ScalafmtOptimizer,
-                          maxStateVisits: Int) {
+                          maxStateVisits: Int,
+                          dialect: Dialect) {
 
   def withParser(newParser: Parse[_ <: Tree]): ScalafmtRunner =
     this.copy(parser = newParser)
@@ -37,7 +39,9 @@ object ScalafmtRunner {
                                eventCallback = _ => Unit,
                                parser = scala.meta.parsers.Parse.parseSource,
                                optimizer = ScalafmtOptimizer.default,
-                               maxStateVisits = 1000000)
+                               maxStateVisits = 1000000,
+    scala.meta.dialects.Scala211
+  )
 
   /**
     * Same as [[default]], except formats the input as a statement/expression.
@@ -45,4 +49,6 @@ object ScalafmtRunner {
     * An example of how to format something other than a compilation unit.
     */
   val statement = default.withParser(scala.meta.parsers.Parse.parseStat)
+
+  val sbt = default.copy(dialect = scala.meta.dialects.Sbt0137)
 }

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -31,12 +31,6 @@ import sourcecode.Text
   *                         go on the same line or will have one line each.
   * @param noNewlinesBeforeJsNative If true, a newline will never be placed in
   *                                 front of js.native.
-  * @param superfluousParensIndent    Indent width inside unnecessary parentheses.
-  *                                   For example:
-  *                                   (function(
-  *
-  *                                         baab) && // indent 4
-  *                                       caab)
   * @param danglingParentheses If true
   *                            AND @binPackArguments is true
   *                            AND @configStyleArguments is false, then this
@@ -71,25 +65,25 @@ import sourcecode.Text
   *                                  scalafmt will fit as many parent constructors
   *                                  on a single line. If false, each parent
   *                                  constructor gets its own line.
-  * @param unindentAllOperators If true, allows no indentation on infix operators
-  *                             in non-top-level functions. For example,
+  * @param unindentTopLevelOperators If true, allows no indentation on infix operators
+  *                                  in non-top-level functions. For example,
   *
-  *                             function(
-  *                                 a &&
-  *                                 b
-  *                             )
+  *                                  function(
+  *                                      a &&
+  *                                      b
+  *                                  )
   *
-  *                             If false, only allows 0 space indentation for
-  *                             top-level statements
+  *                                  If false, only allows 0 space indentation for
+  *                                  top-level statements
   *
-  *                             a &&
-  *                             b
-  *                             function(
-  *                                 a &&
-  *                                   b
-  *                             )
+  *                                  a &&
+  *                                  b
+  *                                  function(
+  *                                      a &&
+  *                                        b
+  *                                  )
   *
-  *                             Context: https://github.com/scala-js/scala-js/blob/master/CODINGSTYLE.md#long-expressions-with-binary-operators
+  *                                  Context: https://github.com/scala-js/scala-js/blob/master/CODINGSTYLE.md#long-expressions-with-binary-operators
   * @param indentOperatorsIncludeFilter Regexp for which infix operators should
   *                                     indent by 2 spaces. For example, .*=
   *                                     produces this output
@@ -143,7 +137,6 @@ case class ScalafmtStyle(
     configStyleArguments: Boolean,
     binPackDotChains: Boolean,
     noNewlinesBeforeJsNative: Boolean,
-    superfluousParensIndent: Int,
     danglingParentheses: Boolean,
     alignByOpenParenCallSite: Boolean,
     alignByOpenParenDefnSite: Boolean,
@@ -191,8 +184,7 @@ object ScalafmtStyle {
       alignByOpenParenDefnSite = true,
       binPackDotChains = false,
       noNewlinesBeforeJsNative = false,
-      superfluousParensIndent = -1,
-      continuationIndentCallSite = 4,
+      continuationIndentCallSite = 2,
       continuationIndentDefnSite = 4,
       alignMixedOwners = false,
       alignTokens = Set.empty[AlignToken],
@@ -218,10 +210,12 @@ object ScalafmtStyle {
       danglingParentheses = true
   )
 
-  val defaultWithAlign = default.copy(
-      alignMixedOwners = true,
-      alignTokens = AlignToken.default
+  def addAlign(style: ScalafmtStyle) = style.copy(
+    alignMixedOwners = true,
+    alignTokens = AlignToken.default
   )
+
+  val defaultWithAlign = addAlign(default)
 
   val default40 = default.copy(maxColumn = 40)
   val default120 = default.copy(maxColumn = 120)
@@ -234,7 +228,8 @@ object ScalafmtStyle {
       noNewlinesBeforeJsNative = true,
       binPackArguments = true,
       binPackParameters = true,
-      superfluousParensIndent = 4,
+      continuationIndentCallSite = 4,
+      continuationIndentDefnSite = 4,
       binPackImportSelectors = true,
       allowNewlineBeforeColonInMassiveReturnTypes = false,
       scalaDocs = false,
@@ -269,6 +264,10 @@ object ScalafmtStyle {
 
   // TODO(olafur) move these elsewhere.
   val testing = default.copy(alignStripMarginStrings = false)
-  val unitTest80 = testing.copy(maxColumn = 80)
-  val unitTest40 = testing.copy(maxColumn = 40)
+  val unitTest80 = testing.copy(
+      maxColumn = 80,
+      continuationIndentCallSite = 4,
+      continuationIndentDefnSite = 4
+  )
+  val unitTest40 = unitTest80.copy(maxColumn = 40)
 }

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -338,10 +338,10 @@ Ok(
     Json.obj(
         "api" -> Json.obj("current" -> api.currentVersion,
                           "olds" -> api.oldVersions.map { old =>
-                        Json.obj("version"       -> old.version,
-                                 "deprecatedAt"  -> old.deprecatedAt,
-                                 "unsupportedAt" -> old.unsupportedAt)
-                      })
+                            Json.obj("version"       -> old.version,
+                                     "deprecatedAt"  -> old.deprecatedAt,
+                                     "unsupportedAt" -> old.unsupportedAt)
+                          })
     )) as JSON
 <<< mixed val/var/def
 {

--- a/core/src/test/resources/default/Advanced.stat
+++ b/core/src/test/resources/default/Advanced.stat
@@ -390,9 +390,9 @@ val createIsArrayOfStat = {
               // Array[A] </: Array[Array[A]]
               !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
               (// Array[Array[A]] <: Array[Object]
-               js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
-               // Array[Int] </: Array[Object]
-               !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
+              js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+              // Array[Int] </: Array[Object]
+              !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
             })
           }))
       }))

--- a/core/src/test/resources/default/Apply.stat
+++ b/core/src/test/resources/default/Apply.stat
@@ -586,10 +586,10 @@ Ok(
 Ok(
     Json.obj("api" -> Json.obj("current" -> api.currentVersion,
                                "olds" -> api.oldVersions.map { old =>
-                         Json.obj("version" -> old.version,
-                                  "deprecatedAt" -> old.deprecatedAt,
-                                  "unsupportedAt" -> old.unsupportedAt)
-                       }))) as JSON
+                                 Json.obj("version" -> old.version,
+                                          "deprecatedAt" -> old.deprecatedAt,
+                                          "unsupportedAt" -> old.unsupportedAt)
+                               }))) as JSON
 <<< router explosion
         Seq(
             Split(modification,
@@ -691,3 +691,71 @@ def startSharding(system: ActorSystem,
     { case (name: String, payload) => (name, payload) },
     { case (name: String, _) => (name.hashCode % shardCount).toString }
 )
+<<< spray shit
+{{{
+      get {
+        respondWithMediaType(MediaTypes.`application/json`) {
+          complete {
+            Map("plugins" -> Map(
+                    "outputblockers" -> pluginContext.outputBlockers.map {
+                  case (n, p) =>
+                    n -> Map(
+                        "name" -> p.pluginName,
+                        "description" -> p.pluginDescription,
+                        "class" -> p.getClass.getName,
+                        "params" -> pluginContext.pluginParams(p.pluginName))
+                },
+                    "outputsniffers" -> pluginContext.outputSniffers.map {
+                  case (n, p) =>
+                    n -> Map(
+                        "name" -> p.pluginName,
+                        "description" -> p.pluginDescription,
+                        "class" -> p.getClass.getName,
+                        "params" -> pluginContext.pluginParams(p.pluginName))
+                }
+                ))
+          }
+        }
+      }
+}}}
+>>>
+{
+  {
+    {
+      get {
+        respondWithMediaType(MediaTypes.`application/json`) {
+          complete {
+            Map(
+                "plugins" -> Map(
+                    "outputblockers" -> pluginContext.outputBlockers.map {
+                      case (n, p) =>
+                        n -> Map("name" -> p.pluginName,
+                                 "description" -> p.pluginDescription,
+                                 "class" -> p.getClass.getName,
+                                 "params" -> pluginContext.pluginParams(
+                                     p.pluginName))
+                    },
+                    "outputsniffers" -> pluginContext.outputSniffers.map {
+                      case (n, p) =>
+                        n -> Map("name" -> p.pluginName,
+                                 "description" -> p.pluginDescription,
+                                 "class" -> p.getClass.getName,
+                                 "params" -> pluginContext.pluginParams(
+                                     p.pluginName))
+                    }
+                ))
+          }
+        }
+      }
+    }
+  }
+}
+<<< SKIP fix with in template
+{{
+      val replier = system.actorOf(Props(new IntReplierActor(10)
+      with EvenHalverInterceptor with OddDoublerInterceptor {
+        override def unhandled(message: Any) = probeRef ! message
+      }))
+}}
+>>>
+x

--- a/core/src/test/resources/default/Case.case
+++ b/core/src/test/resources/default/Case.case
@@ -45,7 +45,7 @@ case Decision(t @ FormatToken(comma: `,`, right, between), splits)
     if owners.get(open) == owners.get(comma) &&
       // If comment is bound to comma, see unit/Comment.
       (!right.isInstanceOf[Comment] ||
-         between.exists(_.isInstanceOf[`\n`])) =>
+        between.exists(_.isInstanceOf[`\n`])) =>
   Decision(t, splits.filter(_.modification == Newline))
 <<< Bug
 case FormatToken(open: `(`, right, _) if leftOwner.isInstanceOf[Term.ApplyInfix] =>

--- a/core/src/test/resources/default/Case.stat
+++ b/core/src/test/resources/default/Case.stat
@@ -55,9 +55,9 @@ x match {
   case tok
       if // TODO(olafur) DRY.
       (leftOwner.isInstanceOf[Term.Interpolate] &&
-         rightOwner.isInstanceOf[Term.Interpolate]) ||
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
         (leftOwner.isInstanceOf[Pat.Interpolate] &&
-           rightOwner.isInstanceOf[Pat.Interpolate]) =>
+          rightOwner.isInstanceOf[Pat.Interpolate]) =>
     Seq(Split(NoSplit, 0))
 }
 <<< PrepJSInterop

--- a/core/src/test/resources/default/For.stat
+++ b/core/src/test/resources/default/For.stat
@@ -1,19 +1,17 @@
 80 columns                                                                     |
 <<< align by superfluous (
-     val weights: Map[Int, Double] =
-     (for {
+     val weights: Map[Int, Double] = (for {
        group <- groupedWeights
        item <- group.items
        index <- model.itemStringIntMap.get(item)
      } yield (index, group.weight)).toMap.withDefaultValue(1.0)
 
 >>>
-val weights: Map[Int, Double] =
-  (for {
-     group <- groupedWeights
-     item <- group.items
-     index <- model.itemStringIntMap.get(item)
-   } yield (index, group.weight)).toMap.withDefaultValue(1.0)
+val weights: Map[Int, Double] = (for {
+  group <- groupedWeights
+  item <- group.items
+  index <- model.itemStringIntMap.get(item)
+} yield (index, group.weight)).toMap.withDefaultValue(1.0)
 <<< Keep multiline like if #256
 for ((key, value) <- properties)
     result(key) = value

--- a/core/src/test/resources/default/Idempotency.stat
+++ b/core/src/test/resources/default/Idempotency.stat
@@ -10,12 +10,13 @@ class A {
 class A {
   def traced(in: A => Unit, out: B => Unit): Fun[A, B] =
     (f.mapIn[A] { x =>
-         in(x); x
-       }
-       .mapOut[B] { x =>
-         out(x); x
-       })
+        in(x); x
+      }
+      .mapOut[B] { x =>
+        out(x); x
+      })
 }
+
 <<< akka 1
 {{{
 val bindingFuture = Http().bindAndHandleSync({
@@ -52,8 +53,8 @@ val bindingFuture = Http().bindAndHandleSync({
         {
           {
             RawRequestURI(new String(
-                    uriBytes,
-                    HttpCharsets.aaaaaaaaaa.nioCharset)) :: headers
+                uriBytes,
+                HttpCharsets.aaaaaaaaaa.nioCharset)) :: headers
           }
         }
       }

--- a/core/src/test/resources/default/If.stat
+++ b/core/src/test/resources/default/If.stat
@@ -126,9 +126,9 @@ while (!hasReachedEof(curr) &&
 >>>
 if (fullInfo)
   return (candidates.toSeq.map(c =>
-                forMap(c, withLocalTypeInference = false, checkFast = false)) ++
-            candidates.toSeq.map(c =>
-                  forMap(c, withLocalTypeInference = true, checkFast = false)))
+    forMap(c, withLocalTypeInference = false, checkFast = false)) ++
+    candidates.toSeq.map(c =>
+      forMap(c, withLocalTypeInference = true, checkFast = false)))
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet

--- a/core/src/test/resources/default/Select.stat
+++ b/core/src/test/resources/default/Select.stat
@@ -111,7 +111,7 @@ val files = FilesUtil
 >>>
 private def extractRhino(e: js.Dynamic): js.Array[String] = {
   (e.stack
-     .asInstanceOf[js.UndefOr[String]])
+    .asInstanceOf[js.UndefOr[String]])
     .getOrElse("")
     .jsReplace("""^\s+at\s+""".re("gm"), "") // remove 'at' and indentation
     .jsReplace("""^(.+?)(?: \((.+)\))?$""".re("gm"), "$2@$1")
@@ -224,7 +224,7 @@ class TypedPipeJoinWithDescriptionJob {
 >>>
 {
   (playerStore
-     .updatePlayer(_: String, _: PlayerUpdate))
+    .updatePlayer(_: String, _: PlayerUpdate))
     .expects("123", PlayerUpdate(active = Some(true)))
     .returning(Future.value(Unit))
   (cache.delete _).expects("123")
@@ -250,8 +250,9 @@ Seq(
 {
   {
     {
-      system.actorOf(Props[ThreadNameEcho].withDispatcher(
-              "myapp.balancing-dispatcher")) ! "what's the name?"
+      system.actorOf(
+          Props[ThreadNameEcho]
+            .withDispatcher("myapp.balancing-dispatcher")) ! "what's the name?"
     }
   }
 }

--- a/core/src/test/resources/default/Unindent.stat
+++ b/core/src/test/resources/default/Unindent.stat
@@ -12,12 +12,10 @@
 {
   {
     {
-      f(
-          (future, message) ⇒
-            (evaluating {
-               Await.result(future.mapTo[java.lang.Thread], timeout.duration)
-             } should produce[java.lang.Exception]).getMessage should ===(
-                message))
+      f((future, message) ⇒
+        (evaluating {
+          Await.result(future.mapTo[java.lang.Thread], timeout.duration)
+        } should produce[java.lang.Exception]).getMessage should ===(message))
     }
   }
 }
@@ -35,10 +33,11 @@
     assert(
         backoffs.force.toSeq ==
           (0 until 10 map { i =>
-             (1 << i).seconds
-           }))
+            (1 << i).seconds
+          }))
   }
 }
+
 <<< assert 2
 {{
     assert((p1 match {
@@ -50,9 +49,9 @@
 {
   {
     assert((p1 match {
-              case Param.Configured(x) => x()
-              case x => throw new MatchError(x)
-            }) == failureAccrualPolicy)
+      case Param.Configured(x) => x()
+      case x => throw new MatchError(x)
+    }) == failureAccrualPolicy)
   }
 }
 <<< setBox
@@ -73,15 +72,14 @@
   {
     {
       setBox(Full((array.map {
-                     case JsonObjectId(objectId) => objectId
-                     case JsonRegex(regex) => regex
-                     case JsonUUID(uuid) => uuid
-                     case JsonDateTime(dt)
-                         if (mf.toString == "org.joda.time.DateTime") =>
-                       dt
-                     case JsonDate(date) => date
-                     case other => other.values
-                   }).asInstanceOf[MyType]))
+        case JsonObjectId(objectId) => objectId
+        case JsonRegex(regex) => regex
+        case JsonUUID(uuid) => uuid
+        case JsonDateTime(dt) if (mf.toString == "org.joda.time.DateTime") =>
+          dt
+        case JsonDate(date) => date
+        case other => other.values
+      }).asInstanceOf[MyType]))
     }
   }
 }
@@ -97,12 +95,10 @@
 {
   {
     def bindingInfoWithFields(style: BindingStyle) =
-      logger.trace(
-          "Looking for fields with style %s".format(style),
-          (for {
-             field <- fields;
-             bindingInfo <- field.binding if bindingInfo.bindingStyle == style
-           } yield (bindingInfo, field)).toList)
+      logger.trace("Looking for fields with style %s".format(style), (for {
+        field <- fields;
+        bindingInfo <- field.binding if bindingInfo.bindingStyle == style
+      } yield (bindingInfo, field)).toList)
   }
 }
 <<< indent too low
@@ -126,13 +122,13 @@
     RedisCodec.toUnifiedFormat(
         Seq(CommandBytes.BITCOUNT, key) ++
           (start match {
-             case Some(i) => Seq(StringToChannelBuffer(i.toString))
-             case None => Seq.empty
-           }) ++
+            case Some(i) => Seq(StringToChannelBuffer(i.toString))
+            case None => Seq.empty
+          }) ++
           (end match {
-             case Some(i) => Seq(StringToChannelBuffer(i.toString))
-             case None => Seq.empty
-           }))
+            case Some(i) => Seq(StringToChannelBuffer(i.toString))
+            case None => Seq.empty
+          }))
   }
 }
 <<< #394 1
@@ -143,10 +139,10 @@
  }) :: acc)
 >>>
 parse0(tail, (head match {
-                case "[*]" => CPathArray
-                case IndexPattern(index) => CPathIndex(index.toInt)
-                case name => CPathField(name)
-              }) :: acc)
+  case "[*]" => CPathArray
+  case IndexPattern(index) => CPathIndex(index.toInt)
+  case name => CPathField(name)
+}) :: acc)
 <<< #394 this sucks but so does your tuple
 {{
     (ref.copy(selector = (prefix \ ref.selector)),
@@ -162,20 +158,12 @@ parse0(tail, (head match {
 {
   {
     (ref.copy(selector = (prefix \ ref.selector)), (ref.ctype match {
-                                                      case CString =>
-                                                        ArrayStrColumn.empty(
-                                                            sliceSize)
-                                                      case CBoolean =>
-                                                        ArrayBoolColumn.empty()
-                                                      case CArrayType(
-                                                          elemType) =>
-                                                        ArrayHomogeneousArrayColumn
-                                                          .empty(sliceSize)(
-                                                              elemType)
-                                                      case CUndefined =>
-                                                        sys.error(
-                                                            "CUndefined cannot be serialized")
-                                                    }))
+      case CString => ArrayStrColumn.empty(sliceSize)
+      case CBoolean => ArrayBoolColumn.empty()
+      case CArrayType(elemType) =>
+        ArrayHomogeneousArrayColumn.empty(sliceSize)(elemType)
+      case CUndefined => sys.error("CUndefined cannot be serialized")
+    }))
   }
 }
 <<< #394 just use variable, it's fine
@@ -195,12 +183,12 @@ val second =
   {
     val second =
       (ref.ctype match {
-         case CString => ArrayStrColumn.empty(sliceSize)
-         case CBoolean => ArrayBoolColumn.empty()
-         case CArrayType(elemType) =>
-           ArrayHomogeneousArrayColumn.empty(sliceSize)(elemType)
-         case CUndefined => sys.error("CUndefined cannot be serialized")
-       })
+        case CString => ArrayStrColumn.empty(sliceSize)
+        case CBoolean => ArrayBoolColumn.empty()
+        case CArrayType(elemType) =>
+          ArrayHomogeneousArrayColumn.empty(sliceSize)(elemType)
+        case CUndefined => sys.error("CUndefined cannot be serialized")
+      })
     (ref.copy(selector = (prefix \ ref.selector)), second)
   }
 }
@@ -212,10 +200,10 @@ val second =
       }))
 >>>
 assertEquals(1, ((NoContext: Any) match {
-                   case that: AnyRef if this eq that => 0
-                   case NoContext => 1
-                   case _ => 2
-                 }))
+  case that: AnyRef if this eq that => 0
+  case NoContext => 1
+  case _ => 2
+}))
 <<< #394 4
 {{{{
         b sort {
@@ -236,11 +224,11 @@ assertEquals(1, ((NoContext: Any) match {
         b sort {
           BSONDocument(
               (for (sorter ← sorters)
-                 yield
-                   sorter._1 -> BSONInteger(sorter._2 match {
-                     case api.SortOrder.Ascending => 1
-                     case api.SortOrder.Descending => -1
-                   })).toStream)
+                yield
+                  sorter._1 -> BSONInteger(sorter._2 match {
+                    case api.SortOrder.Ascending => 1
+                    case api.SortOrder.Descending => -1
+                  })).toStream)
         }
       }
     }
@@ -269,17 +257,17 @@ assertEquals(1, ((NoContext: Any) match {
     copy(user1 = user1.copy(
              score =
                user1.score + (userId match {
-                                case None => wins * 5
-                                case Some(u) if user1.id == u => wins * 10
-                                case _ => 0
-                              })),
+                 case None => wins * 5
+                 case Some(u) if user1.id == u => wins * 10
+                 case _ => 0
+               })),
          user2 = user2.copy(
              score =
                user2.score + (userId match {
-                                case None => wins * 5
-                                case Some(u) if user2.id == u => wins * 10
-                                case _ => 0
-                              })))
+                 case None => wins * 5
+                 case Some(u) if user2.id == u => wins * 10
+                 case _ => 0
+               })))
   }
 }
 <<< #394 6
@@ -295,10 +283,10 @@ assertEquals(1, ((NoContext: Any) match {
   {
     {
       (new FastPath(_) {
-         val (a, b, c, d) = (next[Int], next[Int], next[Int], next[Int])
-         override def read(r: Reader) =
-           new A(a.read(r), b.read(r), c.read(r), d.read(r))
-       })
+        val (a, b, c, d) = (next[Int], next[Int], next[Int], next[Int])
+        override def read(r: Reader) =
+          new A(a.read(r), b.read(r), c.read(r), d.read(r))
+      })
     }
   }
 }
@@ -318,17 +306,16 @@ assertEquals(1, ((NoContext: Any) match {
       { (e: Either[Int, Int], or: Int) =>
         e.left.getOrElse(or) ==
           (e match {
-             case Left(a) => a
-             case Right(_) => or
-           })
+            case Left(a) => a
+            case Right(_) => or
+          })
       }
     }
   }
 }
 <<< testservice
 {
-  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] =
-  (lasts.map {
+  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] = (lasts.map {
                                                               case (b, it) =>
                                                                 lastMappable(b) -> toBuffer(
                                                                     it)
@@ -341,19 +328,17 @@ assertEquals(1, ((NoContext: Any) match {
 }
 >>>
 {
-  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] =
-    (lasts.map {
-       case (b, it) =>
-         lastMappable(b) -> toBuffer(it)
-     } ++ streams.map {
-       case (b, it) =>
-         streamMappable(b) -> toBuffer(it)
-     }).toMap
+  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] = (lasts.map {
+    case (b, it) =>
+      lastMappable(b) -> toBuffer(it)
+  } ++ streams.map {
+    case (b, it) =>
+      streamMappable(b) -> toBuffer(it)
+  }).toMap
 }
 <<< nullDF
 {
-  @inline val nullDF =
-  (for {
+  @inline val nullDF = (for {
                           i <- 0 to 50
                           s <- Seq(null,
                                    "a",
@@ -368,11 +353,10 @@ assertEquals(1, ((NoContext: Any) match {
 }
 >>>
 {
-  @inline val nullDF =
-    (for {
-       i <- 0 to 50
-       s <- Seq(null, "a", "b", "c", "d", "e", "f", null, "g")
-     } yield (i % 5, s, i % 13)).toDF("i", "j", "k")
+  @inline val nullDF = (for {
+    i <- 0 to 50
+    s <- Seq(null, "a", "b", "c", "d", "e", "f", null, "g")
+  } yield (i % 5, s, i % 13)).toDF("i", "j", "k")
 }
 <<< SKIP config blocked by https://github.com/scalameta/scalameta/issues/461
 {

--- a/core/src/test/resources/default/Val.stat
+++ b/core/src/test/resources/default/Val.stat
@@ -49,8 +49,8 @@ val `type`: String = js.native
       }
 >>>
 {
-  implicit val enumeratorTMonadTrans: MonadTrans[λ[(β[_],
-                                                    α) => EnumeratorT[α, β]]] =
+  implicit val enumeratorTMonadTrans: MonadTrans[
+      λ[(β[_], α) => EnumeratorT[α, β]]] =
     new MonadTrans[λ[(β[_], α) => EnumeratorT[α, β]]] {
       def liftM[G[_]: Monad, E](ga: G[E]): EnumeratorT[E, G] =
         new EnumeratorT[E, G] {

--- a/core/src/test/resources/unit/ApplyInfix.stat
+++ b/core/src/test/resources/unit/ApplyInfix.stat
@@ -8,14 +8,13 @@ genIsClassNameInAncestors(
     obj DOT "$classData")
 })))
 >>>
-js.Return(
-    !(!({
-    genIsScalaJSObject(obj) &&
-    ((obj DOT "$classData") === depth) &&
-    genIsClassNameInAncestors(
-        className,
-        obj DOT "$classData")
-  })))
+js.Return(!(!({
+  genIsScalaJSObject(obj) &&
+  ((obj DOT "$classData") === depth) &&
+  genIsClassNameInAncestors(
+      className,
+      obj DOT "$classData")
+})))
 <<< force space on infix application arguments
 opt[(Int, Int)]("range") hidden() action {}
 >>>

--- a/core/src/test/resources/unit/For.stat
+++ b/core/src/test/resources/unit/For.stat
@@ -26,9 +26,9 @@ else cell.toString.length)
 val sizes = for (row <- table)
   yield
     (for (cell <- row)
-       yield
-         if (cell == null) 0
-         else cell.toString.length)
+      yield
+        if (cell == null) 0
+        else cell.toString.length)
 <<< if singleline
 val k = for {
     _ <- Future(1) if !onlyOne

--- a/core/src/test/resources/unit/If.stat
+++ b/core/src/test/resources/unit/If.stat
@@ -74,7 +74,7 @@ lines(tok.between) > 1) &&
      !(isDocstring(left) && between)) 1
 >>>
 if ((gets2x(tok) ||
-     lines(tok.between) > 1) &&
+    lines(tok.between) > 1) &&
     !(isDocstring(left) && between)) 1
 <<< == unary nosplit literal, scalameta/scalameta#344
 if   (firstNewline == -1) tokLength

--- a/core/src/test/scala/org/scalafmt/StripMarginTests.scala
+++ b/core/src/test/scala/org/scalafmt/StripMarginTests.scala
@@ -86,8 +86,8 @@ val msg =
 val msg =
   s'''AAAAAAA
      |${mkString(
-         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-         bbb)}
+       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+       bbb)}
      |'''.stripMargin
 <<< Align | margin 2
 val msg = s'''UNABLE TO FORMAT,

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -93,46 +93,47 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
   def file2style(filename: String): ScalafmtStyle =
     filename.split("/").reverse(1) match {
       case "unit" => ScalafmtStyle.unitTest40
-      case "default" | "standard" | "scala" => ScalafmtStyle.default
-      case "default140" => ScalafmtStyle.default.copy(maxColumn = 140)
-      case "default100" => ScalafmtStyle.default.copy(maxColumn = 100)
+      case "default" | "standard" | "scala" =>
+        ScalafmtStyle.unitTest80
+      case "default140" => ScalafmtStyle.unitTest80.copy(maxColumn = 140)
+      case "default100" => ScalafmtStyle.unitTest80.copy(maxColumn = 100)
       case "scalajs" => ScalafmtStyle.scalaJs
       case "dangling" =>
-        ScalafmtStyle.default.copy(maxColumn = 40,
+        ScalafmtStyle.unitTest80.copy(maxColumn = 40,
                                    alignByOpenParenCallSite = false,
                                    danglingParentheses = true,
                                    configStyleArguments = false)
       case "noAlign" =>
-        ScalafmtStyle.default
+        ScalafmtStyle.unitTest80
           .copy(maxColumn = 40, alignByOpenParenCallSite = false)
       case "stripMargin" =>
-        ScalafmtStyle.default.copy(alignStripMarginStrings = true)
+        ScalafmtStyle.unitTest80.copy(alignStripMarginStrings = true)
       case "spaces" =>
-        ScalafmtStyle.default.copy(spacesInImportCurlyBraces = true,
+        ScalafmtStyle.unitTest80.copy(spacesInImportCurlyBraces = true,
                                    spaceAfterTripleEquals = true)
-      case "align" => ScalafmtStyle.defaultWithAlign
+      case "align" => ScalafmtStyle.addAlign(ScalafmtStyle.unitTest80)
       case "parentConstructors" =>
-        ScalafmtStyle.default.copy(
+        ScalafmtStyle.unitTest80.copy(
             binPackParentConstructors = true,
             maxColumn = 40
         )
       case "noIndentOperators" =>
-        ScalafmtStyle.default.copy(unindentTopLevelOperators = true,
+        ScalafmtStyle.unitTest80.copy(unindentTopLevelOperators = true,
                                    indentOperatorsIncludeFilter =
                                      ScalafmtStyle.indentOperatorsIncludeAkka,
                                    indentOperatorsExcludeFilter =
                                      ScalafmtStyle.indentOperatorsExcludeAkka)
       case "unicode" =>
-        ScalafmtStyle.default.copy(
+        ScalafmtStyle.unitTest80.copy(
             rewriteTokens = Map(
                 "=>" -> "⇒",
                 "<-" -> "←"
             )
         )
       case "spacesBeforeContextBound" =>
-        ScalafmtStyle.default.copy(spaceBeforeContextBoundColon = true)
+        ScalafmtStyle.unitTest80.copy(spaceBeforeContextBoundColon = true)
       case "import" =>
-        ScalafmtStyle.default.copy(binPackImportSelectors = false)
+        ScalafmtStyle.unitTest80.copy(binPackImportSelectors = false)
       case style => throw UnknownStyle(style)
     }
 


### PR DESCRIPTION
This commit should clearly by several commits. The changes are:

- No more superfluous indent settings. Indentation is relaxed
  by default just like scalariform.
- More agressive newline penalty to avoid code like this:

    function("foobar bananas" +
        "continued")

  Instead, this is preferred:

    function(
      "foobar bananas" +
        "continued")

  We could make this configurable, but it's not for now.

- The default continuation indent at call-site is now 2 spaces
  instead of 4. Closes #400.