### PR TITLE
Only align tokens with same distance to root node.

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -215,7 +215,10 @@ class FormatWriter(formatOps: FormatOps) {
       case (row1, row2) =>
         val row2Owner = getAlignOwner(row2.formatToken)
         val row1Owner = getAlignOwner(row1.formatToken)
-        key(row1.formatToken.right) == key(row2.formatToken.right) && {
+        def sameLengthToRoot =
+          lengthToRoot(row1Owner) == lengthToRoot(row2Owner)
+        key(row1.formatToken.right) == key(row2.formatToken.right) &&
+        sameLengthToRoot && {
           val eofParents = parents(owners(endOfLine.right))
           !(eofParents.contains(row1Owner) || eofParents.contains(row2Owner))
         }

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -31,6 +31,12 @@ object TreeOps {
   import LoggerOps._
   import TokenOps._
 
+  @tailrec
+  final def lengthToRoot(tree: Tree, accum: Int = 0): Int = tree.parent match {
+    case Some(parent) => lengthToRoot(parent, accum + 1)
+    case None => 1 + accum
+  }
+
   def getEnumStatements(enums: Seq[Enumerator]): Seq[Enumerator] = {
     val ret = Seq.newBuilder[Enumerator]
     enums.zipWithIndex.foreach {

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -371,3 +371,25 @@ object mixed {
   final case object False                 extends Val
   final case class Zero(zeroty: nir.Type) extends Val
 }
+<<< #513
+{
+  if (cond) foo
+  else { val chars = s.toCharArray }
+  val prefix       = "sbt.paths." + projectName + "." + uncapitalize(config.name) + "."
+}
+>>>
+{
+  if (cond) foo
+  else { val chars = s.toCharArray }
+  val prefix = "sbt.paths." + projectName + "." + uncapitalize(config.name) + "."
+}
+<<< #521
+x match {
+    case (xs: Seq[_], ys: Seq[_])                               =>
+      xs.length == ys.length && xs.zip(ys).forall { case (x, y) => loop(x, y) }
+  }
+>>>
+x match {
+  case (xs: Seq[_], ys: Seq[_]) =>
+    xs.length == ys.length && xs.zip(ys).forall { case (x, y) => loop(x, y) }
+}


### PR DESCRIPTION
This minimizes false positives. Fixes #521 and fixes #513.