### PR TITLE
Semantics preserving rewrites before formatting.

### DIFF
--- a/.scalafmt
+++ b/.scalafmt
@@ -1,4 +1,3 @@
 --maxColumn 80
 --alignTokens %;Infix,%%;Infix
 --assumeStandardLibraryStripMargin true
-

--- a/build.sbt
+++ b/build.sbt
@@ -164,9 +164,18 @@ lazy val macros = project
     )
   )
 
+lazy val cliJvmOptions = Seq(
+  "-Xss4m"
+)
+
 lazy val cli = project
   .settings(allSettings)
   .settings(
+    packSettings,
+    packMain := Map("scalafmt_pack" -> "org.scalafmt.cli.Cli"),
+    packJvmOpts := Map(
+      "scalafmt_pack" -> cliJvmOptions
+    ),
     moduleName := "scalafmt-cli",
     mainClass in assembly := Some("org.scalafmt.cli.Cli"),
     libraryDependencies ++= Seq(

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -21,6 +21,7 @@ import org.scalafmt.ScalafmtRunner
 import org.scalafmt.ScalafmtStyle
 import org.scalafmt.Versions
 import org.scalafmt.macros.Macros
+import org.scalafmt.rewrite.Rewrite
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.LoggerOps
 import scopt.OptionParser

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import org.scalafmt.LineEndings._
 import org.scalafmt.Error.MisformattedFile
 import org.scalafmt.ScalafmtStyle
+import org.scalafmt.rewrite.SortImports
 import org.scalafmt.util.DiffAssertions
 import org.scalafmt.util.FileOps
 import org.scalatest.FunSuite
@@ -40,6 +41,8 @@ class CliTest extends FunSuite with DiffAssertions {
     "false",
     "--rewriteTokens",
     "=>;⇒,<-;←",
+    "--rewriteRules",
+    "SortImportSelectors",
     "--statement",
     "--bestEffortInDeeplyNestedCode",
     "--debug",

--- a/core/src/main/scala/org/scalafmt/LineEndings.scala
+++ b/core/src/main/scala/org/scalafmt/LineEndings.scala
@@ -3,7 +3,7 @@ package org.scalafmt
 import scala.reflect.ClassTag
 
 import metaconfig.Reader
-import org.scalafmt.util.LoggerOps
+import org.scalafmt.util.logger
 
 sealed abstract class Docstrings
 object Docstrings {
@@ -29,7 +29,8 @@ object ReaderUtil {
     Reader.instance[To] {
       case x: String =>
         m.get(x) match {
-          case Some(y) => Right(y)
+          case Some(y) =>
+            Right(y)
           case None =>
             val available = m.keys.mkString(", ")
             val msg =
@@ -39,3 +40,4 @@ object ReaderUtil {
     }
   }
 }
+

--- a/core/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/core/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -1,14 +1,18 @@
 package org.scalafmt
 
+import scala.meta.Input.stringToInput
+import scala.meta.Input.stringToInput
+import scala.meta.inputs.Input
+import scala.util.control.NonFatal
+
+import org.scalafmt.Error.Incomplete
 import org.scalafmt.FormatEvent.CreateFormatOps
+import org.scalafmt.LineEndings.preserve
+import org.scalafmt.LineEndings.windows
 import org.scalafmt.internal.BestFirstSearch
 import org.scalafmt.internal.FormatOps
 import org.scalafmt.internal.FormatWriter
-import scala.util.control.NonFatal
-import scala.meta.Input.stringToInput
-
-import org.scalafmt.Error.Incomplete
-import org.scalafmt.LineEndings.{preserve, windows}
+import org.scalafmt.rewrite.Rewrite
 
 object Scalafmt {
 
@@ -40,7 +44,8 @@ object Scalafmt {
         } else {
           code
         }
-        val tree = new scala.meta.XtensionParseInputLike(unixCode)
+        val toParse = Rewrite(Input.String(unixCode), style)
+        val tree = new scala.meta.XtensionParseInputLike(toParse)
           .parse(stringToInput, runner.parser, runner.dialect)
           .get
         val formatOps = new FormatOps(tree, style, runner)

--- a/core/src/main/scala/org/scalafmt/ScalafmtRunner.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtRunner.scala
@@ -8,6 +8,7 @@ import org.scalafmt.FormatEvent.CompleteFormat
 import org.scalafmt.FormatEvent.Enqueue
 import org.scalafmt.FormatEvent.Explored
 import org.scalafmt.FormatEvent.VisitToken
+import org.scalafmt.rewrite.Rewrite
 import org.scalafmt.util.LoggerOps
 
 /**

--- a/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtStyle.scala
@@ -1,8 +1,11 @@
 package org.scalafmt
 
 import scala.util.matching.Regex
+
 import metaconfig.ConfigReader
 import metaconfig.Reader
+import org.scalafmt.config.RewriteSettings
+import org.scalafmt.rewrite.Rewrite
 import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.ValidationOps
 import sourcecode.Text
@@ -179,7 +182,8 @@ case class ScalafmtStyle(
     keepSelectChainLineBreaks: Boolean,
     alwaysNewlineBeforeLambdaParameters: Boolean,
     lineEndings: LineEndings,
-    bestEffortInDeeplyNestedCode: Boolean
+    bestEffortInDeeplyNestedCode: Boolean,
+    rewrite: RewriteSettings
 ) {
 
   def reformatDocstrings: Boolean = docstrings != Docstrings.preserve
@@ -198,6 +202,7 @@ case class ScalafmtStyle(
   implicit val lineEndingReader: Reader[LineEndings] = LineEndings.reader
   implicit val spacesReader: Reader[Spaces] = spaces.reader
   implicit val docstringsReader: Reader[Docstrings] = Docstrings.reader
+  implicit val rewriteReader: Reader[RewriteSettings] = rewrite.reader
 
   lazy val alignMap: Map[String, Regex] =
     align.tokens.map(x => x.code -> x.owner.r).toMap

--- a/core/src/main/scala/org/scalafmt/Settings.scala
+++ b/core/src/main/scala/org/scalafmt/Settings.scala
@@ -7,7 +7,9 @@ import scala.collection.immutable.Seq
 import metaconfig.ConfigReader
 import metaconfig.Reader
 import metaconfig.String2AnyMap
+import org.scalafmt.rewrite.Rewrite
 import org.scalafmt.util.LoggerOps
+import org.scalafmt.config.RewriteSettings
 
 trait Settings {
 
@@ -36,7 +38,10 @@ trait Settings {
       ifWhileOpenParen = true
     ),
     noNewlinesBeforeJsNative = false,
-    continuationIndent = ContinuationIndent(callSite = 2, defnSite = 4),
+    continuationIndent = ContinuationIndent(
+      callSite = 2,
+      defnSite = 4
+    ),
     binPackImportSelectors = false,
     spaces = Spaces(
       afterTripleEquals = false,
@@ -54,7 +59,8 @@ trait Settings {
     keepSelectChainLineBreaks = false,
     alwaysNewlineBeforeLambdaParameters = false,
     lineEndings = LineEndings.preserve,
-    bestEffortInDeeplyNestedCode = false
+    bestEffortInDeeplyNestedCode = false,
+    rewrite = RewriteSettings()
   )
 
   val intellij = default.copy(

--- a/core/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
+++ b/core/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
@@ -1,0 +1,10 @@
+package org.scalafmt.config
+
+import metaconfig.ConfigReader
+
+@ConfigReader
+case class RedundantBracesSettings(
+    includeInferredType: Boolean = true,
+    includeUnitMethods: Boolean = true,
+    maxLines: Int = 100
+)

--- a/core/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/core/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -1,0 +1,16 @@
+package org.scalafmt.config
+
+import metaconfig.ConfigReader
+import metaconfig.Reader
+import org.scalafmt.rewrite.Rewrite
+
+@ConfigReader
+case class RewriteSettings(
+    rules: Seq[Rewrite] = Nil,
+    redundantBraces: RedundantBracesSettings = RedundantBracesSettings()
+) {
+  implicit val rewriteReader: Reader[Rewrite] = Rewrite.reader
+
+  implicit val curlyReader: Reader[RedundantBracesSettings] =
+    redundantBraces.reader
+}

--- a/core/src/main/scala/org/scalafmt/rewrite/Patch.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/Patch.scala
@@ -1,0 +1,39 @@
+package org.scalafmt.rewrite
+
+import scala.meta._
+import scala.meta.tokens.Token
+
+import scala.meta.tokens.Token
+
+/**
+  * A patch replaces all tokens between [[from]] and [[to]] with [[replace]].
+  */
+case class Patch(from: Token, to: Token, replace: String) {
+  def insideRange(token: Token): Boolean =
+    token.start >= from.start &&
+      token.end <= to.end
+  val tokens = replace.tokenize.get.tokens.toSeq
+  def runOn(str: Seq[Token]): Seq[Token] = {
+    str.flatMap {
+      case `from` => tokens
+      case x if insideRange(x) => Nil
+      case x => Seq(x)
+    }
+  }
+}
+
+object Patch {
+  def verifyPatches(patches: Seq[Patch]): Unit = {
+    // TODO(olafur) assert there's no conflicts.
+  }
+  def apply(input: Seq[Token], patches: Seq[Patch]): String = {
+    verifyPatches(patches)
+    // TODO(olafur) optimize, this is SUPER inefficient
+    patches
+      .foldLeft(input) {
+        case (s, p) => p.runOn(s)
+      }
+      .map(_.syntax)
+      .mkString("")
+  }
+}

--- a/core/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -1,0 +1,73 @@
+package org.scalafmt.rewrite
+
+import scala.meta.Importee
+import scala.meta.Tree
+import scala.meta._
+import scala.meta.tokens.Token.Equals
+import scala.meta.tokens.Token.LF
+import scala.meta.tokens.Token.LeftBrace
+import scala.meta.tokens.Token.RightBrace
+import scala.meta.tokens.Token.Space
+
+import org.scalafmt.util.TreeOps._
+
+import org.scalafmt.util.logger
+
+/**
+  * Removes/adds curly braces where desired.
+  */
+object RedundantBraces extends Rewrite {
+
+  def isCandidate(d: Defn.Def, ctx: RewriteCtx): Boolean = {
+    import ctx.style.rewrite.{redundantBraces => settings}
+    def isBlock = d.body match {
+      case t: Term.Block if t.stats.length == 1 =>
+        !t.stats.head.is[Term.Block] && // Nested blocks are trickier
+          d.body.tokens.head.is[LeftBrace] &&
+          d.body.tokens.last.is[RightBrace]
+      case _ => false
+    }
+
+    def disqualifiedByUnit =
+      !settings.includeUnitMethods || d.decltpe.exists(_.syntax == "Unit")
+
+    def bodyIsNotTooBig: Boolean =
+      d.body match {
+        case t: Term.Block =>
+          val stat = t.stats.head
+          val diff =
+            stat.tokens.last.pos.end.line -
+              stat.tokens.head.pos.start.line
+          diff < settings.maxLines
+        case _ => false
+      }
+
+    !isProcedureSyntax(d) &&
+    isBlock &&
+    !disqualifiedByUnit &&
+    bodyIsNotTooBig
+  }
+
+  override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    import ctx.tokenTraverser._
+    code.collect {
+      case d: Defn.Def if isCandidate(d, ctx) =>
+        val open = d.body.tokens.head
+        val close = d.body.tokens.last
+        val firstNewline = d.body.tokens.tail
+          .find(!_.is[Space])
+          .filter(_.is[LF])
+          .getOrElse(open)
+        val lastNewline = {
+          val next = nextToken(close)
+          if (next.is[LF]) next
+          else close
+        }
+        Seq(
+          Patch(open, firstNewline, ""),
+          Patch(close, lastNewline, "")
+        )
+
+    }.flatten
+  }
+}

--- a/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -1,0 +1,59 @@
+package org.scalafmt.rewrite
+
+import scala.meta._
+
+import org.scalafmt.ReaderUtil
+import org.scalafmt.ScalafmtStyle
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.util.LoggerOps._
+import org.scalafmt.util.StyleMap
+import org.scalafmt.util.TokenTraverser
+
+case class RewriteCtx(
+    style: ScalafmtStyle,
+    tokenTraverser: TokenTraverser
+)
+
+abstract class Rewrite {
+  def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch]
+}
+
+object Rewrite {
+  val reader =
+    ReaderUtil.oneOf[Rewrite](
+      RedundantBraces,
+      SortImports
+    )
+
+  private def nameMap[T](t: sourcecode.Text[T]*): Map[String, T] = {
+    t.map(x => x.source -> x.value)(scala.collection.breakOut)
+  }
+
+  val name2rewrite: Map[String, Rewrite] = nameMap[Rewrite](
+    RedundantBraces,
+    SortImports
+  )
+  val available = Rewrite.name2rewrite.keys.mkString(", ")
+
+  val default: Seq[Rewrite] = name2rewrite.values.toSeq
+
+  def apply(input: Input, style: ScalafmtStyle): String = {
+    val rewrites = style.rewrite.rules
+    def noop = new String(input.chars)
+    if (rewrites.isEmpty) {
+      noop
+    } else {
+      input.parse[Source] match {
+        case Parsed.Success(ast) =>
+          val ctx = RewriteCtx(
+            style,
+            tokenTraverser = new TokenTraverser(ast.tokens)
+          )
+          val rr = rewrites.map(_.getClass)
+          val patches: Seq[Patch] = rewrites.flatMap(_.rewrite(ast, ctx))
+          Patch(ast.tokens, patches)
+        case _ => noop
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -1,0 +1,66 @@
+package org.scalafmt.rewrite
+
+import scala.meta.Importee
+import scala.meta.Tree
+import scala.meta._
+
+import org.scalafmt.util.LoggerOps._
+
+
+/**
+  * Sorts imports inside curly braces.
+  *
+  * For example
+  *
+  * import a.{c, b}
+  *
+  * into
+  *
+  * import a.{b, c}
+  */
+object SortImports extends Rewrite {
+  // sort contributed by @djspiewak: https://gist.github.com/djspiewak/127776c2b6a9d6cd3c21a228afd4580f
+  private val LCase = """([a-z].*)""".r
+  private val UCase = """([A-Z].*)""".r
+  private val Other = """(.+)""".r
+
+  private def sorted(strs: Seq[String]): Seq[String] = {
+    // we really want partition, but there is no ternary version of it
+    val (syms, lcs, ucs) = strs.foldLeft(
+      (Vector.empty[String], Vector.empty[String], Vector.empty[String])) {
+      case ((syms, lcs, ucs), str) =>
+        str match {
+          case LCase(s) => (syms, lcs :+ s, ucs)
+          case UCase(s) => (syms, lcs, ucs :+ s)
+          case Other(s) => (syms :+ s, lcs, ucs)
+        }
+    }
+    syms.sorted ++ lcs.sorted ++ ucs.sorted
+  }
+
+  override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    code.collect {
+      case q"import ..$imports" =>
+        imports.flatMap { `import` =>
+          if (`import`.importees.exists(!_.is[Importee.Name])) {
+            // Do nothing if an importee has for example rename
+            // import a.{d, b => c}
+            // I think we are safe to sort these, just want to convince myself
+            // it's 100% safe first.
+            Nil
+          } else {
+            val sortedImporteesByIndex: Map[Int, String] =
+              sorted(`import`.importees.map(_.syntax)).zipWithIndex
+                .map(_.swap)
+                .toMap
+            `import`.importees.zipWithIndex.collect {
+              case (importee, i) =>
+                Patch(importee.tokens.head,
+                      importee.tokens.last,
+                      sortedImporteesByIndex(i))
+            }
+          }
+        }
+    }.flatten
+  }
+}

--- a/core/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -14,7 +14,7 @@ import sourcecode.Text
   * Debugging utility.
   */
 object LoggerOps {
-  val logger = PrintlnLogger
+  val logger = org.scalafmt.util.logger
 
   // TODO(olafur) parameterize
   def name2style[T](styles: Text[T]*): Map[String, T] =
@@ -57,6 +57,8 @@ object LoggerOps {
             |$tokens
             |""".stripMargin
   }
+
+  def stripTrailingSpace(s: String): String = s.replaceAll("\\s+\n", "\n")
 
   def reveal(s: String): String = s.map {
     case '\n' => '¶'

--- a/core/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -1,0 +1,33 @@
+package org.scalafmt.util
+
+import scala.meta.tokens.Token
+import scala.meta.tokens.Tokens
+
+class TokenTraverser(tokens: Tokens) {
+  private[this] val tok2idx = {
+    val map = Map.newBuilder[Token, Int]
+    var i = 0
+    tokens.foreach { tok =>
+      map += (tok -> i)
+      i += 1
+    }
+    map.result()
+  }
+
+  def nextToken(token: Token): Token = {
+    tok2idx.get(token) match {
+      case Some(i) if tokens.length > i + 1 =>
+        tokens(i + 1)
+      case _ => token
+    }
+  }
+
+  def prevToken(token: Token): Token = {
+    tok2idx.get(token) match {
+      case Some(i) if tokens.length > i - 1 =>
+        tokens(i - 1)
+      case _ => token
+    }
+  }
+
+}

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -313,8 +313,8 @@ object TreeOps {
       case _ =>
         splitApplyIntoLhsAndArgsLifted(leftOwner).getOrElse {
           logger.error(s"""Unknown tree
-                           |${log(leftOwner.parent.get)}
-                           |${isDefnSite(leftOwner)}""".stripMargin)
+                          |${log(leftOwner.parent.get)}
+                          |${isDefnSite(leftOwner)}""".stripMargin)
           throw UnexpectedTree[Term.Apply](leftOwner)
         }
     }
@@ -436,4 +436,8 @@ object TreeOps {
       case Some(_: Term.Block | _: Term.If | _: Term.While | _: Source) => true
       case _ => false
     }
+
+  // procedure syntax has decltpe: Some("")
+  def isProcedureSyntax(defn: Defn.Def): Boolean =
+    defn.decltpe.exists(_.tokens.isEmpty)
 }

--- a/core/src/main/scala/org/scalafmt/util/logger.scala
+++ b/core/src/main/scala/org/scalafmt/util/logger.scala
@@ -8,7 +8,7 @@ import java.io.File
   * I rely heavily on logging for debugging and the standard Java logging
   * doesn't work on Scala.js, which I hope to support one day.
   */
-object PrintlnLogger {
+object logger {
 
   private def log[T](t: sourcecode.Text[T],
                      logLevel: LogLevel,

--- a/core/src/test/resources/rewrite/RedundantBraces.stat
+++ b/core/src/test/resources/rewrite/RedundantBraces.stat
@@ -1,0 +1,105 @@
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.maxLines = 1
+<<< basic
+object a {
+  def x(i: Int): Int = {
+    2
+  }
+}
+>>>
+object a {
+  def x(i: Int): Int = 2
+}
+<<< respect max lines
+object a {
+  def x(i: Int): Int = {
+    List.filter { x =>
+      x > 1
+    }
+  }
+}
+>>>
+object a {
+  def x(i: Int): Int = {
+    List.filter { x =>
+      x > 1
+    }
+  }
+}
+<<< has comment
+object a {
+  def x(i: Int): Int = { // comment
+    2
+  }
+}
+>>>
+object a {
+  def x(i: Int): Int = // comment
+    2
+}
+<<< multiple stats
+object a {
+  def x(i: Int) = {
+    2
+    2
+  }
+}
+>>>
+object a {
+  def x(i: Int) = {
+    2
+    2
+  }
+}
+<<< procedure syntax
+object a {
+  def main(args: Seq[Int]) {
+    2
+  }
+}
+>>>
+object a {
+  def main(args: Seq[Int]) {
+    2
+  }
+}
+<<< procedure syntax 2
+object a {
+  def main(args: Seq[Int] = 2) {
+    2
+  }
+}
+>>>
+object a {
+  def main(args: Seq[Int] = 2) {
+    2
+  }
+}
+<<< no return type
+object a {
+  def main(args: Seq[Int] = 2) {
+    2
+  }
+}
+>>>
+object a {
+  def main(args: Seq[Int] = 2) {
+    2
+  }
+}
+<<< fix your own nested blox
+object a {
+  def x: Int = {
+    { // comment
+      2
+    } // end
+  }
+}
+>>>
+object a {
+  def x: Int = {
+    { // comment
+      2
+    } // end
+  }
+}

--- a/core/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/core/src/test/resources/rewrite/RedundantBraces2.stat
@@ -1,0 +1,14 @@
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.includeUnitMethods = false
+<<< unit return type
+object a {
+  def x(): Unit = {
+    println(1)
+  }
+}
+>>>
+object a {
+  def x(): Unit = {
+    println(1)
+  }
+}

--- a/core/src/test/resources/rewrite/SortImports.stat
+++ b/core/src/test/resources/rewrite/SortImports.stat
@@ -1,0 +1,48 @@
+rewrite.rules = [SortImports]
+<<< basic
+import a.b.{
+  c,
+  a,
+  b
+}, k.{
+  g, f
+}
+>>>
+import a.b.{a, b, c}, k.{f, g}
+<<< nested
+object a {
+import a.b.{
+  c,
+  b
+}
+}
+>>>
+object a {
+  import a.b.{b, c}
+}
+<<< sorting
+import a.{
+  ~>,
+  lowercase,
+  Uppercase,
+  `symbol`
+}
+>>>
+import a.{`symbol`, ~>, lowercase, Uppercase}
+<<< caveat: rename/wildcard/unimport
+import a.{
+  zzzz => _,
+  bar
+}
+>>>
+import a.{zzzz => _, bar}
+<<< caveat: comments
+import a.{
+  c, // comment for c
+  b
+}
+>>>
+import a.{
+  b, // comment for c
+  c
+}

--- a/core/src/test/scala/org/scalafmt/Debug.scala
+++ b/core/src/test/scala/org/scalafmt/Debug.scala
@@ -17,6 +17,7 @@ import org.scalafmt.internal.State
   * Only used during development.
   */
 object Debug {
+
   val treeExplored = mutable.Map.empty[Tree, Int].withDefaultValue(0)
   val tokenExplored = mutable.Map.empty[Token, Int].withDefaultValue(0)
   val formatTokenExplored =

--- a/core/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/core/src/test/scala/org/scalafmt/FormatTests.scala
@@ -68,7 +68,9 @@ class FormatTests
       case x => x.get
     }
     debugResults += saveResult(t, obtained, onlyOne)
-    assertFormatPreservesAst(t.original, obtained)(parse)
+    if (t.style.rewrite.rules.isEmpty) {
+      assertFormatPreservesAst(t.original, obtained)(parse)
+    }
     val formattedAgain = Scalafmt.format(obtained, t.style, runner).get
 //          getFormatOutput(t.style, true) // uncomment to debug
     assertNoDiff(formattedAgain, obtained, "Idempotency violated")

--- a/metaconfig/src/main/scala/metaconfig/Reader.scala
+++ b/metaconfig/src/main/scala/metaconfig/Reader.scala
@@ -41,7 +41,8 @@ object Reader {
     new Reader[T] {
       override def read(any: Any): Result[T] = {
         try {
-          if (ev.runtimeClass.isInstance(any)) {
+          if (ev.runtimeClass.getTypeParameters.isEmpty && // careful with erasure
+              ev.runtimeClass.isInstance(any)) {
             Right(any.asInstanceOf[T])
           } else {
             f.applyOrElse(any, (x: Any) => fail[T](x))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,15 +4,15 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/dancingrobot84/sbt-plugins/")
 )(Resolver.ivyStylePatterns)
 
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+addSbtPlugin("io.get-coursier"    % "sbt-coursier"        % "1.0.0-M14")
+addSbtPlugin("com.eed3si9n"       % "sbt-assembly"        % "0.14.3")
+addSbtPlugin("org.brianmckenna"   % "sbt-wartremover"     % "0.14")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "1.0.1")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"             % "0.2.6")
+addSbtPlugin("com.lihaoyi"        % "scalatex-sbt-plugin" % "0.3.5")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"        % "1.1")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"             % "1.0.0")
+addSbtPlugin("com.dancingrobot84" % "sbt-idea-plugin"     % "0.4.2")
+addSbtPlugin("org.xerial.sbt"     % "sbt-pack"            % "0.8.0")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
-addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
-addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.dancingrobot84" % "sbt-idea-plugin" % "0.4.2")
-//
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This commit adds a new feature to scalafmt so that the input is
rewritten before formatting.

Rewrite rules
-------------
 The commit implements these rewrite rules:

- Sort imports within curly braces, fixes #304
- Strip away curlies for single statement blocks in defs, fixes #432

See this diff on Kafka from running sort imports and strip away curlies:
https://github.com/olafurpg/scala-repos/pull/7/files

Performance
-----------
This commit does not implement any specific optimizations, the main
concern is to have a proof-of-concept. I haven't benchmarked this implementation yet.
My wild guess is that this new features adds 1-10ms overhead to the
total running time depending on the size of the source file.

Caveats
-------

There are some funky corner cases where the current implementation may
perform differently from user expectation. See "caveats" sections in
tests in org.scalafmt.rewrite package.

Configuration
-------------
```
rewrite.rules = [SortImports, RedundantBraces]
```