### PR TITLE
Make SBT plugin pick up .sbt files

### DIFF
--- a/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
+++ b/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
@@ -92,7 +92,7 @@ object ScalaFmtPlugin extends AutoPlugin {
   def configScalafmtSettings: Seq[Setting[_]] =
     List(
       (sourceDirectories in hasScalafmt) := unmanagedSourceDirectories.value,
-      includeFilter in Global in hasScalafmt := "*.scala",
+      includeFilter in Global in hasScalafmt := "*.scala" || "*.sbt",
       scalafmtConfig in Global := None,
       hasScalafmt := {
         val report = update.value
@@ -103,7 +103,8 @@ object ScalaFmtPlugin extends AutoPlugin {
                           streams.value),
           scalafmtConfig.value,
           streams.value,
-          (sourceDirectories in hasScalafmt).value.toList,
+          (baseDirectory in hasScalafmt).value +:
+            (sourceDirectories in hasScalafmt).value.toList,
           (includeFilter in hasScalafmt).value,
           (excludeFilter in hasScalafmt).value,
           thisProjectRef.value)


### PR DESCRIPTION
This addresses to fix #405. Note that this is a "cheap" solution, the better solution would be to read the `scalaFmtConfig` file, read the `formatSbtFiles` config option and then adjust the filter depending on whether we need to read SBT files or not.

I can add this functionality if asked