### PR TITLE
[WIP] Reorganize configuration.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,10 @@
 build:
   image: olafurpg/scalafix:0.0.1
   commands:
-    - export JVM_OPTS="-Xms4000m -Xmx40000m -XX:MaxPermSize=2000m -Xss4m -XX:ReservedCodeCacheSize=1024m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    - export JVM_OPTS="-Xms4000m -Xmx55g -XX:MaxPermSize=2000m -Xss4m -XX:ReservedCodeCacheSize=1024m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
     - pip install --user codecov
     - ./bin/testAll.sh
     # I can't be bothered to hide this token.
-    - $HOME/.local/bin/codecov -t 5f2117aa-0a01-4cf1-8bf7-631a62ccb47a
+#    - $HOME/.local/bin/codecov -t 5f2117aa-0a01-4cf1-8bf7-631a62ccb47a
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 gh-pages/
 .secrets
 
+idea/
+
 repos.tar.gz
 
 # sbt specific

--- a/.scalafmt
+++ b/.scalafmt
@@ -1,2 +1,4 @@
 --maxColumn 80
 --alignTokens %;Infix,%%;Infix
+--assumeStandardLibraryStripMargin true
+

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+maxColumn = 80
+align.tokens = [
+  { code = "%", owner = "Infix" }
+  { code = "%%", owner = "Infix" }
+]
+assumeStandardLibraryStripMargin = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
 - pip install --user codecov
 script:
 - "./bin/testAll.sh"
-after_success:
-- "./bin/travisPublish.sh"
-- codecov
+#after_success:
+#- "./bin/travisPublish.sh"
+#- codecov
 notifications:
   email:
   - olafurpg@gmail.com

--- a/bin/testAll.sh
+++ b/bin/testAll.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-sbt clean coverage test
+#sbt clean coverage test
+sbt clean test
 sbt "core/test:runMain org.scalafmt.FormatExperimentApp"
 sbt "; publishLocal ; scripted"
-sbt coverageAggregate
+#sbt coverageAggregate
 

--- a/cli/src/main/scala/org/scalafmt/Config.scala
+++ b/cli/src/main/scala/org/scalafmt/Config.scala
@@ -1,0 +1,11 @@
+package org.scalafmt
+
+import com.typesafe.config.ConfigFactory
+import org.scalafmt.hocon.Hocon2Class
+
+object Config {
+
+  def fromHocon(string: String) =
+    Hocon2Class.gimmeClass[ScalafmtStyle](string, ScalafmtStyle.configReader)
+
+}

--- a/cli/src/main/scala/org/scalafmt/hocon/Hocon2Class.scala
+++ b/cli/src/main/scala/org/scalafmt/hocon/Hocon2Class.scala
@@ -1,0 +1,37 @@
+package org.scalafmt.hocon
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+
+object Hocon2Class {
+  private def config2map(config: Config): Map[String, Any] = {
+    import scala.collection.JavaConverters._
+    def loop(obj: Any): Any = obj match {
+      case map: java.util.Map[_, _] =>
+        map.asScala.map {
+          case (key, value) => key -> loop(value)
+        }.toMap
+      case map: java.util.List[_] =>
+        map.asScala.map(loop).toList
+      case e => e
+    }
+    loop(config.root().unwrapped()).asInstanceOf[Map[String, Any]]
+  }
+
+  def gimmeClass[T](config: Config,
+                    reader: metaconfig.Reader[T]): metaconfig.Result[T] = {
+    val map = config2map(config)
+    reader.read(map)
+  }
+
+  def gimmeClass[T](configStr: String,
+                    reader: metaconfig.Reader[T]): metaconfig.Result[T] = {
+    try {
+      gimmeClass[T](ConfigFactory.parseString(configStr), reader)
+    } catch {
+      case e: ConfigException => Left(e)
+    }
+  }
+
+}

--- a/cli/src/test/scala/org/scalafmt/cli/ConfigTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/ConfigTest.scala
@@ -1,0 +1,126 @@
+package org.scalafmt.cli
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValue
+import org.scalafmt.AlignToken
+import org.scalafmt.IndentOperator
+import org.scalafmt.ScalafmtStyle
+import org.scalafmt.hocon.Hocon2Class
+import org.scalafmt.util.LoggerOps._
+import org.scalatest.FunSuite
+
+class ConfigTest extends FunSuite {
+
+  test("style = ...") {
+    import org.scalafmt.Config
+    val Left(err) = Config.fromHocon("style = foobar")
+    assert(
+      "Unknown style name foobar. Expected one of: Scala.js, IntelliJ, default, defaultWithAlign" == err.getMessage)
+
+    val overrideOne = Config.fromHocon("""|style = defaultWithAlign
+                                          |maxColumn = 100
+                                          |""".stripMargin)
+    assert(
+      Right(ScalafmtStyle.defaultWithAlign.copy(maxColumn = 100)) == overrideOne)
+    assert(
+      Right(ScalafmtStyle.intellij) == Config.fromHocon("style = intellij"))
+    assert(
+      Right(ScalafmtStyle.scalaJs) == Config.fromHocon("style = Scala.js"))
+    assert(
+      Right(ScalafmtStyle.defaultWithAlign) == Config.fromHocon(
+        "style = defaultWithAlign"))
+  }
+
+  test("hocon2class") {
+    val config =
+      """
+        |style = intellij
+        |allowNewlineBeforeColonInMassiveReturnTypes = true
+        |alwaysNewlineBeforeLambdaParameters = true
+        |assumeStandardLibraryStripMargin = true
+        |binPackImportSelectors = true
+        |configStyleArguments = true
+        |danglingParentheses = true
+        |keepSelectChainLineBreaks = true
+        |maxColumn = 4000
+        |noNewlinesBeforeJsNative = true
+        |poorMansTrailingCommasInConfigStyle = true
+        |unindentTopLevelOperators = true
+        |docstrings = JavaDoc
+        |binPack: {
+        |  defnSite = true
+        |  callSite = true
+        |  parentConstructors = true
+        |}
+        |continuationIndent: {
+        |  callSite = 3
+        |  defnSite = 5
+        |}
+        |spaces: {
+        |  inImportCurlyBraces = true
+        |  afterTripleEquals = true
+        |  beforeContextBoundColon = true
+        |}
+        |align: {
+        |  tokens = [
+        |    {code: "=>", owner: "Function"},
+        |    {code: "//"},
+        |    "%%",
+        |    "%"
+        |  ]
+        |  arrowEnumeratorGenerator = true
+        |  ifWhileOpenParen = true
+        |  openParenCallSite = true
+        |  openParenDefnSite = true
+        |  mixedOwners = true
+        |}
+        |indentOperator: {
+        |  "include" = inc
+        |  exclude = exclude
+        |}
+      """.stripMargin
+    org.scalafmt.Config.fromHocon(config) match {
+      case Left(e) => throw e
+      case Right(obtained) =>
+        assert(obtained.maxColumn == 4000)
+        assert(obtained.assumeStandardLibraryStripMargin)
+        assert(obtained.reformatDocstrings == true)
+        assert(obtained.scalaDocs == false)
+        assert(obtained.binPackArguments == true)
+        assert(obtained.binPackParameters == true)
+        assert(obtained.configStyleArguments == true)
+        assert(obtained.noNewlinesBeforeJsNative == true)
+        assert(obtained.danglingParentheses == true)
+        assert(obtained.align.openParenCallSite == true)
+        assert(obtained.align.openParenDefnSite == true)
+        assert(obtained.continuationIndentCallSite == 3)
+        assert(obtained.continuationIndentDefnSite == 5)
+        assert(obtained.align.mixedOwners == true)
+        assert(obtained.binPackImportSelectors == true)
+        assert(obtained.spaces.inImportCurlyBraces == true)
+        assert(obtained.poorMansTrailingCommasInConfigStyle == true)
+        assert(obtained.allowNewlineBeforeColonInMassiveReturnTypes == true)
+        assert(obtained.binPackParentConstructors == true)
+        assert(obtained.spaces.afterTripleEquals == true)
+        assert(obtained.unindentTopLevelOperators == true)
+        assert(obtained.align.arrowEnumeratorGenerator == true)
+        assert(obtained.align.ifWhileOpenParen == true)
+        assert(obtained.spaces.beforeContextBoundColon == true)
+        assert(obtained.keepSelectChainLineBreaks == true)
+        assert(obtained.alwaysNewlineBeforeLambdaParameters == true)
+        assert(
+          obtained.align.tokens ==
+            Set(
+              AlignToken("//", ".*"),
+              AlignToken("=>", "Function"),
+              AlignToken("%%", ".*"),
+              AlignToken("%", ".*")
+            ))
+        assert(obtained.indentOperator == IndentOperator("inc", "exclude"))
+
+        logger.elem(obtained.indentOperator)
+    }
+  }
+
+}

