### PR TITLE
Use typelevel/scala in SBT plugin, fixes #485.

### DIFF
--- a/core/src/main/scala/org/scalafmt/Versions.scala
+++ b/core/src/main/scala/org/scalafmt/Versions.scala
@@ -5,7 +5,7 @@ package org.scalafmt
   */
 object Versions {
   // Nightly, used in CLI, build.sbt, etc.
-  val nightly = "0.4.6"
+  val nightly = "0.4.7-SNAPSHOT"
   // Stable, used in official user docs.
   val stable = "0.4.6"
   val scala = "2.11.8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
+++ b/scalafmtSbt/src/main/scala/org/scalafmt/sbt/ScalaFmtPlugin.scala
@@ -88,10 +88,23 @@ object ScalaFmtPlugin extends AutoPlugin {
     List(
       ivyConfigurations += config("scalafmt").hide,
       libraryDependencies ++= Seq(
-        // scala-library needs to be explicitly added to fix
-        // https://github.com/olafurpg/scalafmt/issues/190
-        "org.scala-lang" % "scala-library"     % org.scalafmt.Versions.scala   % "scalafmt",
-        "com.geirsson"   % "scalafmt-cli_2.11" % org.scalafmt.Versions.nightly % "scalafmt"
+        //  Context: https://github.com/olafurpg/scalafmt/issues/485#issuecomment-253873977
+        //
+        //  - SBT plugins must build against 2.10
+        //  - scalafmt is 2.11 only because scala.meta makes heavy usage of macro
+        //    annotations.
+        //  - To solve this problem, the scalafmt SBT plugin classloads itself with
+        //    scala-library 2.11.8 in a hidden configuration (see
+        //        http://www.scala-sbt.org/0.13/docs/Library-Management.html#ivy-configurations)
+        //  - This solution is problematic because in 2.12 SBT builds the scala-library:2.11.8
+        //    dependency is evicted in favor of 2.12. Why? It appears SBT special handles
+        //    org.scala-lang:scala-library for some reason.
+        //
+        //    This solution may not work on a project that uses
+        //        org.typeleve:scala-library:2.12.  Hopefully everyone will use SBT 1.0
+        //  before that happens.
+        "org.typelevel" % "scala-library"     % org.scalafmt.Versions.scala   % "scalafmt",
+        "com.geirsson"  % "scalafmt-cli_2.11" % org.scalafmt.Versions.nightly % "scalafmt"
       )
     )
 

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/.scalafmt.conf
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/.scalafmt.conf
@@ -1,0 +1,7 @@
+style               = defaultWithAlign
+danglingParentheses = true
+indentOperator      = spray
+
+spaces {
+  inImportCurlyBraces = true
+}

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/LICENSE
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/NOTICE
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2016 Heiko Seeberger

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/README.md
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/README.md
@@ -1,0 +1,11 @@
+# issue485 #
+
+Welcome to issue485!
+
+## Contribution policy ##
+
+Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
+
+## License ##
+
+This code is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/build.sbt
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/build.sbt
@@ -1,0 +1,9 @@
+lazy val issue485 =
+  project.in(file(".")).enablePlugins(AutomateHeaderPlugin, GitVersioning)
+
+libraryDependencies ++= Vector(
+  Library.scalaTest % "test"
+)
+
+initialCommands := """|import de.heikoseeberger.issue485._
+                      |""".stripMargin

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/Build.scala
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/Build.scala
@@ -1,0 +1,48 @@
+import com.typesafe.sbt.GitPlugin
+import com.typesafe.sbt.GitPlugin.autoImport._
+import de.heikoseeberger.sbtheader.HeaderPlugin
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.license._
+import org.scalafmt.sbt.ScalaFmtPlugin
+import org.scalafmt.sbt.ScalaFmtPlugin.autoImport._
+import sbt._
+import sbt.plugins.JvmPlugin
+import sbt.Keys._
+
+object Build extends AutoPlugin {
+
+  override def requires =
+    JvmPlugin && HeaderPlugin && GitPlugin && ScalaFmtPlugin
+
+  override def trigger = allRequirements
+
+  override def projectSettings =
+    reformatOnCompileSettings ++
+    Vector(
+           // Core settings
+           organization := "de.heikoseeberger",
+           licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
+           mappings.in(Compile, packageBin) += baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
+           scalaVersion := Version.Scala,
+           crossScalaVersions := Vector(scalaVersion.value),
+           scalacOptions ++= Vector(
+             "-unchecked",
+             "-deprecation",
+             "-language:_",
+             "-target:jvm-1.8",
+             "-encoding", "UTF-8"
+           ),
+           unmanagedSourceDirectories.in(Compile) := Vector(scalaSource.in(Compile).value),
+           unmanagedSourceDirectories.in(Test) := Vector(scalaSource.in(Test).value),
+
+           // scalafmt settings
+           formatSbtFiles := false,
+           scalafmtConfig := Some(baseDirectory.in(ThisBuild).value / ".scalafmt.conf"),
+
+           // Git settings
+           git.useGitDescribe := true,
+
+           // Header settings
+           headers := Map("scala" -> Apache2_0("2016", "Heiko Seeberger"))
+    )
+}

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/Dependencies.scala
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/Dependencies.scala
@@ -1,0 +1,10 @@
+import sbt._
+
+object Version {
+  final val Scala     = "2.12.0-RC1"
+  final val ScalaTest = "3.0.0"
+}
+
+object Library {
+  val scalaTest = "org.scalatest" %% "scalatest" % Version.ScalaTest
+}

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/build.properties
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.12

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/plugins.sbt
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % System.getProperty("plugin.version"))
+addSbtPlugin("com.typesafe.sbt"  % "sbt-git"      % "0.8.5")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "1.6.0")

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/shell-prompt.sbt
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/shell-prompt.sbt
@@ -1,0 +1,4 @@
+shellPrompt.in(ThisBuild) := { state =>
+  val project = Project.extract(state).currentRef.project
+  s"[$project]> "
+}

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/src/main/scala/de/heikoseeberger/issue485/package.scala
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/src/main/scala/de/heikoseeberger/issue485/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger
+
+package object issue485 {
+
+  type Traversable[+A] = scala.collection.immutable.Traversable[A]
+  type Iterable[+A]    = scala.collection.immutable.Iterable[A]
+  type Seq[+A]         = scala.collection.immutable.Seq[A]
+  type IndexedSeq[+A]  = scala.collection.immutable.IndexedSeq[A]
+}

--- a/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/test
+++ b/scalafmtSbt/src/sbt-test/scalafmt-sbt/issue485/test
@@ -1,0 +1,1 @@
+> scalafmt


### PR DESCRIPTION
- SBT plugins must build against 2.10
- scalafmt is 2.11 only because scala.meta makes heavy usage of macro
  annotations.
- To solve this problem so far, the scalafmt SBT plugin classloads itself with
  scala-library 2.11.8 in a hidden configuration (see
    http://www.scala-sbt.org/0.13/docs/Library-Management.html#ivy-configurations)
- This solution is problematic because in 2.12 SBT builds the scala-library:2.11.8
  dependency is evicted in favor of 2.12, causing issues like #485. Why? It appears SBT special handles
  org.scala-lang:scala-library for some reason.
- This commit changes the SBT plugin to use
org.typelevel:scala-library instead of org.scala-lang:scala-library.

This solution may not work on a project that use
org.typeleve:scala-library:2.12.  Hopefully everyone will have switched to SBT 1.0
by then.