### PR TITLE
Add AvoidInfix rewrite rule.

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -16,6 +16,7 @@ import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.LogLevel
 import com.martiansoftware.nailgun.NGContext
+import org.scalafmt.util.RegexOps
 
 object Cli {
   def nailMain(nGContext: NGContext): Unit = {
@@ -53,13 +54,6 @@ object Cli {
     CliArgParser.scoptParser.parse(args, init).map(CliOptions.auto(init))
   }
 
-  private def mkRegexp(filters: Seq[String]): Regex =
-    filters match {
-      case Nil => "$a".r // will never match anything
-      case head :: Nil => head.r
-      case _ => filters.mkString("(", "|", ")").r
-    }
-
   def canFormat(path: String): Boolean =
     path.endsWith(".scala") || path.endsWith(".sbt")
 
@@ -81,7 +75,7 @@ object Cli {
     // Ensure all paths are absolute
     val absolute =
       options.customFiles.map(makeAbsolute(options.common.workingDirectory))
-    val exclude = mkRegexp(options.customExcludes)
+    val exclude = RegexOps.mkRegexp(options.customExcludes)
     expandCustomFiles(options.common.workingDirectory, options.customFiles)
       .filter(x => exclude.findFirstIn(x).isEmpty)
   }
@@ -89,8 +83,8 @@ object Cli {
   /** Returns file paths defined via options.project */
   private def getFilesFromProject(options: CliOptions): Seq[String] = {
     val project = options.config.project
-    val include = mkRegexp(project.includeFilters)
-    val exclude = mkRegexp(project.excludeFilters)
+    val include = RegexOps.mkRegexp(project.includeFilters)
+    val exclude = RegexOps.mkRegexp(project.excludeFilters)
 
     def matches(path: String): Boolean =
       include.findFirstIn(path).isDefined &&

--- a/core/src/main/scala/org/scalafmt/config/InfixSettings.scala
+++ b/core/src/main/scala/org/scalafmt/config/InfixSettings.scala
@@ -1,0 +1,4 @@
+package org.scalafmt.config
+
+import metaconfig.ConfigReader
+

--- a/core/src/main/scala/org/scalafmt/config/Matcher.scala
+++ b/core/src/main/scala/org/scalafmt/config/Matcher.scala
@@ -1,0 +1,10 @@
+package org.scalafmt.config
+
+import scala.util.matching.Regex
+
+class Matcher(include: Regex, exclude: Regex) {
+  def matches(input: String): Boolean = {
+    include.findFirstIn(input).isDefined &&
+    exclude.findFirstIn(input).isEmpty
+  }
+}

--- a/core/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/core/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -17,7 +17,7 @@ case class Pattern(
 
 object Pattern {
   val neverInfix = Pattern(
-    Seq("\\w+"),
+    Seq("[\\w\\d_]+"),
     Seq(
       "until",
       "to",
@@ -25,6 +25,7 @@ object Pattern {
       "eq",
       "ne",
       "should.*",
+      "contain.*",
       "be",
       "synchronized",
       "have"

--- a/core/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/core/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -1,0 +1,33 @@
+package org.scalafmt.config
+
+import scala.util.matching.Regex
+
+import metaconfig.ConfigReader
+import org.scalafmt.util.RegexOps
+
+@ConfigReader
+case class Pattern(
+    includeFilters: Seq[String],
+    excludeFilters: Seq[String]
+) {
+  def toMatcher: Matcher =
+    new Matcher(RegexOps.mkRegexp(includeFilters),
+                RegexOps.mkRegexp(excludeFilters))
+}
+
+object Pattern {
+  val neverInfix = Pattern(
+    Seq("\\w+"),
+    Seq(
+      "until",
+      "to",
+      "by",
+      "eq",
+      "ne",
+      "should.*",
+      "be",
+      "synchronized",
+      "have"
+    )
+  )
+}

--- a/core/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/core/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -7,9 +7,11 @@ import org.scalafmt.rewrite.Rewrite
 @ConfigReader
 case class RewriteSettings(
     rules: Seq[Rewrite] = Nil,
-    redundantBraces: RedundantBracesSettings = RedundantBracesSettings()
+    redundantBraces: RedundantBracesSettings = RedundantBracesSettings(),
+    neverInfix: Pattern = Pattern.neverInfix
 ) {
   implicit val rewriteReader: Reader[Rewrite] = Rewrite.reader
+  implicit val patternReader: Reader[Pattern] = neverInfix.reader
 
   implicit val curlyReader: Reader[RedundantBracesSettings] =
     redundantBraces.reader

--- a/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -1,0 +1,38 @@
+package org.scalafmt.rewrite
+
+import scala.meta.Importee
+import scala.meta.Tree
+import scala.meta._
+import scala.meta.tokens.Token.LF
+import scala.meta.tokens.Token.LeftBrace
+import scala.meta.tokens.Token.LeftParen
+
+import org.scalafmt.util.RegexOps
+import org.scalafmt.util.TokenOps
+import org.scalafmt.util.logger
+
+case object AvoidInfix extends Rewrite {
+  override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    val matcher = ctx.style.rewrite.neverInfix.toMatcher
+    code.collect {
+      case infix: Term.ApplyInfix if matcher.matches(infix.op.value) =>
+        val rhs = infix.args.last.tokens
+        val last = rhs.last
+        val head = rhs.head
+        val (open, close) =
+          if (head.is[LeftParen] ||
+              head.is[LeftBrace]) "" -> ""
+          else "(" -> ")"
+        val op = infix.op.tokens.head
+        val opNewline = {
+          val next = ctx.tokenTraverser.nextToken(op)
+          if (next.is[LF]) next
+          else op
+        }
+        Seq(
+          Patch(op, opNewline, s".${op.syntax}$open"),
+          Patch(last, last, s"${last.syntax}$close")
+        )
+    }.flatten
+  }
+}

--- a/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -12,27 +12,48 @@ import org.scalafmt.util.TokenOps
 import org.scalafmt.util.logger
 
 case object AvoidInfix extends Rewrite {
+  // In a perfect world, we could just use
+  // Tree.transform {
+  //   case t: Term.ApplyInfix => Term.Apply(Term.Select(t.lhs, t.op), t.args)
+  // }
+  // and be done with it. However, until transform becomes token aware (see https://github.com/scalameta/scalameta/pull/457)
+  // we will do these dangerous rewritings by hand.
   override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
     val matcher = ctx.style.rewrite.neverInfix.toMatcher
     code.collect {
-      case infix: Term.ApplyInfix if matcher.matches(infix.op.value) =>
-        val rhs = infix.args.last.tokens
-        val last = rhs.last
-        val head = rhs.head
-        val (open, close) =
-          if (head.is[LeftParen] ||
-              head.is[LeftBrace]) "" -> ""
-          else "(" -> ")"
+      case infix: Term.ApplyInfix
+          if matcher.matches(infix.op.value) &&
+            !infix.lhs.is[Term.ApplyInfix] =>
+        val last = infix.args.last.tokens.last
+        val head = infix.args.head.tokens.head
+        val singleArgument = infix.args.length == 1
+        val needsParens =
+          singleArgument && // infix application owns parens if !singleArgument
+            !head.is[LeftParen] &&
+            !head.is[LeftBrace]
+        val (open, close) = if (needsParens) "(" -> ")" else "" -> ""
         val op = infix.op.tokens.head
-        val opNewline = {
-          val next = ctx.tokenTraverser.nextToken(op)
-          if (next.is[LF]) next
-          else op
+        /* We skip infix operators with crazy comments like this:
+            foo infixOp // crazy comment
+              (argument)
+         */
+        val hasCrazyComment =
+          ctx.tokenTraverser
+            .filter(op, head)(x => TokenOps.isInlineComment(x))
+            .nonEmpty
+        if (hasCrazyComment) Nil
+        else {
+          val removeNewlines =
+            ctx.tokenTraverser
+              .filter(op, head)(x => x.is[LF])
+              .map(lf => Patch(lf, lf, ""))
+          val rewriteInfixIntoTermApplication =
+            Seq(
+              Patch(op, op, s".${op.syntax}$open"),
+              Patch(last, last, s"${last.syntax}$close")
+            )
+          removeNewlines ++ rewriteInfixIntoTermApplication
         }
-        Seq(
-          Patch(op, opNewline, s".${op.syntax}$open"),
-          Patch(last, last, s"${last.syntax}$close")
-        )
     }.flatten
   }
 }

--- a/core/src/main/scala/org/scalafmt/util/RegexOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/RegexOps.scala
@@ -1,0 +1,12 @@
+package org.scalafmt.util
+
+import scala.util.matching.Regex
+
+object RegexOps {
+  def mkRegexp(filters: Seq[String]): Regex =
+    filters match {
+      case Nil => "$a".r // will never match anything
+      case head :: Nil => head.r
+      case _ => filters.mkString("(", "|", ")").r
+    }
+}

--- a/core/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -40,6 +40,15 @@ class TokenTraverser(tokens: Tokens) {
     }
   }
 
+  final def filter(start: Token, end: Token)(
+      predicate: Token => Boolean): Seq[Token] = {
+    if (start == end || nextToken(start) == start) Nil
+    else {
+      val tail = filter(nextToken(start), end)(predicate)
+      if (predicate(start)) start +: tail
+      else tail
+    }
+  }
   @tailrec
   final def reverseFind(token: Token)(
       predicate: Token => Boolean): Option[Token] = {

--- a/core/src/test/resources/rewrite/AvoidInfix.stat
+++ b/core/src/test/resources/rewrite/AvoidInfix.stat
@@ -7,6 +7,12 @@ lst.map(foo)
 lst map (foo)
 >>>
 lst.map(foo)
+<<< has curly
+lst map { x => y }
+>>>
+lst.map { x =>
+  y
+}
 <<< to
 1 to 100
 >>>
@@ -20,3 +26,43 @@ consumerPollers forall
    (poller => poller.isSubscribeRequestProcessed())
 >>>
 consumerPollers.forall(poller => poller.isSubscribeRequestProcessed())
+<<< don't rewrite if comment
+consumerPollers forall // Why write a comment here??
+   (poller => poller.isSubscribeRequestProcessed())
+>>>
+consumerPollers forall // Why write a comment here??
+  (poller => poller.isSubscribeRequestProcessed())
+<<< Dangerous 2
+(consumerPollers forall
+
+
+
+   (poller => poller.isSubscribeRequestProcessed()))
+>>>
+(consumerPollers.forall(poller => poller.isSubscribeRequestProcessed()))
+<<< Dangerous 3
+consumerPollers forall (a, b)
+>>>
+consumerPollers.forall(a, b)
+<<< Dangerous 4
+consumerPollers forall (
+    a, b)
+>>>
+consumerPollers.forall(a, b)
+<<< do nothing if lhs is whitelisted
+an[SparkException] should be thrownBy {
+     // foobar
+}
+>>>
+an[SparkException] should be thrownBy {
+  // foobar
+}
+<<< nested infix
+a banana walked into a green bar
+>>>
+a.banana(walked) into a green bar
+<<< more scalatest
+cp should not contain (jar3.getPath())
+>>>
+cp should not contain (jar3.getPath())
+

--- a/core/src/test/resources/rewrite/AvoidInfix.stat
+++ b/core/src/test/resources/rewrite/AvoidInfix.stat
@@ -1,0 +1,22 @@
+rewrite.rules = [AvoidInfix]
+<<< basic
+lst map foo
+>>>
+lst.map(foo)
+<<< has parens
+lst map (foo)
+>>>
+lst.map(foo)
+<<< to
+1 to 100
+>>>
+1 to 100
+<<< until
+1 until 100
+>>>
+1 until 100
+<<< Dangerous
+consumerPollers forall
+   (poller => poller.isSubscribeRequestProcessed())
+>>>
+consumerPollers.forall(poller => poller.isSubscribeRequestProcessed())

--- a/core/src/test/resources/rewrite/AvoidInfix2.stat
+++ b/core/src/test/resources/rewrite/AvoidInfix2.stat
@@ -1,0 +1,6 @@
+rewrite.rules = [AvoidInfix]
+rewrite.neverInfix.includeFilters = [".*"]
+<<< basic
+lst :: foo
+>>>
+lst.::(foo)

--- a/core/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/core/src/test/scala/org/scalafmt/FormatTests.scala
@@ -51,6 +51,14 @@ class FormatTests
     .withFilter(testShouldRun)
     .foreach(runTest(run))
 
+  def normalize(tree: Tree): Tree = {
+    import scala.meta._
+    tree.transform {
+      case t: Term.ApplyInfix =>
+        Term.Apply(Term.Select(t.lhs, t.op), t.args)
+    }
+  }
+
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
     val runner = scalafmtRunner.copy(parser = parse)
     val obtained =

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -2,6 +2,7 @@ package org.scalafmt.util
 
 import scala.collection.mutable
 import scala.meta.Tree
+import scala.meta.dialects.Scala211
 import scala.meta.parsers.Parse
 import scala.meta.parsers.ParseException
 import scala.util.Try


### PR DESCRIPTION
The AvoidInfix rule rewrites unconventional infix operators into regular term
application. For example

``` diff
-          promise success "done"
+          promise.success("done")
```

The configuration is like this

```
rewrite.rules = [AvoidInfix]
rewrite.neverInfix.includeFilters = ["\\w+"]
rewrite.neverInfix.excludeFilters = ["until", "to"]
```

The defaults exclude symbolic operators and regulars like `until` and `should` (from scalatest).

This implementation ignores nested infix operators, for example

``` scala
an[Exception] should be thrownBy foo
```

Diff from running AvoidInfix on spark and kafka:
  https://github.com/olafurpg/scala-repos/pull/11/files
