### PR TITLE
Exclude files with a CLI option

### DIFF
--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -180,4 +180,40 @@ class CliTest extends FunSuite with DiffAssertions {
     val obtained2 = FileOps.readFile(file2)
     assertNoDiff(obtained2, expected2)
   }
+
+  test("ignores files if told so by the configuration") {
+    val dir = File.createTempFile("dir", "dir")
+    dir.delete()
+    dir.mkdir()
+    val file1 = File.createTempFile("foo", ".scala", dir)
+    val file2 = File.createTempFile("bar", ".scala", dir)
+    val original1 = """
+                      |object   a {
+                      |println(1)
+                      |}
+                    """.stripMargin
+    val expected1 = """
+                      |object a {
+                      |  println(1)
+                      |}
+                    """.stripMargin
+    val original2 = """
+                      |object   a {
+                      |println(1)
+                      |}
+                    """.stripMargin
+    val expected2 = """
+                      |object   a {
+                      |println(1)
+                      |}
+                    """.stripMargin
+    FileOps.writeFile(file1.getAbsolutePath, original1)
+    FileOps.writeFile(file2.getAbsolutePath, original2)
+    val config = Cli.Config.default.copy(inPlace = true, files = Seq(dir), exclude = Seq(file2))
+    Cli.run(config)
+    val obtained1 = FileOps.readFile(file1)
+    val obtained2 = FileOps.readFile(file2)
+    assertNoDiff(obtained1, expected1)
+    assertNoDiff(obtained2, expected2)
+  }
 }

--- a/core/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -11,11 +11,12 @@ object FileOps {
     listFiles(new File(path))
   }
 
-  def listFiles(file: File): Vector[String] = {
-    if (file.isFile) { Vector(file.getAbsolutePath) } else {
+  def listFiles(file: File, excludes: Set[File] = Set.empty): Vector[String] = {
+    if (file.isFile && !excludes(file)) { Vector(file.getAbsolutePath) } else {
       def listFilesIter(s: File): Iterable[String] = {
         val (dirs, files) = Option(s.listFiles()).toIterable
           .flatMap(_.toIterator)
+          .filterNot(excludes)
           .partition(_.isDirectory)
         files.map(_.getPath) ++ dirs.flatMap(listFilesIter)
       }


### PR DESCRIPTION
Adds a `--exclude` flag to the CLI utility to ignore certain files.