### PR TITLE
Fast get owners

### DIFF
--- a/core/src/main/scala/org/scalafmt/Error.scala
+++ b/core/src/main/scala/org/scalafmt/Error.scala
@@ -20,7 +20,8 @@ object Error {
 
   def reportIssue: String =
     "Please file an issue on https://github.com/olafurpg/scalafmt/issues"
-  case object UnableToParseCliOptions extends Error("Failed to parse CLI options")
+  case object UnableToParseCliOptions
+      extends Error("Failed to parse CLI options")
 
   case class Incomplete(formattedCode: String)
       extends Error("Unable to format file due to bug in scalafmt")
@@ -48,7 +49,7 @@ object Error {
 
   case class UnexpectedTree[Expected <: Tree: ClassTag](obtained: Tree)
       extends Error(
-        s"Expected: ${classTag[Expected].getClass}\nObtained: ${log(obtained)}")
+        s"Expected: ${classTag[Expected].runtimeClass.getSimpleName}\nObtained: ${log(obtained)}")
 
   case class CantFormatFile(msg: String)
       extends Error("scalafmt cannot format this file:\n" + msg)

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -37,7 +37,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   import TreeOps._
 
   val tokens: Array[FormatToken] = FormatToken.formatTokens(tree.tokens)
-  val ownersMap = getOwners(tree)
+  val ownersMap = fastGetOwners(tree)
   val statementStarts = getStatementStarts(tree)
   val dequeueSpots = getDequeueSpots(tree) ++ statementStarts.keys
   val matchingParentheses = getMatchingParentheses(tree.tokens)
@@ -440,6 +440,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     var inside = false
     var expire = tree.tokens.head
     tree.tokens.foreach {
+      case t if t.is[Whitespace] =>
       case t if !inside && ((t, ownersMap(hash(t))) match {
             case (LeftParen(), _: Term.Apply) =>
               // TODO(olafur) https://github.com/scalameta/scalameta/issues/345

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -997,7 +997,9 @@ class Router(formatOps: FormatOps) {
           if !nextNonComment(tok).right.is[KwIf] =>
         val expire = leftOwner match {
           case t: Term.If => t.elsep.tokens.last
-          case x => throw new UnexpectedTree[Term.If](x)
+          case x =>
+            logger.elem(formatToken)
+            throw new UnexpectedTree[Term.If](x)
         }
         Seq(
           Split(Space,

--- a/core/src/test/resources/Test.manual
+++ b/core/src/test/resources/Test.manual
@@ -1,3 +1,4 @@
+SKIP benchmarks/src/resources/scala-js/GenJSCode.scala
 SKIP https://raw.githubusercontent.com/scala-js/scala-js/8663c8060ca96a51bfc1f87f2f3f30babbeadbc3/scalalib/overrides-2.12/scala/collection/immutable/NumericRange.scala
 SKIP https://raw.githubusercontent.com/apache/spark/2c5b18fb0fdeabd378dd97e91f72d1eac4e21cc7/graphx/src/test/scala/org/apache/spark/graphx/PregelSuite.scala
 SKIP https://raw.githubusercontent.com/akka/akka/3698928fbdaa8fef8e2037fbc51887ab60addefb/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala

--- a/core/src/test/scala/org/scalafmt/FormatExperiment.scala
+++ b/core/src/test/scala/org/scalafmt/FormatExperiment.scala
@@ -21,10 +21,12 @@ import org.scalafmt.util.ExperimentResult.Skipped
 import org.scalafmt.util.ExperimentResult.Success
 import org.scalafmt.util.ExperimentResult.Timeout
 import org.scalafmt.util.ExperimentResult.UnknownFailure
+import org.scalafmt.util.FileOps
 import org.scalafmt.util.FormatAssertions
 import org.scalafmt.util.ScalaFile
 import org.scalafmt.util.ScalaProjectsExperiment
 import org.scalafmt.util.ScalacParser
+import org.scalafmt.util.TreeOps
 
 trait FormatExperiment extends ScalaProjectsExperiment with FormatAssertions {
   override val verbose = false
@@ -142,5 +144,16 @@ object FormatExperimentApp extends FormatExperiment with App {
   nonValidResults.foreach(println)
   if (nonValidResults.nonEmpty) {
     throw MegaTestFailed
+  }
+}
+
+object Profile {
+  def main(args: Array[String]): Unit = {
+    val code =
+      FileOps.readFile("benchmarks/src/resources/scala-js/GenJSCode.scala")
+    val tree = code.parse[Source].get
+    (0 until 10000).foreach { t =>
+      TreeOps.fastGetOwners(tree)
+    }
   }
 }

--- a/core/src/test/scala/org/scalafmt/util/GetOwnersTest.scala
+++ b/core/src/test/scala/org/scalafmt/util/GetOwnersTest.scala
@@ -1,0 +1,49 @@
+package org.scalafmt.util
+
+import scala.meta.dialects.Scala211
+import scala.meta.internal.parsers.ScalametaParser
+
+import org.scalafmt.UnitTests
+import org.scalafmt.util.TokenOps.TokenHash
+import org.scalatest.FunSuite
+
+class GetOwnersTest extends FunSuite with HasTests {
+  def check(diffTest: DiffTest): Unit = {
+    test(diffTest.fullName) {
+      import scala.meta._
+      val input = Input.String(diffTest.original)
+      val dialect = Scala211
+      val tree: Tree =
+        Scala211(input).parse(filename2parse(diffTest.filename).get).get
+
+      val parser = new ScalametaParser(input, Scala211)
+      val pos = new parser.TreePos(tree)
+      val hash2tok: Map[TokenHash, Token] =
+        tree.tokens.map(x => TokenOps.hash(x) -> x).toMap
+      val slow = TreeOps.getOwners(tree)
+      val fast = TreeOps.fastGetOwners(tree)
+      val sslow = slow.map {
+        case (k, v) => hash2tok(k).structure -> v
+      }
+      val ffast = fast.map {
+        case (k, v) => hash2tok(k).structure -> v
+      }
+//      logger.elem(sslow, ffast)
+//      tree.tokens.foreach(tok => logger.elem(tok.structure))
+      tree.tokens.foreach {
+        case Whitespace() =>
+        case tok if tok.start == tok.end =>
+        case tok =>
+          val k = TokenOps.hash(tok)
+          val (l, r) = fast(k) -> slow(k)
+          if (l != r) {
+            logger.elem(tok, tok.structure, l, l.structure, r, r.structure)
+            ???
+          }
+      }
+    }
+  }
+  UnitTests.tests.withFilter(!_.skip).foreach(check)
+
+  override def tests: Seq[DiffTest] = Nil
+}

--- a/metaconfig/src/main/scala/metaconfig/ConfigReader.scala
+++ b/metaconfig/src/main/scala/metaconfig/ConfigReader.scala
@@ -11,6 +11,18 @@ case class ConfigErrors(es: Seq[Throwable])
     extends Error(s"Errors: ${es.mkString("\n")}")
 
 @compileTimeOnly("@metaconfig.Config not expanded")
+class DefAnnotation extends scala.annotation.StaticAnnotation {
+  inline def apply(defn: Any): Any = meta {
+    defn match {
+      case d: Defn.Def =>
+        println(d.structure)
+        d
+      case _ => abort("no no no")
+    }
+  }
+}
+
+@compileTimeOnly("@metaconfig.Config not expanded")
 class ConfigReader extends scala.annotation.StaticAnnotation {
 
   inline def apply(defn: Any): Any = meta {

--- a/metaconfig/src/test/scala/metaconfig/ConfigReaderTest.scala
+++ b/metaconfig/src/test/scala/metaconfig/ConfigReaderTest.scala
@@ -5,6 +5,11 @@ import org.scalatest.FunSuite
 class ConfigReaderTest extends FunSuite {
   type Result[T] = Either[Throwable, T]
 
+  @DefAnnotation
+  def myDef = 2
+
+  myDef
+
   @ConfigReader
   case class Inner(nest: Int)
 
@@ -87,7 +92,6 @@ class ConfigReaderTest extends FunSuite {
 //      )
 //    )
 //    val o = Outer(2, Inner(3)).reader.read(m)
-
 
   }
 


### PR DESCRIPTION
It's definitely faster, but still appalingly slow

```
[info] # Run complete. Total time: 00:01:40
[info]
[info] Benchmark                       Mode  Cnt     Score     Error  Units
[info] Micro.ExtraLarge.fastGetOwners  avgt   10  2007.994 ± 119.539  ms/op
[info] Micro.ExtraLarge.getOwners      avgt   10  2802.432 ± 353.113  ms/op
```

This file contains 4k LOC and parsing it takes 50ms.