--- a/core/src/main/scala/org/scalafmt/Align.scala
+++ b/core/src/main/scala/org/scalafmt/Align.scala
@@ -1,0 +1,17 @@
+package org.scalafmt
+
+import metaconfig.ConfigReader
+import metaconfig.Reader
+
+@ConfigReader
+case class Align(
+    openParenCallSite: Boolean,
+    openParenDefnSite: Boolean,
+    mixedOwners: Boolean,
+    tokens: Set[AlignToken],
+    arrowEnumeratorGenerator: Boolean,
+    ifWhileOpenParen: Boolean
+) {
+  implicit val alignReader: Reader[AlignToken] = ScalafmtStyle.alignReader
+
+}

--- a/core/src/main/scala/org/scalafmt/AlignToken.scala
+++ b/core/src/main/scala/org/scalafmt/AlignToken.scala
@@ -1,12 +1,16 @@
 package org.scalafmt
 
+import metaconfig.ConfigReader
+
 /**
   * Configuration option for aligning tokens.
   *
   * @param code string literal value of the token to align by.
   * @param owner regexp for class name of scala.meta.Tree "owner" of [[code]].
   */
+@ConfigReader
 case class AlignToken(code: String, owner: String)
+
 
 object AlignToken {
   val applyInfix = "Term.ApplyInfix"

--- a/core/src/main/scala/org/scalafmt/BaseStyle.scala
+++ b/core/src/main/scala/org/scalafmt/BaseStyle.scala
@@ -1,0 +1,25 @@
+package org.scalafmt
+
+import metaconfig.Reader
+
+case class BaseStyle(style: ScalafmtStyle)
+
+object BaseStyle {
+  val default: BaseStyle = BaseStyle(ScalafmtStyle.default)
+  implicit val styleReader: Reader[BaseStyle] = Reader.instance[BaseStyle] {
+    case b: BaseStyle => Right(b) // TODO(olafur) provide this in instance
+    case any =>
+      println(any)
+      for {
+        str <- Reader.stringR.read(any).right
+        style <- {
+          ScalafmtStyle.availableStyles.get(str.toLowerCase) match {
+            case Some(s) => Right(s)
+            case None =>
+              Left(new IllegalArgumentException(
+                s"Unknown style name $str. Expected one of ${ScalafmtStyle.activeStyles.keys}"))
+          }
+        }.right
+      } yield BaseStyle(style)
+  }
+}

--- a/core/src/main/scala/org/scalafmt/BinPack.scala
+++ b/core/src/main/scala/org/scalafmt/BinPack.scala
@@ -1,0 +1,8 @@
+package org.scalafmt
+
+import metaconfig.ConfigReader
+
+@ConfigReader
+case class BinPack(callSite: Boolean,
+                   defnSite: Boolean,
+                   parentConstructors: Boolean)

--- a/core/src/main/scala/org/scalafmt/ContinuationIndent.scala
+++ b/core/src/main/scala/org/scalafmt/ContinuationIndent.scala
@@ -1,0 +1,14 @@
+package org.scalafmt
+
+import metaconfig.ConfigReader
+import metaconfig.Reader
+
+@ConfigReader
+case class ContinuationIndent(callSite: Int, defnSite: Int)
+
+@ConfigReader
+case class Spaces(
+    beforeContextBoundColon: Boolean,
+    afterTripleEquals: Boolean,
+    inImportCurlyBraces: Boolean
+)

--- a/core/src/main/scala/org/scalafmt/Error.scala
+++ b/core/src/main/scala/org/scalafmt/Error.scala
@@ -20,6 +20,7 @@ object Error {
 
   def reportIssue: String =
     "Please file an issue on https://github.com/olafurpg/scalafmt/issues"
+  case object UnableToParseCliOptions extends Error("Failed to parse CLI options")
 
   case class Incomplete(formattedCode: String)
       extends Error("Unable to format file due to bug in scalafmt")
@@ -69,6 +70,12 @@ object Error {
 
   case class InvalidScalafmtConfiguration(file: File)
       extends Error(s"Unable to parse scalafmt configuration file: $file")
+
+  case class InvalidOption(option: String)
+      extends Error(s"Invalid option $option")
+
+  case class FailedToParseOption(path: String, error: Throwable)
+      extends Error(s"Failed to read option $path, error: $error")
 
   case class IdempotencyViolated(msg: String) extends Error(msg)
 

--- a/core/src/main/scala/org/scalafmt/IndentOperator.scala
+++ b/core/src/main/scala/org/scalafmt/IndentOperator.scala
@@ -1,0 +1,16 @@
+package org.scalafmt
+
+import metaconfig.ConfigReader
+
+@ConfigReader
+case class IndentOperator(include: String, exclude: String) {
+  val includeRegexp = include.r
+  val excludeRegexp = exclude.r
+}
+
+object IndentOperator {
+  val default = IndentOperator(ScalafmtStyle.indentOperatorsIncludeDefault,
+                               ScalafmtStyle.indentOperatorsExcludeDefault)
+  val akka = IndentOperator(ScalafmtStyle.indentOperatorsIncludeAkka,
+                            ScalafmtStyle.indentOperatorsExcludeAkka)
+}

--- a/core/src/main/scala/org/scalafmt/LineEndings.scala
+++ b/core/src/main/scala/org/scalafmt/LineEndings.scala
@@ -1,0 +1,41 @@
+package org.scalafmt
+
+import scala.reflect.ClassTag
+
+import metaconfig.Reader
+import org.scalafmt.util.LoggerOps
+
+sealed abstract class Docstrings
+object Docstrings {
+  val reader = ReaderUtil.oneOf[Docstrings](JavaDoc, ScalaDoc, preserve)
+  case object JavaDoc extends Docstrings
+  case object ScalaDoc extends Docstrings
+  case object preserve extends Docstrings
+}
+
+sealed abstract class LineEndings
+
+object LineEndings {
+  val reader = ReaderUtil.oneOf[LineEndings](unix, windows, preserve)
+  case object unix extends LineEndings
+  case object windows extends LineEndings
+  case object preserve extends LineEndings
+}
+
+object ReaderUtil {
+  // Poor mans coproduct reader
+  def oneOf[To: ClassTag](options: sourcecode.Text[To]*): Reader[To] = {
+    val m = options.map(x => x.source -> x.value).toMap
+    Reader.instance[To] {
+      case x: String =>
+        m.get(x) match {
+          case Some(y) => Right(y)
+          case None =>
+            val available = m.keys.mkString(", ")
+            val msg =
+              s"Unknown input '$x'. Expected one of $available"
+            Left(new IllegalArgumentException(msg))
+        }
+    }
+  }
+}

--- a/core/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/core/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -8,7 +8,7 @@ import scala.util.control.NonFatal
 import scala.meta.Input.stringToInput
 
 import org.scalafmt.Error.Incomplete
-import org.scalafmt.ScalafmtStyle.{PreserveLineEndings, WindowsLineEndings}
+import org.scalafmt.LineEndings.{preserve, windows}
 
 object Scalafmt {
 
@@ -50,8 +50,8 @@ object Scalafmt {
         val partial = search.getBestPath
         val formattedString = formatWriter.mkString(partial.splits)
         val correctedFormattedString =
-          if ((style.lineEndings == PreserveLineEndings && isWindows) ||
-              style.lineEndings == WindowsLineEndings) {
+          if ((style.lineEndings == preserve && isWindows) ||
+              style.lineEndings == windows) {
             formattedString.replaceAll(UnixLineEnding, WindowsLineEnding)
           } else {
             formattedString

--- a/core/src/main/scala/org/scalafmt/ScalafmtOptimizer.scala
+++ b/core/src/main/scala/org/scalafmt/ScalafmtOptimizer.scala
@@ -53,7 +53,6 @@ package org.scalafmt
   */
 case class ScalafmtOptimizer(dequeueOnNewStatements: Boolean,
                              escapeInPathologicalCases: Boolean,
-                             bestEffortEscape: Boolean,
                              MaxVisitsPerToken: Int,
                              MaxEscapes: Int,
                              MaxDepth: Int,
@@ -66,7 +65,6 @@ object ScalafmtOptimizer {
   val default = ScalafmtOptimizer(
     dequeueOnNewStatements = true,
     escapeInPathologicalCases = true,
-    bestEffortEscape = false,
     MaxVisitsPerToken = 513,
     MaxEscapes = 16,
     MaxDepth = 100,

--- a/core/src/main/scala/org/scalafmt/Settings.scala
+++ b/core/src/main/scala/org/scalafmt/Settings.scala
@@ -1,0 +1,168 @@
+package org.scalafmt
+
+import scala.util.matching.Regex
+import scala.collection.immutable.Set
+import scala.collection.immutable.Seq
+
+import metaconfig.ConfigReader
+import metaconfig.Reader
+import metaconfig.String2AnyMap
+import org.scalafmt.util.LoggerOps
+
+trait Settings {
+
+  val indentOperatorsIncludeAkka = "^.*=$"
+  val indentOperatorsExcludeAkka = "^$"
+  val indentOperatorsIncludeDefault = ".*"
+  val indentOperatorsExcludeDefault = "^(&&|\\|\\|)$"
+
+  val default = ScalafmtStyle(
+    maxColumn = 80,
+    docstrings = Docstrings.ScalaDoc,
+    assumeStandardLibraryStripMargin = false,
+    binPack = BinPack(
+      callSite = false,
+      defnSite = false,
+      parentConstructors = false
+    ),
+    configStyleArguments = true,
+    danglingParentheses = false,
+    align = Align(
+      openParenCallSite = true,
+      openParenDefnSite = true,
+      mixedOwners = false,
+      tokens = Set.empty[AlignToken],
+      arrowEnumeratorGenerator = false,
+      ifWhileOpenParen = true
+    ),
+    noNewlinesBeforeJsNative = false,
+    continuationIndent = ContinuationIndent(callSite = 2, defnSite = 4),
+    binPackImportSelectors = false,
+    spaces = Spaces(
+      afterTripleEquals = false,
+      beforeContextBoundColon = false,
+      inImportCurlyBraces = false
+    ),
+    poorMansTrailingCommasInConfigStyle = false,
+    allowNewlineBeforeColonInMassiveReturnTypes = true,
+    unindentTopLevelOperators = false,
+    indentOperator = IndentOperator(
+      include = indentOperatorsIncludeDefault,
+      exclude = indentOperatorsExcludeDefault
+    ),
+    rewriteTokens = Map.empty[String, String],
+    keepSelectChainLineBreaks = false,
+    alwaysNewlineBeforeLambdaParameters = false,
+    lineEndings = LineEndings.preserve,
+    bestEffortInDeeplyNestedCode = false
+  )
+
+  val intellij = default.copy(
+    continuationIndent = ContinuationIndent(2, 2),
+    align = default.align.copy(openParenCallSite = false),
+    configStyleArguments = false,
+    danglingParentheses = true
+  )
+
+  def addAlign(style: ScalafmtStyle) = style.copy(
+    align = style.align.copy(
+      mixedOwners = true,
+      tokens = AlignToken.default
+    )
+  )
+
+  val defaultWithAlign = addAlign(default)
+
+  val default40 = default.copy(maxColumn = 40)
+  val default120 = default.copy(maxColumn = 120)
+
+  /**
+    * Experimental implementation of:
+    * https://github.com/scala-js/scala-js/blob/master/CODINGSTYLE.md
+    */
+  val scalaJs = default.copy(
+    noNewlinesBeforeJsNative = true,
+    binPack = BinPack(
+      defnSite = true,
+      callSite = true,
+      parentConstructors = true
+    ),
+    continuationIndent = ContinuationIndent(4, 4),
+    binPackImportSelectors = true,
+    allowNewlineBeforeColonInMassiveReturnTypes = false,
+    docstrings = Docstrings.JavaDoc,
+    align = default.align.copy(
+      arrowEnumeratorGenerator = false,
+      tokens = Set(AlignToken.caseArrow),
+      ifWhileOpenParen = false
+    )
+  )
+
+  /**
+    * Ready styles provided by scalafmt.
+    */
+  val activeStyles =
+    Map(
+      "Scala.js" -> scalaJs,
+      "IntelliJ" -> intellij
+    ) ++ LoggerOps.name2style(
+      default,
+      defaultWithAlign
+    )
+
+  val availableStyles = {
+    activeStyles ++ LoggerOps.name2style(
+      scalaJs
+    )
+  }.map { case (k, v) => k.toLowerCase -> v }
+
+  // TODO(olafur) move these elsewhere.
+  val testing = default.copy(assumeStandardLibraryStripMargin = false)
+  val unitTest80 = testing.copy(
+    maxColumn = 80,
+    continuationIndent = ContinuationIndent(4, 4)
+  )
+
+  val unitTest40 = unitTest80.copy(maxColumn = 40)
+
+  def oneOf[T](m: Map[String, T])(input: String): metaconfig.Result[T] =
+    m.get(input.toLowerCase()) match {
+      case Some(x) => Right(x)
+      case None =>
+        val available = m.keys.mkString(", ")
+        val msg =
+          s"Unknown line endings type $input. Expected one of $available"
+        Left(new IllegalArgumentException(msg))
+
+    }
+
+  val configReader: Reader[ScalafmtStyle] = Reader.instance[ScalafmtStyle] {
+    case String2AnyMap(map) =>
+      map.get("style") match {
+        case Some(baseStyle) =>
+          val noStyle = map.-("style")
+          ScalafmtStyle.availableStyles.get(baseStyle.toString.toLowerCase) match {
+            case Some(s) => s.reader.read(noStyle)
+            case None =>
+              val alternatives = ScalafmtStyle.activeStyles.keys.mkString(", ")
+              Left(new IllegalArgumentException(
+                s"Unknown style name $baseStyle. Expected one of: $alternatives"))
+          }
+        case None => ScalafmtStyle.default.reader.read(map)
+      }
+  }
+
+  def gimmeStrPairs(tokens: Seq[String]): Seq[(String, String)] = {
+    tokens.map { token =>
+      val splitted = token.split(";", 2)
+      if (splitted.length != 2)
+        throw new IllegalArgumentException("pair must contain ;")
+      (splitted(0), splitted(1))
+    }
+  }
+  protected[scalafmt] val fallbackAlign = new AlignToken("<empty>", ".*")
+  lazy val alignReader: Reader[AlignToken] = Reader.instance[AlignToken] {
+    case str: String => Right(AlignToken(str, ".*"))
+    case x => fallbackAlign.reader.read(x)
+  }
+}

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -204,7 +204,7 @@ class BestFirstSearch(val formatOps: FormatOps,
           Q.dequeueAll
           best.clear()
           visits.clear()
-          if (!bestEffortEscape) {
+          if (!style.bestEffortInDeeplyNestedCode) {
             runner.eventCallback(CompleteFormat(explored, deepestYet, tokens))
             throw SearchStateExploded(deepestYet,
                                       formatWriter.mkString(deepestYet.splits),

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -389,10 +389,10 @@ class FormatOps(val tree: Tree,
     val indent = {
       if ((style.unindentTopLevelOperators ||
           isTopLevelInfixApplication(owner)) &&
-          (style.indentOperatorsIncludeFilter
+          (style.indentOperator.includeRegexp
             .findFirstIn(op.tokens.head.syntax)
             .isEmpty ||
-          style.indentOperatorsExcludeFilter
+          style.indentOperator.excludeRegexp
             .findFirstIn(op.tokens.head.syntax)
             .isDefined)) 0
       else if (!modification.isNewline &&

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -74,7 +74,7 @@ class FormatWriter(formatOps: FormatOps) {
 
   val leadingPipeSpace = Pattern.compile("\n *\\|", Pattern.MULTILINE)
   private def formatMarginizedString(token: Token, indent: Int): String = {
-    if (!style.alignStripMarginStrings) token.syntax
+    if (!style.assumeStandardLibraryStripMargin) token.syntax
     else if (token.is[Interpolation.Part] ||
              isMarginizedString(token)) {
       val firstChar: Char = token match {
@@ -187,7 +187,7 @@ class FormatWriter(formatOps: FormatOps) {
   def key(token: Token): Int = {
     val ownerKey = {
       val className = owners(token).getClass.getName
-      if (style.alignMixedOwners)
+      if (style.align.mixedOwners)
         FormatWriter.ownerCategory.getOrElse(className, className)
       else className
     }
@@ -232,7 +232,7 @@ class FormatWriter(formatOps: FormatOps) {
   // imperative and error-prone right now.
   def alignmentTokens(locations: Array[FormatLocation],
                       style: ScalafmtStyle): Map[FormatToken, Int] = {
-    if (style.alignTokens.isEmpty) Map.empty[FormatToken, Int]
+    if (style.align.tokens.isEmpty) Map.empty[FormatToken, Int]
     else {
       val finalResult = Map.newBuilder[FormatToken, Int]
       var i = 0

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -122,7 +122,7 @@ class Router(formatOps: FormatOps) {
           if (style.binPackImportSelectors) newlineBeforeClosingCurly
           else newlineBeforeClosingCurly.andThen(OneArgOneLineSplit(open))
         Seq(
-          Split(if (style.spacesInImportCurlyBraces) Space else NoSplit, 0)
+          Split(if (style.spaces.inImportCurlyBraces) Space else NoSplit, 0)
             .withPolicy(policy),
           Split(Newline, 1, ignoreIf = isInterpolate)
             .withPolicy(newlinePolicy)
@@ -132,7 +132,7 @@ class Router(formatOps: FormatOps) {
           if parents(rightOwner).exists(_.is[Import]) ||
             rightOwner.is[Term.Interpolate] =>
         Seq(
-          Split(if (style.spacesInImportCurlyBraces) Space else NoSplit, 0)
+          Split(if (style.spaces.inImportCurlyBraces) Space else NoSplit, 0)
         )
       case FormatToken(Dot(), underscore @ Underscore(), _)
           if parents(rightOwner).exists(_.is[Import]) =>
@@ -310,7 +310,7 @@ class Router(formatOps: FormatOps) {
         val modification: Modification = leftOwner match {
           case _: Mod => Space
           case t: Term.Name
-              if style.spaceAfterTripleEquals &&
+              if style.spaces.afterTripleEquals &&
                 t.tokens.map(_.syntax) == Seq("===") =>
             Space
           case _ => NoSplit
@@ -583,8 +583,8 @@ class Router(formatOps: FormatOps) {
         }
         val skipOpenParenAlign = {
           !isTuple && {
-            (defnSite && !style.alignByOpenParenDefnSite) ||
-            (!defnSite && !style.alignByOpenParenCallSite)
+            (defnSite && !style.align.openParenDefnSite) ||
+            (!defnSite && !style.align.openParenCallSite)
           }
         }
 
@@ -719,7 +719,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(left, Colon(), _) =>
         val mod: Modification = rightOwner match {
           case _: Type.Param =>
-            if (style.spaceBeforeContextBoundColon) Space else NoSplit
+            if (style.spaces.beforeContextBoundColon) Space else NoSplit
           case _ =>
             left match {
               case ident: Ident => identModification(ident)
@@ -931,7 +931,7 @@ class Router(formatOps: FormatOps) {
         val close = matchingParentheses(hash(open))
         val penalizeNewlines = penalizeNewlineByNesting(open, close)
         val indent: Length =
-          if (style.alignByIfWhileOpenParen) StateColumn
+          if (style.align.ifWhileOpenParen) StateColumn
           else style.continuationIndentCallSite
         Seq(
           Split(NoSplit, 0)
@@ -1141,7 +1141,7 @@ class Router(formatOps: FormatOps) {
           if leftOwner.is[Enumerator.Generator] =>
         val lastToken = leftOwner.tokens.last
         val indent: Length =
-          if (style.alignByArrowEnumeratorGenerator) StateColumn
+          if (style.align.arrowEnumeratorGenerator) StateColumn
           else Num(0)
         Seq(
           // Either everything fits in one line or break on =>

--- a/core/src/main/scala/org/scalafmt/util/HasStringKeys.scala
+++ b/core/src/main/scala/org/scalafmt/util/HasStringKeys.scala
@@ -1,0 +1,8 @@
+package org.scalafmt.util
+
+/**
+  * Extend this class to expose the fields are string values.
+  */
+class HasStringKeys(implicit _args: sourcecode.Args) {
+  val validKeys = _args.value.value.flatten.map(_.source).toSet
+}

--- a/core/src/test/scala/org/scalafmt/BestEffortTest.scala
+++ b/core/src/test/scala/org/scalafmt/BestEffortTest.scala
@@ -265,10 +265,12 @@ val options = List[OptionAssigner](
     parseDiffTests(stateExplosions, "default/StateExplosion.stat")
 
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
-    val runner = scalafmtRunner.copy(
-      parser = parse,
-      optimizer = ScalafmtOptimizer.default.copy(bestEffortEscape = true))
-    val obtained = Scalafmt.format(t.original, t.style, runner).get
+    val runner = scalafmtRunner.copy(parser = parse)
+    val obtained = Scalafmt
+      .format(t.original,
+              t.style.copy(bestEffortInDeeplyNestedCode = true),
+              runner)
+      .get
     debugResults += saveResult(t, obtained, t.only)
     // Disabled, these tests change too often. This feature will be supported
     // with a best-effort :)

--- a/core/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/core/src/test/scala/org/scalafmt/CommentTest.scala
@@ -4,7 +4,8 @@ import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
 class CommentTest extends FunSuite with DiffAssertions {
-  val javadocStyle = ScalafmtStyle.default.copy(scalaDocs = false)
+  val javadocStyle =
+    ScalafmtStyle.default.copy(docstrings = Docstrings.JavaDoc)
 
   test("javadoc docstrings are correct") {
     val original = """object a {
@@ -28,20 +29,20 @@ class CommentTest extends FunSuite with DiffAssertions {
   test("remove trailing space in comments") {
     val trailingSpace = "   "
     val original = s"""object a {
-                     |  // inline comment$trailingSpace
-                     |/**$trailingSpace
-                     |  * Y is cool$trailingSpace
-                     |  */
-                     |/*$trailingSpace
-                     |  * X is cool$trailingSpace
-                     |  */
-                     |/*
-                     |    I have blank lines.
-                     |
-                     |    Please preserve them.
-                     |  */
-                     |val y = 2
-                     |}
+                      |  // inline comment$trailingSpace
+                      |/**$trailingSpace
+                      |  * Y is cool$trailingSpace
+                      |  */
+                      |/*$trailingSpace
+                      |  * X is cool$trailingSpace
+                      |  */
+                      |/*
+                      |    I have blank lines.
+                      |
+                      |    Please preserve them.
+                      |  */
+                      |val y = 2
+                      |}
                    """.stripMargin
     val expected = """object a {
                      |  // inline comment

--- a/core/src/test/scala/org/scalafmt/ContinuationIndentTests.scala
+++ b/core/src/test/scala/org/scalafmt/ContinuationIndentTests.scala
@@ -41,8 +41,7 @@ def foo(
   testsToRun.foreach(runTest(run))
 
   val style = ScalafmtStyle.default.copy(
-    continuationIndentCallSite = 5,
-    continuationIndentDefnSite = 3
+    continuationIndent = ContinuationIndent(5, 3)
   )
 
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {

--- a/core/src/test/scala/org/scalafmt/DialectsTest.scala
+++ b/core/src/test/scala/org/scalafmt/DialectsTest.scala
@@ -4,7 +4,6 @@ import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
 class DialectsTest extends FunSuite with DiffAssertions {
-  val javadocStyle = ScalafmtStyle.default.copy(scalaDocs = false)
 
   test("sbt") {
     val original =

--- a/core/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/core/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -22,8 +22,14 @@ class FidelityTest extends FunSuite with FormatAssertions {
   val files = FileOps
     .listFiles(".")
     .filter(_.endsWith(".scala"))
-    .filterNot(_.contains("/target/"))
-    .filterNot(_.contains("/resources/"))
+    .filterNot(
+      x =>
+        Set(
+          "ConfigReader.scala",
+          "/target/",
+          "/resources/",
+          "/gh-pages/"
+        ).exists(x.contains))
 
   val examples = files.map(Test.apply)
 

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -66,9 +66,9 @@ trait FormatExperiment extends ScalaProjectsExperiment with FormatAssertions {
           val elapsed = System.nanoTime() - startTime
           assertFormatPreservesAst[Source](code, formatted)
           val formattedSecondTime = Scalafmt
-            .format(
-              formatted,
-              ScalafmtStyle.default.copy(alignStripMarginStrings = false))
+            .format(formatted,
+                    ScalafmtStyle.default.copy(
+                      assumeStandardLibraryStripMargin = false))
             .get
           try {
             assertNoDiff(formattedSecondTime, formatted, "Idempotency")

--- a/core/src/test/scala/org/scalafmt/LineEndingsTest.scala
+++ b/core/src/test/scala/org/scalafmt/LineEndingsTest.scala
@@ -1,10 +1,6 @@
 package org.scalafmt
 
-import org.scalafmt.ScalafmtStyle.{
-  PreserveLineEndings,
-  UnixLineEndings,
-  WindowsLineEndings
-}
+import org.scalafmt.LineEndings._
 import org.scalafmt.util.DiffAssertions
 import org.scalatest.FunSuite
 
@@ -16,7 +12,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = PreserveLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = preserve))
       .get
     assertNoDiff(obtained, expected)
   }
@@ -27,7 +23,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\nobject a {\n  val y = 2\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = PreserveLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = preserve))
       .get
     assertNoDiff(obtained, expected)
   }
@@ -38,7 +34,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = WindowsLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = windows))
       .get
     assertNoDiff(obtained, expected)
   }
@@ -49,7 +45,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = WindowsLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = windows))
       .get
     assertNoDiff(obtained, expected)
   }
@@ -60,7 +56,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\nobject a {\n  val y = 2\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = UnixLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = unix))
       .get
     assertNoDiff(obtained, expected)
   }
@@ -71,7 +67,7 @@ class LineEndingsTest extends FunSuite with DiffAssertions {
     val expected = "@Singleton\nobject a {\n  val y = 2\n}"
     val obtained = Scalafmt
       .format(original,
-              ScalafmtStyle.default.copy(lineEndings = UnixLineEndings))
+              ScalafmtStyle.default.copy(lineEndings = unix))
       .get
     assertNoDiff(obtained, expected)
   }

--- a/core/src/test/scala/org/scalafmt/StripMarginTests.scala
+++ b/core/src/test/scala/org/scalafmt/StripMarginTests.scala
@@ -130,7 +130,8 @@ val msg = s'''AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
   testsToRun.foreach(runTest(run))
 
-  val alignStyle = ScalafmtStyle.default.copy(alignStripMarginStrings = true)
+  val alignStyle =
+    ScalafmtStyle.default.copy(assumeStandardLibraryStripMargin = true)
 
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
     val runner = scalafmtRunner.withParser(parse)

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -22,8 +22,12 @@ import scala.meta.Tree
 import scala.meta.parsers.Parse
 import scala.meta.parsers.ParseException
 
+import org.scalafmt.BinPack
+import org.scalafmt.IndentOperator
+
 trait HasTests extends FunSuiteLike with FormatAssertions {
   import LoggerOps._
+  import ScalafmtStyle._
   val scalafmtRunner = ScalafmtRunner.default.copy(
     debug = true,
     maxStateVisits = 150000,
@@ -100,41 +104,48 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
       case "scalajs" => ScalafmtStyle.scalaJs
       case "dangling" =>
         ScalafmtStyle.unitTest80.copy(maxColumn = 40,
-                                      alignByOpenParenCallSite = false,
+                                      align = unitTest80.align.copy(
+                                        openParenCallSite = false
+                                      ),
                                       danglingParentheses = true,
                                       configStyleArguments = false)
       case "noAlign" =>
-        ScalafmtStyle.unitTest80
-          .copy(maxColumn = 40, alignByOpenParenCallSite = false)
+        ScalafmtStyle.unitTest80.copy(
+          maxColumn = 40,
+          align = unitTest80.align.copy(
+            openParenCallSite = false
+          )
+        )
       case "stripMargin" =>
-        ScalafmtStyle.unitTest80.copy(alignStripMarginStrings = true)
+        ScalafmtStyle.unitTest80.copy(assumeStandardLibraryStripMargin = true)
       case "spaces" =>
-        ScalafmtStyle.unitTest80.copy(spacesInImportCurlyBraces = true,
-                                      spaceAfterTripleEquals = true)
+        ScalafmtStyle.unitTest80.copy(
+          spaces = unitTest80.spaces
+            .copy(inImportCurlyBraces = true, afterTripleEquals = true)
+        )
       case "align" => ScalafmtStyle.addAlign(ScalafmtStyle.unitTest80)
       case "alignNoSpace" =>
         ScalafmtStyle.unitTest80.copy(
-          alignTokens = Set(
-            AlignToken(":", ".*"),
-            AlignToken(",", ".*")
+          align = ScalafmtStyle.unitTest80.align.copy(
+            tokens = Set(
+              AlignToken(":", ".*"),
+              AlignToken(",", ".*")
+            )
           )
         )
       case "parentConstructors" =>
         ScalafmtStyle.unitTest80.copy(
-          binPackParentConstructors = true,
+          binPack = BinPack(false, false, parentConstructors = true),
           maxColumn = 40
         )
       case "alignByArrowEnumeratorGenerator" =>
         ScalafmtStyle.unitTest40.copy(
-          alignByArrowEnumeratorGenerator = true
+          align = ScalafmtStyle.unitTest40.align
+            .copy(arrowEnumeratorGenerator = true)
         )
       case "noIndentOperators" =>
-        ScalafmtStyle.unitTest80.copy(
-          unindentTopLevelOperators = true,
-          indentOperatorsIncludeFilter =
-            ScalafmtStyle.indentOperatorsIncludeAkka,
-          indentOperatorsExcludeFilter =
-            ScalafmtStyle.indentOperatorsExcludeAkka)
+        ScalafmtStyle.unitTest80.copy(unindentTopLevelOperators = true,
+                                      indentOperator = IndentOperator.akka)
       case "unicode" =>
         ScalafmtStyle.unitTest80.copy(
           rewriteTokens = Map(
@@ -143,7 +154,8 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
           )
         )
       case "spacesBeforeContextBound" =>
-        ScalafmtStyle.unitTest80.copy(spaceBeforeContextBoundColon = true)
+        ScalafmtStyle.unitTest80.copy(
+          spaces = unitTest80.spaces.copy(beforeContextBoundColon = true))
       case "trailing-commas" =>
         ScalafmtStyle.unitTest40.copy(
           poorMansTrailingCommasInConfigStyle = true)

--- a/intellij/intellij.iml
+++ b/intellij/intellij.iml
@@ -9,7 +9,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
-    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-143.1821.5" jdkType="IDEA JDK" />
+    <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-162.2032.8" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="scala-sdk-2.11.7" level="application" />
     <orderEntry type="module-library">

--- a/metaconfig/src/main/scala/metaconfig/ConfigReader.scala
+++ b/metaconfig/src/main/scala/metaconfig/ConfigReader.scala
@@ -1,0 +1,108 @@
+package metaconfig
+
+import scala.annotation.compileTimeOnly
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta.tokens.Token.Constant
+
+class Error(msg: String) extends Exception(msg)
+case class ConfigError(msg: String) extends Error(msg)
+case class ConfigErrors(es: Seq[Throwable])
+    extends Error(s"Errors: ${es.mkString("\n")}")
+
+@compileTimeOnly("@metaconfig.Config not expanded")
+class ConfigReader extends scala.annotation.StaticAnnotation {
+
+  inline def apply(defn: Any): Any = meta {
+    def genReader(typ: Type, params: Seq[Term.Param] = Seq.empty): Defn.Val = {
+      def defaultArgs: Seq[Term.Arg] = {
+        params.collect {
+          case Term.Param(_, pName: Term.Name, Some(pTyp: Type), _) =>
+            val nameLit = Lit(pName.syntax)
+            Term.Arg.Named(pName, q"get[$pTyp]($nameLit, $pName)")
+        }
+      }
+      val argLits = params.map(x => Lit(x.name.syntax))
+      val classLit = Lit(typ.syntax)
+      val constructor = Ctor.Ref.Name(typ.syntax)
+      val bind = Term.Name("x")
+      val patTyped = Pat.Typed(Pat.Var.Term(bind), typ.asInstanceOf[Pat.Type])
+      q"""val reader = new _root_.metaconfig.Reader[$typ] {
+          override def read(any: Any): _root_.metaconfig.Result[$typ] = {
+            any match {
+              case ($patTyped) => Right($bind)
+              case _root_.metaconfig.String2AnyMap(map) =>
+                def get[T](path: String, default: T)(implicit
+                    ev: _root_.metaconfig.Reader[T]) = {
+                  ev.read(map.getOrElse(path, default)) match {
+                    case Right(e) => e
+                    case Left(e: java.lang.IllegalArgumentException) =>
+                      val msg =
+                        "Error reading field '" + path +
+                        "' on class " + $classLit +
+                        ". Expected argument of type " + default.getClass.getSimpleName +
+                        ". Obtained " + e.getMessage()
+                      throw _root_.metaconfig.ConfigError(msg)
+                    case Left(e) => throw e
+                  }
+                }
+                val validFields = _root_.scala.collection.immutable.Set(..$argLits)
+                val invalidFields = map.keys.filterNot(validFields)
+                if (invalidFields.nonEmpty) {
+                  val msg = "Invalid fields: " + invalidFields.mkString(", ")
+                  Left(_root_.metaconfig.ConfigError(msg))
+                } else {
+                  try {
+                      Right(new $constructor(..$defaultArgs))
+                  } catch {
+                    case _root_.scala.util.control.NonFatal(e) => Left(e)
+                  }
+                }
+              case els =>
+                val msg =
+                  $classLit + " cannot be '" + els +
+                    "' (of class " + els.getClass.getSimpleName + ")."
+                Left(_root_.metaconfig.ConfigError(msg))
+            }
+          }
+        }
+     """
+    }
+
+    def expandClass(c: Defn.Class): Stat = {
+      val q"..$mods class $tname[..$tparams] ..$mods2 (...$paramss) extends $template" =
+        c
+      val template"{ ..$earlyStats } with ..$ctorcalls { $param => ..$stats }" =
+        template
+      val flatParams = paramss.flatten
+      val fields: Seq[Term.Tuple] = flatParams.collect {
+        case Term.Param(_, name: Term.Name, _, _) =>
+          q"(${Lit(name.syntax)}, $name)"
+      }
+      val fieldsDef: Stat = {
+        val body =
+          Term.Apply(q"_root_.scala.collection.immutable.Map", fields)
+        q"def fields = $body"
+      }
+      val typReader = genReader(tname, flatParams)
+      val newStats = stats ++ Seq(fieldsDef) ++ Seq(typReader)
+      val newTemplate = template"""
+        { ..$earlyStats } with ..$ctorcalls { $param => ..$newStats }
+                                  """
+      val result =
+        q"""
+            ..$mods class $tname[..$tparams] ..$mods2 (...$paramss) extends $newTemplate
+         """
+      result
+    }
+    defn match {
+      case c: Defn.Class => expandClass(c)
+      case Term.Block(Seq(c: Defn.Class, companion)) =>
+        q"""
+        ${expandClass(c)}; $companion
+         """
+      case els =>
+        abort(s"Failed to expand: ${els.structure}")
+    }
+  }
+}

--- a/metaconfig/src/main/scala/metaconfig/Reader.scala
+++ b/metaconfig/src/main/scala/metaconfig/Reader.scala
@@ -1,0 +1,100 @@
+package metaconfig
+
+import scala.collection.immutable.Iterable
+import scala.collection.immutable.Seq
+import scala.collection.immutable.Set
+import scala.reflect.ClassTag
+
+trait Reader[+T] { self =>
+  def read(any: Any): Result[T]
+
+//  def orElse(els: Reader[T]): Reader[T] =
+//    new Reader[T] {
+//      override def read(any: Any): Result[T] = self.read(any) match {
+//        case Right(x) => Right(x)
+//        // TODO(olafur) accumulate errors
+//        case Left(_) => els.read(any)
+//      }
+//    }
+
+  def map[TT](f: T => TT): Reader[TT] = self.flatMap(x => Right(f(x)))
+
+  def flatMap[TT](f: T => Result[TT]): Reader[TT] =
+    new Reader[TT] {
+      override def read(any: Any) = self.read(any) match {
+        case Right(x) => f(x)
+        case Left(x) => Left(x)
+      }
+    }
+}
+
+object Reader {
+
+  def fail[T](x: Any): Result[T] = {
+    Left(
+      new IllegalArgumentException(
+        s"value '$x' of type ${x.getClass.getSimpleName}."))
+  }
+
+  def instance[T](f: PartialFunction[Any, Result[T]])(
+      implicit ev: ClassTag[T]) =
+    new Reader[T] {
+      override def read(any: Any): Result[T] = {
+        try {
+          if (ev.runtimeClass.isInstance(any)) {
+            Right(any.asInstanceOf[T])
+          } else {
+            f.applyOrElse(any, (x: Any) => fail[T](x))
+          }
+        } catch {
+          case e: ConfigError => Left(e)
+        }
+      }
+    }
+  implicit val intR = instance[Int] { case x: Int => Right(x) }
+  implicit val stringR = instance[String] { case x: String => Right(x) }
+  implicit val boolR = instance[scala.Boolean] {
+    case x: Boolean => Right(x)
+  }
+  implicit def seqR[T](implicit ev: Reader[T]): Reader[Seq[T]] =
+    instance[Seq[T]] {
+      case lst: Seq[_] =>
+        val res = lst.map(ev.read)
+        val lefts = res.collect { case Left(e) => e }
+        if (lefts.nonEmpty) Left(ConfigErrors(lefts))
+        else Right(res.collect { case Right(e) => e })
+    }
+
+  implicit def setR[T](implicit ev: Reader[T]): Reader[Set[T]] =
+    instance[Set[T]] {
+      case lst: Set[_] => Right(lst.asInstanceOf[Set[T]])
+      case lst: Seq[_] =>
+        val res = lst.map(ev.read)
+        val lefts = res.collect { case Left(e) => e }
+        if (lefts.nonEmpty) Left(ConfigErrors(lefts))
+        else Right(res.collect({ case Right(e) => e }).to[Set])
+    }
+
+  // TODO(olafur) generic can build from reader
+  implicit def mapR[K, V](implicit evK: Reader[K],
+                          evV: Reader[V]): Reader[Map[K, V]] =
+    instance[Map[K, V]] {
+      case map: Map[_, _] =>
+        val res = map.map {
+          case (k, v) =>
+            for {
+              kk <- evK.read(k).right
+              vv <- evV.read(v).right
+            } yield (kk, vv)
+        }
+        val sRes = Seq(res.toSeq: _*)
+        val lefts: Seq[Throwable] = sRes.collect {
+          case Left(e) => e
+        }
+        if (lefts.nonEmpty) Left(ConfigErrors(lefts.toSeq))
+        else {
+          val resultMap = sRes.collect { case Right(e) => e }
+          Right(resultMap.toMap)
+        }
+    }
+}

--- a/metaconfig/src/main/scala/metaconfig/String2AnyMap.scala
+++ b/metaconfig/src/main/scala/metaconfig/String2AnyMap.scala
@@ -1,0 +1,14 @@
+package metaconfig
+
+object String2AnyMap {
+  def unapply(arg: Any): Option[Map[String, Any]] = arg match {
+    case someMap: Map[_, _] =>
+      try {
+        Some(someMap.asInstanceOf[Map[String, Any]])
+      } catch {
+        case _: ClassCastException =>
+          None
+      }
+    case _ => None
+  }
+}

--- a/metaconfig/src/main/scala/metaconfig/package.scala
+++ b/metaconfig/src/main/scala/metaconfig/package.scala
@@ -1,0 +1,4 @@
+
+package object metaconfig {
+  type Result[T] = Either[Throwable, T]
+}

--- a/metaconfig/src/test/scala/metaconfig/ConfigReaderTest.scala
+++ b/metaconfig/src/test/scala/metaconfig/ConfigReaderTest.scala
@@ -1,0 +1,94 @@
+package metaconfig
+
+import org.scalatest.FunSuite
+
+class ConfigReaderTest extends FunSuite {
+  type Result[T] = Either[Throwable, T]
+
+  @ConfigReader
+  case class Inner(nest: Int)
+
+  @ConfigReader
+  case class Outer(i: Int, inner: Inner) {
+    implicit val innerReader: Reader[Inner] = inner.reader
+  }
+
+  @ConfigReader
+  case class Bar(i: Int, b: Boolean, s: String)
+
+  @ConfigReader
+  case class HasList(i: Seq[Int])
+
+  @ConfigReader
+  case class HasMap(i: Map[Int, Int])
+
+  val b = Bar(0, true, "str")
+  test("invalid field") {
+    assert(
+      b.reader.read(Map("is" -> 2, "var" -> 3)) ==
+        Left(ConfigError("Invalid fields: is, var")))
+  }
+
+  test("read OK") {
+    assert(b.reader.read(Map("i" -> 2)) == Right(b.copy(i = 2)))
+    assert(b.reader.read(Map("s" -> "str")) == Right(b.copy(s = "str")))
+    assert(b.reader.read(Map("b" -> true)) == Right(b.copy(b = true)))
+    assert(
+      b.reader.read(
+        Map(
+          "i" -> 3,
+          "b" -> true,
+          "s" -> "rand"
+        )) == Right(b.copy(i = 3, s = "rand", b = true)))
+  }
+  test("unexpected type") {
+    val msg =
+      "Error reading field 'i' on class Bar. Expected argument of type Integer. Obtained value 'str' of type String."
+    assert(b.reader.read(Map("i" -> "str")) == Left(ConfigError(msg)))
+  }
+
+  test("write OK") {
+    assert(
+      b.fields == Map(
+        "i" -> 0,
+        "b" -> true,
+        "s" -> "str"
+      ))
+  }
+  test("nested OK") {
+    val m: Map[String, Any] = Map(
+      "i" -> 4,
+      "inner" -> Map(
+        "nest" -> 5
+      )
+    )
+    val o = Outer(2, Inner(3)).reader.read(m)
+    println(o)
+  }
+
+  test("Seq") {
+    val lst = HasList(List(1, 2, 3))
+    assert(
+      lst.reader.read(Map("i" -> Seq(666, 777))) == Right(
+        HasList(Seq(666, 777))))
+  }
+
+  test("Map") {
+    val lst = HasMap(Map(1 -> 2))
+    assert(
+      lst.reader.read(Map("i" -> Map(666 -> 777))) ==
+          Right(
+        HasMap(Map(666 -> 777))))
+  }
+
+  test("inner") {
+//    val m: Map[String, Any] = Map(
+//      "i" -> 4
+//      )
+//    )
+//    val o = Outer(2, Inner(3)).reader.read(m)
+
+
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,8 @@
 resolvers += Classpaths.sbtPluginReleases
+resolvers += Resolver.url(
+  "dancingrobot84-bintray",
+  url("http://dl.bintray.com/dancingrobot84/sbt-plugins/")
+)(Resolver.ivyStylePatterns)
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
@@ -10,3 +14,5 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.5")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.dancingrobot84" % "sbt-idea-plugin" % "0.4.2")
+//

--- a/readme/Adopters.scala
+++ b/readme/Adopters.scala
@@ -17,17 +17,14 @@ object Adopters {
     Adopter("scalafmt",
             "http://scalafmt.org",
             Some("Code formatter for Scala")),
-    Adopter("HERE",
-            "http://here.com",
-            None),
-    Adopter("Letgo",
-            "http://letgo.com",
-            None),
+    Adopter("HERE", "http://here.com", None),
+    Adopter("Letgo", "http://letgo.com", None),
     Adopter("Seventh Sense",
             "http://7thsense.io",
             Some("Predictive analytics for sales and marketing")),
-    Adopter("Teralytics",
-            "http://teralytics.net",
-            Some("We transform raw, human activity data into valuable insights."))
+    Adopter(
+      "Teralytics",
+      "http://teralytics.net",
+      Some("We transform raw, human activity data into valuable insights."))
   )
 }

--- a/readme/Changelog01.scalatex
+++ b/readme/Changelog01.scalatex
@@ -120,7 +120,7 @@
 @sect{0.1.4}
   @ul
     @li
-      @sect.ref{--assumeStandardLibraryStripMargin}.
+      @sect.ref{assumeStandardLibraryStripMargin}.
     @li
       @sect.ref{// format: off}.
     @li

--- a/readme/Changelog02.scalatex
+++ b/readme/Changelog02.scalatex
@@ -265,11 +265,11 @@
       The tests now format 1.244.070 LOC @b("twice") to ensure that
       scalafmt is idempotent.
     @li
-      @sect.ref{--assumeStandardLibraryStripMargin} is now disabled by default for two
+      @sect.ref{assumeStandardLibraryStripMargin} is now disabled by default for two
       reasons: 1. it may cause non-idempotent formatting in very rare cases
       and 2. it makes the false assumption that
       @code("stripMargin") comes from the standard library (discussion here @issues(170)).
-      Refer to @sect.ref{--assumeStandardLibraryStripMargin} to enable it at your own risk.
+      Refer to @sect.ref{assumeStandardLibraryStripMargin} to enable it at your own risk.
     @li
       IntelliJ plugin does not require restart when @code(".scalafmt") changes.
       Instead, new changes are picked up automatically and a green info bubble
@@ -316,7 +316,7 @@
     @li
       Custom style configuration, see @sect.ref{Configuration}
     @li
-      Token alignment, see @sect.ref{--alignTokens}
+      Token alignment, see @sect.ref{align.tokens}
     @li
       Closed issues: @issues( 144, 143, 138, 131, 120, 114).
     @li

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -6,18 +6,19 @@
 @sect{Configuration}
 
   @p
-    Configuration for scalafmt is a bit unorthodox, it is managed with a
-    plain text file @code{.scalafmt} where options are defined as CLI flags.
-    I recommend you create the @code(".scalafmt") in in the root directory
-    of your project.
+    Configuration for scalafmt is defined in a
+    plain text file @code{.scalafmt.conf} using
+    @lnk("HOCON", "https://github.com/typesafehub/config") syntax.
+    To reuse your configuration with IntelliJ,
+    @code(".scalafmt.conf") must be placed in the root directory of your project.
 
   @p
-    Here is an example @code(".scalafmt").
+    Here is an example @code(".scalafmt.conf").
 
     @cliFlags
       # Example .scalafmt, comments are supported.
-      --style defaultWithAlign # For pretty alignment.
-      --maxColumn 100          # For my wide 30" display.
+      style = defaultWithAlign # For pretty alignment.
+      maxColumn = 100          # For my wide 30" display.
 
   @p
     A note of warning. I personally use the default style which means that the
@@ -39,7 +40,7 @@
     by default.
 
 
-  @sect{--style}
+  @sect{style}
     Option 1: @b{default}
     @fmt(ScalafmtStyle.default.copy(maxColumn = 40))
       // Column 40                           |
@@ -96,17 +97,17 @@
 
         function(argument1, argument2)
 
-        // --continuationIndent 2 for call + defn site
-        // --alignByOpenParenCallSite false
-        // --danglingParentheses true
+        // continuationIndent = 2  # for call + defn site
+        // align.openParenCallSite = false
+        // danglingParentheses = true
         function(argument1, argument2, argument3, argument4)
 
-        // --alignByOpenParenCallSite true
+        // openParenCallSite = true
         def foobar(argument1: Type1, argument2: Type2): Int = argument1 + argument2
 
       }
 
-  @sect{--maxColumn}
+  @sect{maxColumn}
     Default: @b(default.maxColumn)
 
     @ul
@@ -119,7 +120,7 @@
       @li
         Consider refactoring your code before of choosing a value above 100.
 
-  @sect{--continuationIndentCallSite}
+  @sect{continuationIndent.callSite}
     Default: @b(default.continuationIndentCallSite)
 
     @p
@@ -129,17 +130,17 @@
           argument1 // indented by 2
         )
 
-  @sect{--continuationIndentDefnSite}
+  @sect{continuationIndent.defnSite}
     Default: @b(default.continuationIndentDefnSite)
 
     @p
-      Same as @code{--continuationIndentCallSite} except for definition site.
+      Same as @code{continuationIndent.callSite} except for definition site.
       Example:
       @hl.scala
         def function(
             argument1: Type1): ReturnType // Indented by 4
 
-  @sect{--alignTokens}
+  @sect{align.tokens}
     Default: @b{off}
 
     @p
@@ -194,8 +195,8 @@
         indentation level. It's best to enable formatting at the same level as
         when it was disabled.
 
-  @sect{--assumeStandardLibraryStripMargin}
-    Default: @b(default.alignStripMarginStrings)
+  @sect{assumeStandardLibraryStripMargin}
+    Default: @b(default.assumeStandardLibraryStripMargin)
 
     @p
       If @b{true}, the margin character @code("|") is aligned with the opening triple
@@ -206,15 +207,15 @@
 
       @note. May cause non-idempotent formatting in rare cases, see @issue(192).
 
-  @sect{--javaDocs vs. --scalaDocs}
-    Default: --scalaDocs
+  @sect{docstrings}
+    Default: @b(default.docstrings.toString)
 
     @hl.scala
-      // --scalaDocs
+      // ScalaDoc
       /** Align by second asterisk.
         *
         */
-      // --javaDocs
+      // JavaDoc
       /** Align by first asterisk.
        *
        */
@@ -232,7 +233,7 @@
           Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] = 2
 
   @sect{--alignByArrowEnumeratorGenerator}
-    Default: @default.alignByArrowEnumeratorGenerator
+    Default: @default.align.arrowEnumeratorGenerator
 
     @hl.scala
       // false
@@ -270,7 +271,7 @@
         // body ...
       }
   @sect{--alignByOpenParenCallSite}
-    Default: @default.alignByOpenParenCallSite
+    Default: @default.align.openParenCallSite
 
     @hl.scala
       // Column limit |

--- a/readme/Readme.scala
+++ b/readme/Readme.scala
@@ -8,6 +8,7 @@ import java.util.Date
 
 import com.twitter.util.Eval
 import org.scalafmt.AlignToken
+import org.scalafmt.Config
 import org.scalafmt.Scalafmt
 import org.scalafmt.ScalafmtStyle
 import org.scalafmt.cli.Cli
@@ -47,7 +48,7 @@ object Readme {
   }
 
   def cliFlags(flags: String) = {
-    require(Cli.parseConfigFile(flags).isDefined)
+    require(Config.fromHocon(flags).isRight)
     hl.scala(flags)
   }
 
@@ -84,14 +85,17 @@ object Readme {
 
   def exampleAlign(code: String): TypedTag[String] = {
     val formatted = Scalafmt
-      .format(code,
-              ScalafmtStyle.default40.copy(alignTokens = AlignToken.default))
+      .format(
+        code,
+        ScalafmtStyle.default40.copy(
+          align =
+            ScalafmtStyle.default40.align.copy(tokens = AlignToken.default)))
       .get
     hl.scala(formatted)
   }
 
   val stripMarginStyle =
-    ScalafmtStyle.default.copy(alignStripMarginStrings = true)
+    ScalafmtStyle.default.copy(assumeStandardLibraryStripMargin = true)
 
   def fmt(style: ScalafmtStyle)(code: String): TypedTag[String] =
     example(code, style)

--- a/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
+++ b/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
@@ -90,8 +90,8 @@ object ScalaFmtPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         // scala-library needs to be explicitly added to fix
         // https://github.com/olafurpg/scalafmt/issues/190
-        "org.scala-lang" % "scala-library"     % org.scalafmt.Versions.scala   % "scalafmt",
-        "com.geirsson"   % "scalafmt-cli_2.11" % org.scalafmt.Versions.nightly % "scalafmt"
+        "org.scala-lang" % "scala-library" % org.scalafmt.Versions.scala % "scalafmt",
+        "com.geirsson" % "scalafmt-cli_2.11" % org.scalafmt.Versions.nightly % "scalafmt"
       )
     )
 

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/helloworld/.scalafmt
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/helloworld/.scalafmt
@@ -1,1 +1,1 @@
---style IntelliJ
+style = IntelliJ


### PR DESCRIPTION
- [x] metaconfig, boilerplate-free config-agnostic library using scala.meta inline/meta macro annotations.
- [x] hocon2class, boilerplate free HOCON using metaconfig
- [x] Automatic @ConfigReader for ScalafmtStyle, fixes #316
- [x] remove CLI style flags
- [x] reorganize ScalafmtStyle, fixes #453
- [x] update docs
- [x] sbt read config
- [x] intellij plugin
- [x] config migration
- [x] move runner flags into scalafmtstyle