### PR TITLE
Add scala-reflect back, fixes #492.

### DIFF
--- a/bin/issue492.scala
+++ b/bin/issue492.scala
@@ -1,0 +1,3 @@
+object A {
+    <.section(render(props)
+}

--- a/bin/issue492.sh
+++ b/bin/issue492.sh
@@ -1,0 +1,10 @@
+# sbt cli/assembly
+# I can't reproduce this error in sbt, see https://github.com/olafurpg/scalafmt/issues/492
+set -e
+echo "Issue 492"
+in_file=bin/issue492.scala
+out_file=target/issue492-formatted.scala
+sbt cli/assembly
+java -jar cli/target/scala-2.11/scalafmt.jar -f $in_file > $out_file
+diff --ignore-blank-lines $in_file $out_file
+

--- a/bin/testAll.sh
+++ b/bin/testAll.sh
@@ -5,5 +5,6 @@ set -e
 sbt clean test
 sbt "core/test:runMain org.scalafmt.FormatExperimentApp"
 sbt "; publishLocal ; scripted"
+./bin/issue492.sh
 #sbt coverageAggregate
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val buildSettings = Seq(
 
 lazy val metaMacroSettings: Seq[Def.Setting[_]] = Seq(
   libraryDependencies += "org.scalameta" %% "scalameta" % Deps.scalameta,
-  sources in (Compile,doc) := Nil,
+  sources in (Compile, doc) := Nil,
   addCompilerPlugin(
     "org.scalameta" % "paradise" % "3.0.0-M5" cross CrossVersion.full),
   scalacOptions += "-Xplugin-require:macroparadise"
@@ -135,12 +135,12 @@ lazy val core = project
       (runMain in Test).toTask(" org.scalafmt.FormatExperimentApp").value
     },
     libraryDependencies ++= Seq(
-      "com.lihaoyi"   %% "sourcecode" % "0.1.2",
-      "org.scalameta" %% "scalameta"  % Deps.scalameta,
-      "com.typesafe"     % "config" % "1.2.1",
+      "com.lihaoyi"    %% "sourcecode"   % "0.1.2",
+      "org.scalameta"  %% "scalameta"    % Deps.scalameta,
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "com.typesafe"   % "config"        % "1.2.1",
       // Test dependencies
       "org.scalariform"                %% "scalariform"    % Deps.scalariform,
-      "org.scala-lang"                 % "scala-reflect"   % scalaVersion.value % "test",
       "org.scala-lang"                 % "scala-compiler"  % scalaVersion.value % "test",
       "ch.qos.logback"                 % "logback-classic" % "1.1.6" % "test",
       "com.googlecode.java-diff-utils" % "diffutils"       % "1.3.0" % "test",

--- a/core/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/core/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -29,6 +29,7 @@ class FidelityTest extends FunSuite with FormatAssertions {
           "ConfigReader.scala",
           "BuildTime.scala",
           "GitCommit.scala",
+          "issue492.scala",
           "/target/",
           "/resources/",
           "/gh-pages/"


### PR DESCRIPTION
Once https://github.com/scalameta/scalameta/issues/502 is fixed, we can
remove scala-reflect.

Crazy enough, I wasn't able to reproduce the error via SBT so now I have
a bash script to ensure the same doesn't happen again.