### PR TITLE
Replace java.io.File with custom AbsoluteFile.

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -6,6 +6,7 @@ import java.io.File
 import java.io.InputStream
 
 import org.scalafmt.Error.MisformattedFile
+import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 
 sealed abstract class InputMethod {
@@ -33,8 +34,8 @@ object InputMethod {
       options.common.out.println(code)
     }
   }
-  case class FileContents(filename: String) extends InputMethod {
-    require(new File(filename).isAbsolute)
+  case class FileContents(file: AbsoluteFile) extends InputMethod {
+    override def filename = file.path
     def readInput: String = FileOps.readFile(filename)
     override def write(formatted: String,
                        original: String,

--- a/cli/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -2,11 +2,12 @@ package org.scalafmt.cli
 
 import java.io.File
 
+import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.GitOps
 import org.scalafmt.util.logger
 
-class FakeGitOps(root: File) extends GitOps {
-  override def lsTree = FileOps.listFiles(root)
-  override def rootDir = Some(root)
+class FakeGitOps(root: AbsoluteFile) extends GitOps {
+  override def lsTree: Vector[AbsoluteFile] = FileOps.listFiles(root)
+  override def rootDir: Option[AbsoluteFile] = Some(root)
 }

--- a/cli/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -2,6 +2,7 @@ package org.scalafmt.cli
 
 import java.io.File
 
+import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 
 object FileTestOps {
@@ -10,7 +11,7 @@ object FileTestOps {
     * The inverse of [[dir2string]]. Given a string represenatation creates the
     * necessary files/directories with respective file contents.
     */
-  def string2dir(layout: String): File = {
+  def string2dir(layout: String): AbsoluteFile = {
     val root = File.createTempFile("root", "root")
     root.delete()
     root.mkdir()
@@ -21,7 +22,7 @@ object FileTestOps {
       file.getParentFile.mkdirs()
       FileOps.writeFile(file, contents)
     }
-    root
+    AbsoluteFile.fromPath(root.getAbsolutePath).get
   }
 
   /** Gives a string represenatation of a directory. For example
@@ -33,13 +34,13 @@ object FileTestOps {
     * /target/scala-2.11/foo.class
     * ^!*@#@!*#&@*!&#^
     */
-  def dir2string(file: File): String = {
+  def dir2string(file: AbsoluteFile): String = {
     FileOps
-      .listFiles(file)
+      .listFiles(file.jfile)
       .sorted
       .map { path =>
         val contents = FileOps.readFile(path)
-        s"""|${path.stripPrefix(file.getPath)}
+        s"""|${path.stripPrefix(file.jfile.getPath)}
             |$contents""".stripMargin
       }
       .mkString("\n")

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -812,8 +812,9 @@ class Router(formatOps: FormatOps) {
         }
       case tok @ FormatToken(left, dot @ Dot(), _)
           if rightOwner.is[Term.Select] &&
-            isOpenApply(next(next(tok)).right,
-                        includeCurly = style.includeCurlyBraceInSelectChains) &&
+            isOpenApply(
+              next(next(tok)).right,
+              includeCurly = style.includeCurlyBraceInSelectChains) &&
             !left.is[Underscore] &&
             !parents(rightOwner).exists(_.is[Import]) =>
         val owner = rightOwner.asInstanceOf[Term.Select]

--- a/core/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
+++ b/core/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
@@ -1,0 +1,26 @@
+package org.scalafmt.util
+
+import java.io.File
+
+/** Wrapper around java.io.File with an absolute path. */
+sealed abstract case class AbsoluteFile(jfile: File) {
+  def path: String = jfile.getAbsolutePath
+  def /(other: String) = new AbsoluteFile(new File(jfile, other)) {}
+}
+
+object AbsoluteFile {
+  def fromFiles(files: Seq[File],
+                workingDir: AbsoluteFile): Seq[AbsoluteFile] = {
+    files.map(x => fromFile(x, workingDir))
+  }
+  // If file is already absolute, then workingDir is not used.
+  def fromFile(file: File, workingDir: AbsoluteFile): AbsoluteFile = {
+    new AbsoluteFile(FileOps.makeAbsolute(workingDir.jfile)(file)) {}
+  }
+  def fromPath(path: String): Option[AbsoluteFile] = {
+    val file = new File(path)
+    if (file.isAbsolute) Some(new AbsoluteFile(file) {})
+    else None
+  }
+  def userDir = new AbsoluteFile(new File(System.getProperty("user.dir"))) {}
+}

--- a/core/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -15,6 +15,10 @@ object FileOps {
     listFiles(new File(path))
   }
 
+  def listFiles(file: AbsoluteFile): Vector[AbsoluteFile] = {
+    listFiles(file.jfile).map(x => AbsoluteFile.fromFile(new File(x), file))
+  }
+
   def listFiles(file: File): Vector[String] = {
     if (file.isFile) {
       Vector(file.getAbsolutePath)
@@ -42,6 +46,10 @@ object FileOps {
     } else {
       readFile(new File(filename))
     }
+  }
+
+  def readFile(file: AbsoluteFile): String = {
+    readFile(file.jfile)
   }
 
   def readFile(file: File): String = {

--- a/core/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/core/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -7,6 +7,6 @@ import org.scalatest.FunSuite
 class GitOpsTest extends FunSuite {
   test("lsTree") {
     val files = GitOps().lsTree
-    assert(files.exists(x => x.endsWith("scalafmt/.gitignore")))
+    assert(files.exists(x => x.path.endsWith("scalafmt/.gitignore")))
   }
 }


### PR DESCRIPTION
java.io.File is dangerous as it hard to keep track of which files have
relative paths and which have absolute paths.  The reason I don't use
ammonite ops (which already contains absolute paths) is that scalafmt
needs to work with Java 6, which means no java.nio.

Fixes #551.