### PR TITLE
Add support to align by tokens that have no space before them

### DIFF
--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -185,6 +185,7 @@ case class ScalafmtStyle(
     keepSelectChainLineBreaks: Boolean,
     alwaysNewlineBeforeLambdaParameters: Boolean
 ) {
+
   lazy val alignMap: Map[String, Regex] =
     alignTokens.map(x => x.code -> x.owner.r).toMap
   ValidationOps.assertNonNegative(
@@ -297,3 +298,5 @@ object ScalafmtStyle {
   )
   val unitTest40 = unitTest80.copy(maxColumn = 40)
 }
+
+

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -371,4 +371,3 @@ object mixed {
   final case object False                 extends Val
   final case class Zero(zeroty: nir.Type) extends Val
 }
-

--- a/core/src/test/resources/alignNoSpace/AlignTokens.stat
+++ b/core/src/test/resources/alignNoSpace/AlignTokens.stat
@@ -1,0 +1,21 @@
+80 columns                                                                     |
+<<< align colons
+def foo(
+  a: Int,
+  aa: Int
+): Unit
+>>>
+def foo(
+    a:  Int,
+    aa: Int
+): Unit
+<<< align commas
+{
+  foo(a, b, c)
+  foo(aa, bb, c)
+}
+>>>
+{
+  foo(a,  b,  c)
+  foo(aa, bb, c)
+}

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -112,6 +112,13 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
         ScalafmtStyle.unitTest80.copy(spacesInImportCurlyBraces = true,
                                       spaceAfterTripleEquals = true)
       case "align" => ScalafmtStyle.addAlign(ScalafmtStyle.unitTest80)
+      case "alignNoSpace" =>
+        ScalafmtStyle.unitTest80.copy(
+          alignTokens = Set(
+            AlignToken(":", ".*"),
+            AlignToken(",", ".*")
+          )
+        )
       case "parentConstructors" =>
         ScalafmtStyle.unitTest80.copy(
           binPackParentConstructors = true,
@@ -143,8 +150,7 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
       case "import" =>
         ScalafmtStyle.unitTest80.copy(binPackImportSelectors = false)
       case "keepLineBreaks" =>
-        ScalafmtStyle.unitTest80.copy(
-          keepSelectChainLineBreaks = true)
+        ScalafmtStyle.unitTest80.copy(keepSelectChainLineBreaks = true)
       case "newlineBeforeLambdaParams" =>
         ScalafmtStyle.default.copy(alwaysNewlineBeforeLambdaParameters = true)
       case style => throw UnknownStyle(style)


### PR DESCRIPTION
Partly addresses #174.