### PR TITLE
[WIP] Diff formatting

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -189,14 +189,14 @@ object Cli {
       case Formatted.Success(formatted) =>
         inputMethod.write(formatted, input, options)
       case Formatted.Failure(e) =>
-        if (options.config.runner.fatalWarnings) {
-          throw e
-        } else {
-          logger.elem(options.config.runner.fatalWarnings)
-          options.common.err.println(
-            s"${LogLevel.warn} Error in ${inputMethod.filename}: $e"
-          )
-        }
+      if (options.config.runner.fatalWarnings) {
+        throw e
+      } else {
+        logger.elem(options.config.runner.fatalWarnings)
+        options.common.err.println(
+          s"${LogLevel.warn} Error in ${inputMethod.filename}: $e"
+        )
+      }
     }
   }
 

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -26,6 +26,7 @@ import org.scalafmt.util.LogLevel
 import com.martiansoftware.nailgun.NGContext
 import org.scalafmt.diff.FileDiff
 import org.scalafmt.util.AbsoluteFile
+import org.scalafmt.util.logger
 
 object Cli {
   def nailMain(nGContext: NGContext): Unit = {
@@ -149,9 +150,12 @@ object Cli {
         .mkString(FileOps.lineSeparator)
       val fileDiffs = FileDiff.fromUnified(unifiedDiff)
       fileDiffs.map { fd =>
+        logger.elem(fd)
         val path =
           AbsoluteFile.fromFile(new File(fd.filename),
                                 options.common.workingDirectory)
+        val ranges = fd.additions.map(_.toRange)
+        logger.elem(ranges)
         InputMethod.FileContents(path, fd.additions.map(_.toRange))
       }
     } else {

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -150,12 +150,9 @@ object Cli {
         .mkString(FileOps.lineSeparator)
       val fileDiffs = FileDiff.fromUnified(unifiedDiff)
       fileDiffs.map { fd =>
-        logger.elem(fd)
         val path =
           AbsoluteFile.fromFile(new File(fd.filename),
                                 options.common.workingDirectory)
-        val ranges = fd.additions.map(_.toRange)
-        logger.elem(ranges)
         InputMethod.FileContents(path, fd.additions.map(_.toRange))
       }
     } else {
@@ -168,8 +165,9 @@ object Cli {
 
   private def handleFile(inputMethod: InputMethod, options: CliOptions): Unit = {
     val input = inputMethod.readInput
-    val range: Set[Range] =
-      if (inputMethod.range.nonEmpty) inputMethod.range.toSet
+    logger.elem(inputMethod.range, inputMethod.range.toSet)
+    val range: Seq[Range] =
+      if (inputMethod.range.nonEmpty) inputMethod.range
       else options.range
     val formatResult =
       Scalafmt.format(input, options.config, range)

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -165,7 +165,6 @@ object Cli {
 
   private def handleFile(inputMethod: InputMethod, options: CliOptions): Unit = {
     val input = inputMethod.readInput
-    logger.elem(inputMethod.range, inputMethod.range.toSet)
     val range: Seq[Range] =
       if (inputMethod.range.nonEmpty) inputMethod.range
       else options.range

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -157,7 +157,7 @@ object Cli {
           "Unable to read diff. Specify --stdin enable project.git=true")
       }
     val fileDiffs = FileDiff.fromUnified(unifiedDiff)
-    fileDiffs.map { fd =>
+    fileDiffs.withFilter(x => canFormat(x.filename)).map { fd =>
       val path =
         AbsoluteFile.fromFile(new File(fd.filename),
                               options.common.workingDirectory)

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -192,7 +192,6 @@ object Cli {
       if (options.config.runner.fatalWarnings) {
         throw e
       } else {
-        logger.elem(options.config.runner.fatalWarnings)
         options.common.err.println(
           s"${LogLevel.warn} Error in ${inputMethod.filename}: $e"
         )

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -192,6 +192,7 @@ object Cli {
         if (options.config.runner.fatalWarnings) {
           throw e
         } else {
+          logger.elem(options.config.runner.fatalWarnings)
           options.common.err.println(
             s"${LogLevel.warn} Error in ${inputMethod.filename}: $e"
           )

--- a/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -80,23 +80,23 @@ object CliArgParser {
         .action((excludes, c) => c.copy(customExcludes = excludes))
         .text(
           "file or directory, in which case all *.scala files are formatted.")
-      opt[String]('c', "config")
-        .action(readConfigFromFile)
-        .text(
-          "either a file or configuration wrapped in quotes \" with no spaces.")
-      opt[Unit]("debug")
-        .action(
-          (_, c) =>
-            c.copy(
-              config = c.config.copy(
-                runner = c.config.runner.copy(
-                  fatalWarnings = true
-                )
-              )))
-        .text("read from stdin and print to stdout")
-      opt[Unit]("stdin")
-        .action((_, c) => c.copy(stdIn = true))
-        .text("read from stdin and print to stdout")
+    opt[String]('c', "config")
+      .action(readConfigFromFile)
+      .text(
+        "either a file or configuration wrapped in quotes \" with no spaces.")
+    opt[Unit]("debug")
+      .action(
+        (_, c) =>
+          c.copy(
+            config = c.config.copy(
+              runner = c.config.runner.copy(
+                fatalWarnings = true
+              )
+            )))
+      .text("read from stdin and print to stdout")
+    opt[Unit]("stdin")
+      .action((_, c) => c.copy(stdIn = true))
+      .text("read from stdin and print to stdout")
       opt[Unit]("diff")
         .action((_, c) => c.copy(diff = true, inPlace = true))
         .text("read diff output from stdin and" +

--- a/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -87,6 +87,10 @@ object CliArgParser {
       opt[Unit]("stdin")
         .action((_, c) => c.copy(stdIn = true))
         .text("read from stdin and print to stdout")
+      opt[Unit]("diff")
+        .action((_, c) => c.copy(diff = true, inPlace = true))
+        .text("read diff output from stdin and" +
+          "print to stdout with only diff formatted")
       opt[String]("assume-filename")
         .action((filename, c) => c.copy(assumeFilename = filename))
         .text("required to format .sbt files with --stdin flag.")

--- a/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -117,7 +117,7 @@ object CliArgParser {
         .action({
           case ((from, to), c) =>
             val offset = if (from == to) 0 else -1
-            c.copy(range = c.range + Range(from - 1, to + offset))
+            c.copy(range = c.range :+ Range(from - 1, to + offset))
         })
         .text("(experimental) only format line range from=to")
 

--- a/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -84,6 +84,16 @@ object CliArgParser {
         .action(readConfigFromFile)
         .text(
           "either a file or configuration wrapped in quotes \" with no spaces.")
+      opt[Unit]("debug")
+        .action(
+          (_, c) =>
+            c.copy(
+              config = c.config.copy(
+                runner = c.config.runner.copy(
+                  fatalWarnings = true
+                )
+              )))
+        .text("read from stdin and print to stdout")
       opt[Unit]("stdin")
         .action((_, c) => c.copy(stdIn = true))
         .text("read from stdin and print to stdout")

--- a/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -83,7 +83,7 @@ case class CommonOptions(
 
 case class CliOptions(
     config: ScalafmtConfig = ScalafmtConfig.default,
-    range: Set[Range] = Set.empty[Range],
+    range: Seq[Range] = Seq.empty[Range],
     customFiles: Seq[AbsoluteFile] = Nil,
     customExcludes: Seq[String] = Nil,
     inPlace: Boolean = false,

--- a/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -12,6 +12,7 @@ import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.GitOps
 import org.scalafmt.util.GitOpsImpl
+import org.scalafmt.util.logger
 
 object CliOptions {
   val default = CliOptions()

--- a/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -89,6 +89,7 @@ case class CliOptions(
     inPlace: Boolean = false,
     testing: Boolean = false,
     stdIn: Boolean = false,
+    diff: Boolean = false,
     assumeFilename: String = "stdin.scala", // used when read from stdin
     migrate: Option[AbsoluteFile] = None,
     common: CommonOptions = CommonOptions(),

--- a/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -37,7 +37,7 @@ object InputMethod {
   }
   case class FileContents(file: AbsoluteFile, override val range: Seq[Range])
       extends InputMethod {
-    override def filename = file.path
+    override def filename: String = file.path
     def readInput: String = FileOps.readFile(filename)
     override def write(formatted: String,
                        original: String,

--- a/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -10,9 +10,10 @@ import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 
 sealed abstract class InputMethod {
-  def isSbt = filename.endsWith(".sbt")
+  def isSbt: Boolean = filename.endsWith(".sbt")
   def readInput: String
   def filename: String
+  def range: Seq[Range] = Nil
   def write(formatted: String, original: String, options: CliOptions): Unit
 }
 
@@ -34,7 +35,8 @@ object InputMethod {
       options.common.out.println(code)
     }
   }
-  case class FileContents(file: AbsoluteFile) extends InputMethod {
+  case class FileContents(file: AbsoluteFile, override val range: Seq[Range])
+      extends InputMethod {
     override def filename = file.path
     def readInput: String = FileOps.readFile(filename)
     override def write(formatted: String,

--- a/cli/src/test/scala/org/scalafmt/cli/AbstractCliDiffTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/AbstractCliDiffTest.scala
@@ -1,0 +1,34 @@
+package org.scalafmt.cli
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+import org.scalafmt.util.DiffAssertions
+import org.scalafmt.util.LoggerOps
+
+abstract class AbstractCliDiffTest
+    extends AbstractCliTest
+    with DiffAssertions {
+  import FileTestOps._
+
+  def skip(original: String, expected: String, diff: String): Unit =
+    ignore(LoggerOps.reveal(original)) { () }
+
+  def check(original: String, expected: String, diff: String): Unit = {
+    test(LoggerOps.reveal(original)) {
+      val root = string2dir(original)
+      val init = getMockOptions(root)
+      val bais = new ByteArrayInputStream(diff.getBytes)
+      val baos = new ByteArrayOutputStream()
+      val config = Cli.getConfig(Array("--diff", "--stdin"), init).get
+      Cli.run(
+        config.copy(
+          common = config.common.copy(
+            in = bais
+          )
+        ))
+      val obtained = dir2string(root)
+      assertNoDiff(obtained, expected)
+    }
+  }
+}

--- a/cli/src/test/scala/org/scalafmt/cli/AbstractCliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/AbstractCliTest.scala
@@ -1,0 +1,32 @@
+package org.scalafmt.cli
+
+import java.io.File
+
+import org.scalafmt.util.AbsoluteFile
+import org.scalafmt.util.DiffAssertions
+import org.scalatest.FunSuite
+
+abstract class AbstractCliTest extends FunSuite with DiffAssertions {
+  def getMockOptions(baseDir: AbsoluteFile): CliOptions =
+    getMockOptions(baseDir, baseDir)
+
+  def getMockOptions(baseDir: AbsoluteFile,
+                     workingDir: AbsoluteFile): CliOptions = {
+    CliOptions.default.copy(
+      gitOpsConstructor = x => new FakeGitOps(baseDir),
+      common = CliOptions.default.common.copy(
+        workingDirectory = workingDir
+      )
+    )
+  }
+
+  val baseCliOptions: CliOptions = getMockOptions(
+    AbsoluteFile
+      .fromPath(File.createTempFile("base", "dir").getAbsolutePath)
+      .get)
+
+  def getConfig(args: Array[String]): CliOptions = {
+    Cli.getConfig(args, baseCliOptions).get
+  }
+
+}

--- a/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
@@ -1,0 +1,115 @@
+package org.scalafmt.cli
+
+class CliDiffTest extends AbstractCliDiffTest {
+
+  check(
+    """|/edited.scala
+       |object   A {
+       |  val x=2
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A {
+       |  val x = 2
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -2,1 +2,1 @@ foo
+       |-  val a=1
+       |+  val x=1
+      """.stripMargin
+  )
+  check(
+    // no diff
+    """|/edited.scala
+       |object   A {
+       |  val x=2  }
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A {
+       |  val x=2  }
+       |""".stripMargin,
+    ""
+  )
+  check(
+    // 2 diffs
+    """|/edited.scala
+       |object   A  {
+       |  val x=1
+       |  val y=2
+       |  val z=3
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A  {
+       |  val x = 1
+       |  val y=2
+       |  val z = 3
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -2,1 +2,1 @@ foo
+       |-  val a=1
+       |+  val x = 1
+       |@@ -4,1 +4,1 @@ foo
+       |-  val b=3
+       |+  val z = 3
+    """.stripMargin
+  )
+
+  check(
+    // leave untouched comments alone
+    """|/edited.scala
+       | /*
+       |   * banana
+       |   */
+       |object   A  {
+       |  val x=1
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       | /*
+       |   * banana
+       |   */
+       |object   A  {
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -5,1 +5,1 @@ foo
+       |-  val a=1
+       |+  val x = 1
+    """.stripMargin
+  )
+  check(
+    // leave untouched comments alone
+    """|/edited.scala
+       |object A {
+       |  function(a, x =>
+       |    x+ 2,
+       |    b, {
+       |    val y = 1
+       |    y+2
+       |  })
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object A {
+       |  function(a, x => x + 2, b, {
+       |    val y = 1
+       |    y+2
+       |  })
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -4,1 +3,1 @@ foo
+       |-  x+ 3
+       |+  x+ 2
+    """.stripMargin
+  )
+  // TODO(olafur) argument indentation
+}

--- a/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
@@ -1,6 +1,30 @@
 package org.scalafmt.cli
 
+class X extends AbstractCliDiffTest {
+}
+
 class CliDiffTest extends AbstractCliDiffTest {
+  check(
+    """|/version.sbt
+       |version in ThisBuild :=  "0.1.5-SNAPSHOT"
+       |/.scalafmt.conf
+       |runner.fatalWarnings = true
+       |project.git = true
+       |""".stripMargin,
+    """|/.scalafmt.conf
+       |runner.fatalWarnings = true
+       |project.git = true
+       |
+       |/version.sbt
+       |version in ThisBuild := "0.1.5-SNAPSHOT"
+       |""".stripMargin,
+    """|--- a/version.sbt
+       |+++ b/version.sbt
+       |@@ -1 +1 @@
+       |-version in ThisBuild := "0.1.5-SNAPSHOT"
+       |+version in ThisBuild := "0.1.6-SNAPSHOT"
+    """.stripMargin
+  )
 
   check(
     """|/edited.scala

--- a/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliDiffTest.scala
@@ -1,7 +1,6 @@
 package org.scalafmt.cli
 
-class X extends AbstractCliDiffTest {
-}
+class X extends AbstractCliDiffTest {}
 
 class CliDiffTest extends AbstractCliDiffTest {
   check(
@@ -135,5 +134,92 @@ class CliDiffTest extends AbstractCliDiffTest {
        |+  x+ 2
     """.stripMargin
   )
-  // TODO(olafur) argument indentation
+
+  check(
+    // case
+    """|/edited.scala
+       |object   A {
+       |  x match {
+       |    case 1 =>
+       |      x+1
+       |      y+1
+       |  }
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A {
+       |  x match {
+       |    case 1 =>
+       |      x+1
+       |      y + 1
+       |  }
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -2,1 +5,1 @@ foo
+       |-  y+2
+       |+  y+1
+    """.stripMargin
+  )
+  check(
+    // lambda
+    """|/edited.scala
+       |object   A {
+       |  lst.map { x =>
+       |    x+1
+       |  }
+       |  lst.map {
+       |    x =>
+       |      x+1
+       |      x+1
+       |  }
+       |  lst.map { x => // comment
+       |    x+1
+       |  }
+       |  lst.map { // comment
+       |    x => // comment
+       |      x+1
+       |      x+1
+       |  }
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A {
+       |  lst.map { x =>
+       |    x + 1
+       |  }
+       |  lst.map {
+       |    x =>
+       |      x + 1
+       |      x+1
+       |  }
+       |  lst.map { x => // comment
+       |    x + 1
+       |  }
+       |  lst.map { // comment
+       |    x => // comment
+       |      x + 1
+       |      x+1
+       |  }
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -2,1 +3,1 @@ foo
+       |-  x+2
+       |+  x+1
+       |@@ -2,1 +7,1 @@ foo
+       |-    x+2
+       |+    x+1
+       |@@ -2,1 +11,1 @@ foo
+       |-    x+2
+       |+    x+1
+       |@@ -2,1 +15,1 @@ foo
+       |-    x+2
+       |+    x+1
+    """.stripMargin
+  )
+  // TODO(olafur) case
+  // TODO(olafur) lambda
 }

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -23,6 +23,9 @@ import org.scalatest.FunSuite
 class CliDiffTest extends AbstractCliTest with DiffAssertions {
   import FileTestOps._
 
+  def skip(original: String, expected: String, diff: String): Unit =
+    ignore(LoggerOps.reveal(original)) { () }
+
   def check(original: String, expected: String, diff: String): Unit = {
     test(LoggerOps.reveal(original)) {
       val root = string2dir(original)
@@ -61,30 +64,29 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
   )
 
   check( // 2 diffs
-    """|/edited.scala
-       |object A {
-       |  val x=1
-       |  val y=2
-       |  val z=3
-       |}
-       |""".stripMargin,
-    """|/edited.scala
-       |object   A {
-       |  val x = 1
-       |  val y=2
-       |  val z = 3
-       |}
-       |""".stripMargin,
-    """|--- a/edited.scala
-       |+++ b/edited.scala
-       |@@ -2,1 +2,1 @@ foo
-       |-  val a=1
-       |+  val x = 1
-       |@@ -4,1 +4,1 @@ foo
-       |-  val b=3
-       |+  val z = 3
-    """.stripMargin
-  )
+        """|/edited.scala
+           |object   A  {
+           |  val x=1
+           |  val y=2
+           |  val z=3
+           |}
+           |""".stripMargin,
+        """|/edited.scala
+           |object   A  {
+           |  val x = 1
+           |  val y=2
+           |  val z = 3
+           |}
+           |""".stripMargin,
+        """|--- a/edited.scala
+           |+++ b/edited.scala
+           |@@ -2,1 +2,1 @@ foo
+           |-  val a=1
+           |+  val x = 1
+           |@@ -4,1 +4,1 @@ foo
+           |-  val b=3
+           |+  val z = 3
+    """.stripMargin)
 }
 
 class CliTest extends AbstractCliTest with DiffAssertions {

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -32,7 +32,7 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
       val init = getMockOptions(root)
       val bais = new ByteArrayInputStream(diff.getBytes)
       val baos = new ByteArrayOutputStream()
-      val config = Cli.getConfig(Array("--diff"), init).get
+      val config = Cli.getConfig(Array("--diff", "--stdin"), init).get
       Cli.run(
         config.copy(
           common = config.common.copy(

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -62,33 +62,47 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
        |+  val x=1
       """.stripMargin
   )
+  check(
+    // no diff
+    """|/edited.scala
+       |object   A {
+       |  val x=2  }
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A {
+       |  val x=2  }
+       |""".stripMargin,
+    ""
+  )
+  check(
+    // 2 diffs
+    """|/edited.scala
+       |object   A  {
+       |  val x=1
+       |  val y=2
+       |  val z=3
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       |object   A  {
+       |  val x = 1
+       |  val y=2
+       |  val z = 3
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -2,1 +2,1 @@ foo
+       |-  val a=1
+       |+  val x = 1
+       |@@ -4,1 +4,1 @@ foo
+       |-  val b=3
+       |+  val z = 3
+    """.stripMargin
+  )
 
-  check( // 2 diffs
-        """|/edited.scala
-           |object   A  {
-           |  val x=1
-           |  val y=2
-           |  val z=3
-           |}
-           |""".stripMargin,
-        """|/edited.scala
-           |object   A  {
-           |  val x = 1
-           |  val y=2
-           |  val z = 3
-           |}
-           |""".stripMargin,
-        """|--- a/edited.scala
-           |+++ b/edited.scala
-           |@@ -2,1 +2,1 @@ foo
-           |-  val a=1
-           |+  val x = 1
-           |@@ -4,1 +4,1 @@ foo
-           |-  val b=3
-           |+  val z = 3
-    """.stripMargin)
-
-  check( // leave untouched comments alone
+  check(
+    // leave untouched comments alone
     """|/edited.scala
        | /*
        |   * banana
@@ -110,7 +124,10 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
        |@@ -5,1 +5,1 @@ foo
        |-  val a=1
        |+  val x = 1
-    """.stripMargin)
+    """.stripMargin
+  )
+  // TODO(olafur) argument list
+  // TODO(olafur) argument indentation
 }
 
 class CliTest extends AbstractCliTest with DiffAssertions {

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -87,6 +87,30 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
            |-  val b=3
            |+  val z = 3
     """.stripMargin)
+
+  check( // leave untouched comments alone
+    """|/edited.scala
+       | /*
+       |   * banana
+       |   */
+       |object   A  {
+       |  val x=1
+       |}
+       |""".stripMargin,
+    """|/edited.scala
+       | /*
+       |   * banana
+       |   */
+       |object   A  {
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    """|--- a/edited.scala
+       |+++ b/edited.scala
+       |@@ -5,1 +5,1 @@ foo
+       |-  val a=1
+       |+  val x = 1
+    """.stripMargin)
 }
 
 class CliTest extends AbstractCliTest with DiffAssertions {

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -62,7 +62,7 @@ class CliDiffTest extends AbstractCliTest with DiffAssertions {
 
   check( // 2 diffs
     """|/edited.scala
-       |object   A {
+       |object A {
        |  val x=1
        |  val y=2
        |  val z=3

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -2,9 +2,7 @@ package org.scalafmt.cli
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.FileNotFoundException
-import java.io.InputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -12,123 +10,9 @@ import java.nio.file.Files
 import org.scalafmt.Error.MisformattedFile
 import org.scalafmt.config.Config
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.DiffAssertions
 import org.scalafmt.util.FileOps
-import org.scalafmt.util.GitOps
-import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.logger
-import org.scalatest.FunSuite
-
-class CliDiffTest extends AbstractCliTest with DiffAssertions {
-  import FileTestOps._
-
-  def skip(original: String, expected: String, diff: String): Unit =
-    ignore(LoggerOps.reveal(original)) { () }
-
-  def check(original: String, expected: String, diff: String): Unit = {
-    test(LoggerOps.reveal(original)) {
-      val root = string2dir(original)
-      val init = getMockOptions(root)
-      val bais = new ByteArrayInputStream(diff.getBytes)
-      val baos = new ByteArrayOutputStream()
-      val config = Cli.getConfig(Array("--diff", "--stdin"), init).get
-      Cli.run(
-        config.copy(
-          common = config.common.copy(
-            in = bais
-          )
-        ))
-      val obtained = dir2string(root)
-      assertNoDiff(obtained, expected)
-    }
-  }
-
-  check(
-    """|/edited.scala
-       |object   A {
-       |  val x=2
-       |}
-       |""".stripMargin,
-    """|/edited.scala
-       |object   A {
-       |  val x = 2
-       |}
-       |""".stripMargin,
-    """|--- a/edited.scala
-       |+++ b/edited.scala
-       |@@ -2,1 +2,1 @@ foo
-       |-  val a=1
-       |+  val x=1
-      """.stripMargin
-  )
-  check(
-    // no diff
-    """|/edited.scala
-       |object   A {
-       |  val x=2  }
-       |""".stripMargin,
-    """|/edited.scala
-       |object   A {
-       |  val x=2  }
-       |""".stripMargin,
-    ""
-  )
-  check(
-    // 2 diffs
-    """|/edited.scala
-       |object   A  {
-       |  val x=1
-       |  val y=2
-       |  val z=3
-       |}
-       |""".stripMargin,
-    """|/edited.scala
-       |object   A  {
-       |  val x = 1
-       |  val y=2
-       |  val z = 3
-       |}
-       |""".stripMargin,
-    """|--- a/edited.scala
-       |+++ b/edited.scala
-       |@@ -2,1 +2,1 @@ foo
-       |-  val a=1
-       |+  val x = 1
-       |@@ -4,1 +4,1 @@ foo
-       |-  val b=3
-       |+  val z = 3
-    """.stripMargin
-  )
-
-  check(
-    // leave untouched comments alone
-    """|/edited.scala
-       | /*
-       |   * banana
-       |   */
-       |object   A  {
-       |  val x=1
-       |}
-       |""".stripMargin,
-    """|/edited.scala
-       | /*
-       |   * banana
-       |   */
-       |object   A  {
-       |  val x = 1
-       |}
-       |""".stripMargin,
-    """|--- a/edited.scala
-       |+++ b/edited.scala
-       |@@ -5,1 +5,1 @@ foo
-       |-  val a=1
-       |+  val x = 1
-    """.stripMargin
-  )
-  // TODO(olafur) argument list
-  // TODO(olafur) argument indentation
-}
 
 class CliTest extends AbstractCliTest with DiffAssertions {
   import FileTestOps._

--- a/cli/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -10,4 +10,5 @@ import org.scalafmt.util.logger
 class FakeGitOps(root: AbsoluteFile) extends GitOps {
   override def lsTree: Vector[AbsoluteFile] = FileOps.listFiles(root)
   override def rootDir: Option[AbsoluteFile] = Some(root)
+  override def diff(baseBranch: String): String = ""
 }

--- a/core/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/core/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -38,7 +38,7 @@ object Scalafmt {
     */
   def format(code: String,
              style: ScalafmtConfig = ScalafmtConfig.default,
-             range: Set[Range] = Set.empty[Range]): Formatted = {
+             range: Seq[Range] = Seq.empty[Range]): Formatted = {
     try {
       val runner = style.runner
       if (code.matches("\\s*")) Formatted.Success(System.lineSeparator())
@@ -58,9 +58,9 @@ object Scalafmt {
         val formatWriter = new FormatWriter(formatOps)
         val formatTokenRange = FileDiff.getFormatTokenRanges(
           formatOps.tokens,
-          range.toSeq) // TODO(olafur) replace set with seq
+          range)
         val search =
-          new BestFirstSearch(formatOps, range.toSeq, formatWriter)
+          new BestFirstSearch(formatOps, range, formatWriter)
         val partial = search.getBestPath
         val formattedString = formatWriter.mkString(partial.splits)
         val correctedFormattedString =

--- a/core/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/core/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -53,12 +53,12 @@ object Scalafmt {
         val tree = new scala.meta.XtensionParseInputLike(toParse)
           .parse(stringToInput, runner.parser, runner.dialect)
           .get
-        val formatOps = new FormatOps(tree, style, range)
+        val formatOps = new FormatOps(tree, style, range.toSeq)
         runner.eventCallback(CreateFormatOps(formatOps))
         val formatWriter = new FormatWriter(formatOps)
         val formatTokenRange = FileDiff.getFormatTokenRanges(
           formatOps.tokens,
-          range.toSeq.map(x => Addition(x.start, x.end - x.end + 1)))
+          range.toSeq) // TODO(olafur) replace set with seq
         val search =
           new BestFirstSearch(formatOps, range.toSeq, formatWriter)
         val partial = search.getBestPath

--- a/core/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/core/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -7,6 +7,7 @@ import metaconfig.ConfigReader
 @ConfigReader
 case class ProjectFiles(
     git: Boolean = false,
+    baseBranch: String = "master",
     files: Seq[String] = Nil,
     includeFilters: Seq[String] = Seq(".*"),
     excludeFilters: Seq[String] = Nil

--- a/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
+++ b/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
@@ -1,0 +1,99 @@
+package org.scalafmt.diff
+
+import scala.meta.Tree
+import scala.util.Try
+
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.internal.FormatOps
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.util.logger
+
+case class FormatTokenRange(start: FormatToken, end: FormatToken) {
+  def contains(tok: FormatToken): Boolean = {
+    val result = tok.left.start >= start.left.start && tok.right.end <= end.right.end
+    logger.elem(tok,result)
+    result
+  }
+  override def toString: String = s"$start <-> $end"
+}
+case class Addition(startLine: Int, lineCount: Int) {
+  def endLine = startLine + lineCount - 1
+}
+case class FileDiff(filename: String, additions: Seq[Addition])
+
+object FileDiff {
+  val NewFile = "^\\+\\+\\+\\ (.*?/)(\\S*)".r
+  val DiffBlock =
+    "^@@.*\\+(\\d+)(,(\\d+))?".r("startLine", "skip", "lineCount")
+
+  /** Parses a unified diff into FileDiffs.
+    *
+    * Example commands to produce unified diff:
+    *    git diff -U0 HEAD
+    *    svn diff --diff-cmd=diff -x-U0
+    *
+    * Produces something like:
+    *    --- /dev/null
+    *    +++ b/DiffTest.scala
+    *    @@ -54 +54,2 @@ class Router(formatOps: FormatOps) {
+    *
+    * Example parsed result:
+    *    Seq(FileDiff("DiffTest.scala", Seq(Addition(54, 2))))
+    */
+  def fromUnified(diff: String): Seq[FileDiff] = {
+    var currentFilename = Option.empty[String]
+    val fileDiffs = Seq.newBuilder[FileDiff]
+    val additions = Seq.newBuilder[Addition]
+    def addLastFile(): Unit = {
+      currentFilename.foreach { lastFilename =>
+        fileDiffs += FileDiff(lastFilename, additions.result())
+        additions.clear()
+      }
+    }
+    diff.lines.foreach {
+      case NewFile(_, filename) =>
+        addLastFile()
+        currentFilename = Some(filename)
+      case other =>
+        for {
+          diffBlock <- DiffBlock.findAllMatchIn(other)
+          startLine <- Try(diffBlock.group("startLine").toInt).toOption.toIterable
+          lineCount = Try(diffBlock.group("lineCount").toInt).getOrElse(1)
+        } {
+          additions += Addition(startLine, lineCount)
+        }
+    }
+    addLastFile()
+    fileDiffs.result()
+  }
+
+  /** Returns the start and end FormatTokens corresponding to each addition. */
+  def getFormatTokenRanges(tokens: Array[FormatToken],
+                           additions: Seq[Addition]): Seq[FormatTokenRange] = {
+    val builder = Seq.newBuilder[FormatTokenRange]
+    val N = tokens.length
+    var curr = 0
+    def getLine(tok: FormatToken): Int = tok.right.pos.start.line + 1
+    def forwardToLine(line: Int): Unit = {
+      while (curr < N && getLine(tokens(curr)) < line) {
+        curr += 1
+      }
+      if (curr >= N) curr = N - 1 // edge case, EOF
+    }
+    additions.foreach { addition =>
+      forwardToLine(addition.startLine)
+      val start = curr
+      curr -= 1 // end can be same as start in case of multi-line token.
+      forwardToLine(addition.endLine + 1)
+      val end = curr
+      builder += FormatTokenRange(tokens(start), tokens(end))
+    }
+    builder.result()
+  }
+
+  def expandToEnclosingStatements(formatTokenRange: FormatTokenRange,
+                                  formatOps: FormatOps): FormatTokenRange = {
+    import formatTokenRange._
+    formatTokenRange
+  }
+}

--- a/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
+++ b/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
@@ -8,6 +8,7 @@ import scala.util.matching.Regex
 import org.scalafmt.internal.FormatOps
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.util.TokenOps
+import org.scalafmt.util.logger
 
 case class FormatTokenRange(start: FormatToken, end: FormatToken) {
   def contains(tok: FormatToken): Boolean =
@@ -89,7 +90,6 @@ object FileDiff {
       }
       if (curr >= N) {
         isEOF = true
-        curr = N - 1 // edge case, EOF
       }
     }
     additions.foreach { addition =>
@@ -97,7 +97,7 @@ object FileDiff {
       forwardToLine(addition.start)
       if (!isEOF) {
         val start = curr
-        curr -= 1 // end can be same as start in case of multi-line token.
+        curr = Math.max(0, curr - 1) // end can be same as start in case of multi-line token.
         forwardToLine(addition.end + 1)
         val end = curr
         builder += FormatTokenRange(tokens(start), tokens(end))

--- a/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
+++ b/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
@@ -17,7 +17,8 @@ case class FormatTokenRange(start: FormatToken, end: FormatToken) {
   override def toString: String = s"$start <-> $end"
 }
 case class Addition(startLine: Int, lineCount: Int) {
-  def endLine = startLine + lineCount - 1
+  def endLine: Int = startLine + lineCount - 1
+  def toRange: Range = Range(startLine, endLine)
 }
 case class FileDiff(filename: String, additions: Seq[Addition])
 
@@ -69,7 +70,7 @@ object FileDiff {
 
   /** Returns the start and end FormatTokens corresponding to each addition. */
   def getFormatTokenRanges(tokens: Array[FormatToken],
-                           additions: Seq[Addition]): Seq[FormatTokenRange] = {
+                           additions: Seq[Range]): Seq[FormatTokenRange] = {
     val builder = Seq.newBuilder[FormatTokenRange]
     val N = tokens.length
     var curr = 0
@@ -81,10 +82,10 @@ object FileDiff {
       if (curr >= N) curr = N - 1 // edge case, EOF
     }
     additions.foreach { addition =>
-      forwardToLine(addition.startLine)
+      forwardToLine(addition.start)
       val start = curr
       curr -= 1 // end can be same as start in case of multi-line token.
-      forwardToLine(addition.endLine + 1)
+      forwardToLine(addition.end + 1)
       val end = curr
       builder += FormatTokenRange(tokens(start), tokens(end))
     }

--- a/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
+++ b/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
@@ -5,18 +5,14 @@ import scala.meta.tokens.Token.RightBrace
 import scala.util.Try
 import scala.util.matching.Regex
 
-import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatOps
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.util.TokenOps
-import org.scalafmt.util.logger
 
 case class FormatTokenRange(start: FormatToken, end: FormatToken) {
-  def contains(tok: FormatToken): Boolean = {
-    val result = tok.left.start >= start.left.start && tok.right.end <= end.right.end
-    logger.elem(tok, result)
-    result
-  }
+  def contains(tok: FormatToken): Boolean =
+    tok.left.start >= start.left.start &&
+      tok.right.end <= end.right.end
   override def toString: String = s"$start <-> $end"
 }
 case class Addition(startLine: Int, lineCount: Int) {
@@ -50,7 +46,6 @@ object FileDiff {
     val additions = Seq.newBuilder[Addition]
     def addLastFile(): Unit = {
       currentFilename.foreach { lastFilename =>
-        logger.elem(lastFilename)
         fileDiffs += FileDiff(lastFilename, additions.result())
         additions.clear()
       }
@@ -85,14 +80,12 @@ object FileDiff {
       }
       if (curr >= N) curr = N - 1 // edge case, EOF
     }
-    logger.elem(additions)
     additions.foreach { addition =>
       forwardToLine(addition.start)
       val start = curr
       curr -= 1 // end can be same as start in case of multi-line token.
       forwardToLine(addition.end + 1)
       val end = curr
-      logger.elem(end)
       builder += FormatTokenRange(tokens(start), tokens(end))
     }
     builder.result()

--- a/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
+++ b/core/src/main/scala/org/scalafmt/diff/FileDiff.scala
@@ -50,6 +50,7 @@ object FileDiff {
     val additions = Seq.newBuilder[Addition]
     def addLastFile(): Unit = {
       currentFilename.foreach { lastFilename =>
+        logger.elem(lastFilename)
         fileDiffs += FileDiff(lastFilename, additions.result())
         additions.clear()
       }
@@ -84,12 +85,14 @@ object FileDiff {
       }
       if (curr >= N) curr = N - 1 // edge case, EOF
     }
+    logger.elem(additions)
     additions.foreach { addition =>
       forwardToLine(addition.start)
       val start = curr
       curr -= 1 // end can be same as start in case of multi-line token.
       forwardToLine(addition.end + 1)
       val end = curr
+      logger.elem(end)
       builder += FormatTokenRange(tokens(start), tokens(end))
     }
     builder.result()

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -9,6 +9,7 @@ import org.scalafmt.config.FormatEvent.CompleteFormat
 import org.scalafmt.config.FormatEvent.Enqueue
 import org.scalafmt.config.FormatEvent.Explored
 import org.scalafmt.config.FormatEvent.VisitToken
+import org.scalafmt.diff.FormatTokenRange
 import org.scalafmt.internal.ExpiresOn.Right
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.util.LoggerOps
@@ -19,7 +20,7 @@ import org.scalafmt.util.TreeOps
   * Implements best first search to find optimal formatting.
   */
 class BestFirstSearch(val formatOps: FormatOps,
-                      range: Set[Range],
+                      range: Seq[Range],
                       formatWriter: FormatWriter) {
   import Token._
 
@@ -168,7 +169,8 @@ class BestFirstSearch(val formatOps: FormatOps,
         result = curr
         Q.dequeueAll
       } else if (shouldEnterState(curr)) {
-        val splitToken = tokens(curr.splits.length)
+        val i = curr.splits.length
+        val splitToken = tokens(i)
         val style = styleMap.at(splitToken)
         if (curr.splits.length > deepestYet.splits.length) {
           deepestYet = curr
@@ -220,9 +222,8 @@ class BestFirstSearch(val formatOps: FormatOps,
         } else {
 
           val splits: Seq[Split] =
-            if (curr.formatOff) List(provided(splitToken))
-            else if (splitToken.inside(range)) routes(curr.splits.length)
-            else List(provided(splitToken))
+            if (formatOff(i)) List(provided(splitToken))
+            else routes(curr.splits.length)
 
           val actualSplit = {
             curr.policy

--- a/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/core/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -41,14 +41,15 @@ class BestFirstSearch(val formatOps: FormatOps,
     }
     result.result()
   }
-  val noOptimizations = noOptimizationZones(tree)
+  val noOptimizations: Set[Token] = noOptimizationZones(tree)
   var explored = 0
-  var deepestYet = State.start
-  var deepestYetSafe = State.start
+  var deepestYet: State = State.start
+  var deepestYetSafe: State = State.start
   var statementCount = 0
-  val best = mutable.Map.empty[Token, State]
+  val best: mutable.Map[Token, State] = mutable.Map.empty[Token, State]
   var pathologicalEscapes = 0
-  val visits = mutable.Map.empty[FormatToken, Int].withDefaultValue(0)
+  val visits: mutable.Map[FormatToken, Int] =
+    mutable.Map.empty[FormatToken, Int].withDefaultValue(0)
 
   type StateHash = Long
 
@@ -97,11 +98,11 @@ class BestFirstSearch(val formatOps: FormatOps,
     // TODO(olafur) the indentation is not correctly set.
     val split = Split(Provided(formatToken.between.map(_.syntax).mkString), 0)
     val result =
-      if (formatToken.left.is[LeftBrace])
-        split.withIndent(Num(2),
-                         matchingParentheses(hash(formatToken.left)),
-                         Right)
-      else split
+      formatOps.estimateIndent(formatToken) match {
+        case Some((indent, expire)) =>
+          split.withIndent(Num(indent), expire, Right)
+        case _ => split
+      }
     result
   }
 
@@ -113,7 +114,8 @@ class BestFirstSearch(val formatOps: FormatOps,
     explored > runner.maxStateVisits || state.splits.length == tokens.length
   }
 
-  val memo = mutable.Map.empty[(Int, StateHash), State]
+  val memo: mutable.Map[(Int, StateHash), State] =
+    mutable.Map.empty[(Int, StateHash), State]
 
   def shortestPathMemo(start: State, stop: Token, depth: Int, maxCost: Int)(
       implicit line: sourcecode.Line): State = {

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -617,4 +617,19 @@ class FormatOps(val tree: Tree,
       case None => count
     }
   }
+
+  def estimateIndent(formatToken: FormatToken): Option[(Int, Token)] =
+    formatToken match {
+      case FormatToken(open @ LeftBrace(), _, _)
+          if nextNonComment(formatToken).hasNewline =>
+        Some((2, matchingParentheses(hash(open))))
+      case FormatToken(arrow @ RightArrow(), _, _)
+          if nextNonComment(formatToken).hasNewline =>
+        owners(arrow) match {
+          case t: Case => Some((2, lastToken(t.body)))
+          case t: Term.Function => Some((2, lastToken(t.body)))
+          case _ => None
+        }
+      case _ => None
+    }
 }

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -56,6 +56,7 @@ class FormatOps(val tree: Tree,
     FileDiff
       .getFormatTokenRanges(tokens, range)
       .map(FileDiff.expandToEnclosingStatements(_, this))
+//  logger.elem(tokenRanges)
   val formatOff: Array[Boolean] = {
     val result = new Array[Boolean](tokens.length)
     var off = formatSubset

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -63,11 +63,18 @@ class FormatOps(val tree: Tree,
     val enableFormat = tokenRanges.map(_.start).toSet
     val disableFormat = tokenRanges.map(_.end).toSet
     tokens.foreach { tok =>
-      if (isFormatOff(tok.left) ||
-          (formatSubset && disableFormat(tok))) off = true
-      else if (isFormatOn(tok.left) ||
-               (formatSubset && enableFormat(tok))) off = false
+      val disable =
+        isFormatOff(tok.left) ||
+          (formatSubset && disableFormat(tok))
+      val enable =
+        isFormatOn(tok.left) ||
+          (formatSubset && enableFormat(tok))
+      off =
+        if (enable) false
+        else if (disable) true
+        else off
       result(i) = off
+      if (disable && enable) off = true
       i += 1
     }
     result

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -56,8 +56,6 @@ class FormatOps(val tree: Tree,
     FileDiff
       .getFormatTokenRanges(tokens, range)
       .map(FileDiff.expandToEnclosingStatements(_, this))
-  logger.elem(tokenRanges)
-
   val formatOff: Array[Boolean] = {
     val result = new Array[Boolean](tokens.length)
     var off = formatSubset

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -38,7 +38,7 @@ import org.scalafmt.util.logger
   */
 class FormatOps(val tree: Tree,
                 val initStyle: ScalafmtConfig,
-                range: Set[Range] = Set.empty[Range]) {
+                range: Seq[Range] = Seq.empty[Range]) {
   val runner: ScalafmtRunner = initStyle.runner
   import TokenOps._
   import TreeOps._
@@ -51,10 +51,8 @@ class FormatOps(val tree: Tree,
     tree.tokens)
   val styleMap = new StyleMap(tokens, initStyle)
   private val vAlignDepthCache = mutable.Map.empty[Tree, Int]
-  val additions: Seq[Addition] =
-    range.map(x => Addition(x.start, x.end - x.start + 1)).toSeq
   val tokenRanges: Seq[FormatTokenRange] =
-    FileDiff.getFormatTokenRanges(tokens, additions)
+    FileDiff.getFormatTokenRanges(tokens, range)
   logger.elem(tokenRanges)
   val formatOff: Array[Boolean] = {
     val result = new Array[Boolean](tokens.length)

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -21,7 +21,7 @@ case class FormatToken(left: Token, right: Token, between: Vector[Token]) {
 
   override def toString = s"${left.syntax}∙${right.syntax}"
 
-  def inside(range: Set[Range]): Boolean = {
+  def inside(range: Seq[Range]): Boolean = {
     if (range.isEmpty) true
     else range.exists(_.contains(right.pos.end.line))
   }

--- a/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.internal
 
 import scala.meta.tokens.Token
+import scala.meta.tokens.Token.LF
 import scala.meta.tokens.Tokens
 
 import org.scalafmt.util.TokenOps._
@@ -26,7 +27,11 @@ case class FormatToken(left: Token, right: Token, between: Vector[Token]) {
     else range.exists(_.contains(right.pos.end.line))
   }
 
-  val leftHasNewline = left.syntax.contains('\n')
+  def newlines: Int = between.count(_.is[LF])
+
+  def hasNewline: Boolean = between.exists(_.is[LF])
+
+  val leftHasNewline: Boolean = left.syntax.contains('\n')
 
   /**
     * A format token is uniquely identified by its left token.

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -9,6 +9,8 @@ import scala.meta.tokens.Token._
 import java.util.regex.Pattern
 
 import org.scalafmt.internal.FormatWriter.FormatLocation
+import org.scalafmt.util.LoggerOps
+import org.scalafmt.util.logger
 
 /**
   * Produces formatted output from sequence of splits.
@@ -22,6 +24,7 @@ class FormatWriter(formatOps: FormatOps) {
     var lastState = State.start // used to calculate start of formatToken.right.
     reconstructPath(tokens, splits, debug = false) {
       case (state, formatToken, whitespace) =>
+        logger.elem(formatToken, state.splits.last)
         formatToken.left match {
           case c: Comment =>
             sb.append(formatComment(c, state.indentation))
@@ -49,12 +52,12 @@ class FormatWriter(formatOps: FormatOps) {
     sb.toString()
   }
 
-  val trailingSpace = Pattern.compile(" +$", Pattern.MULTILINE)
+  val trailingSpace: Pattern = Pattern.compile(" +$", Pattern.MULTILINE)
   private def removeTrailingWhiteSpace(str: String): String = {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  val leadingAsteriskSpace =
+  val leadingAsteriskSpace: Pattern =
     Pattern.compile("\n *\\*(?!\\*)", Pattern.MULTILINE)
   private def formatComment(comment: Comment, indent: Int): String = {
     val alignedComment =
@@ -97,7 +100,6 @@ class FormatWriter(formatOps: FormatOps) {
     }
   }
 
-  import org.scalafmt.util.LoggerOps._
   import org.scalafmt.util.TokenOps._
 
   def getFormatLocations(toks: Array[FormatToken],
@@ -114,7 +116,7 @@ class FormatWriter(formatOps: FormatOps) {
         statesBuilder += FormatLocation(tok, split, currState)
         // TIP. Use the following line to debug origin of splits.
         if (debug && tokens.length < 1000) {
-          val left = cleanup(tok.left).slice(0, 15)
+          val left = LoggerOps.cleanup(tok.left).slice(0, 15)
           logger.debug(
             f"$left%-15s $split ${currState.indentation} ${currState.column}")
         }

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -22,10 +22,9 @@ class FormatWriter(formatOps: FormatOps) {
   def mkString(splits: Vector[Split]): String = {
     val sb = new StringBuilder()
     var lastState = State.start // used to calculate start of formatToken.right.
-    var i = -1
     reconstructPath(tokens, splits, debug = false) {
-      case (state, formatToken, whitespace) =>
-        i += 1
+      case (state, formatToken, whitespace, i) =>
+//        logger.elem(formatOps.formatOff(i), formatToken)
         if (formatOps.formatOff(i)) {
           sb.append(formatToken.left.syntax)
           sb.append(whitespace)
@@ -137,7 +136,7 @@ class FormatWriter(formatOps: FormatOps) {
   def reconstructPath(
       toks: Array[FormatToken],
       splits: Vector[Split],
-      debug: Boolean)(callback: (State, FormatToken, String) => Unit): Unit = {
+      debug: Boolean)(callback: (State, FormatToken, String, Int) => Unit): Unit = {
     require(toks.length >= splits.length, "splits !=")
     val locations = getFormatLocations(toks, splits, debug)
     val tokenAligns = alignmentTokens(locations).withDefaultValue(0)
@@ -171,7 +170,7 @@ class FormatWriter(formatOps: FormatOps) {
           case NoSplit => ""
         }
         lastModification = split.modification
-        callback.apply(state, tok, whitespace)
+        callback.apply(state, tok, whitespace, i)
     }
     locations.lastOption.foreach { location =>
       if (debug) logger.debug(s"Total cost: ${location.state.cost}")

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -174,10 +174,10 @@ class FormatWriter(formatOps: FormatOps) {
               else " " * state.indentation
             newline + indentation
           case Provided(literal) => literal
-          case NoSplit => ""
-        }
-        lastModification = split.modification
-        callback.apply(state, tok, whitespace, i)
+        case NoSplit => ""
+      }
+      lastModification = split.modification
+      callback.apply(state, tok, whitespace, i)
     }
     locations.lastOption.foreach { location =>
       if (debug) logger.debug(s"Total cost: ${location.state.cost}")

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -24,7 +24,6 @@ class FormatWriter(formatOps: FormatOps) {
     var lastState = State.start // used to calculate start of formatToken.right.
     reconstructPath(tokens, splits, debug = false) {
       case (state, formatToken, whitespace) =>
-        logger.elem(formatToken, state.splits.last)
         formatToken.left match {
           case c: Comment =>
             sb.append(formatComment(c, state.indentation))

--- a/core/src/main/scala/org/scalafmt/internal/State.scala
+++ b/core/src/main/scala/org/scalafmt/internal/State.scala
@@ -16,8 +16,7 @@ final case class State(cost: Int,
                        splits: Vector[Split],
                        indentation: Int,
                        pushes: Vector[Indent[Num]],
-                       column: Int,
-                       formatOff: Boolean)
+                       column: Int)
     extends Ordered[State] {
 
   def compare(that: State): Int = {
@@ -54,8 +53,7 @@ object State {
                     Vector.empty[Split],
                     0,
                     Vector.empty[Indent[Num]],
-                    0,
-                    formatOff = false)
+                    0)
 
   /**
     * Calculates next State given split at tok.
@@ -111,18 +109,12 @@ object State {
       }
     }
 
-    val nextFormatOff =
-      if (TokenOps.isFormatOff(tok.right)) true
-      else if (TokenOps.isFormatOn(tok.right)) false
-      else formatOff
-
     State(cost + splitWithPenalty.cost,
           // TODO(olafur) expire policy, see #18.
           newPolicy,
           splits :+ splitWithPenalty,
           newIndent,
           newIndents,
-          nextStateColumn,
-          nextFormatOff)
+          nextStateColumn)
   }
 }

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -164,7 +164,7 @@ object TokenOps {
   def newlinesBetween(between: Vector[Token]): Int =
     between.count(_.is[LF])
 
-  def isAttachedComment(token: Token, between: Vector[Token]) =
+  def isAttachedComment(token: Token, between: Vector[Token]): Boolean =
     isInlineComment(token) && newlinesBetween(between) == 0
 
   def defnTemplate(tree: Tree): Option[Template] = tree match {

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -2,25 +2,91 @@ package org.scalafmt
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.DiffAssertions
+import org.scalafmt.util.LoggerOps
 import org.scalatest.FunSuite
 
 class RangeTest extends FunSuite with DiffAssertions {
-  test("range preserves indent") {
-    val original = """object a {
-                     |val x = 1
-                     |val y = 2
-                     |}
-      """.stripMargin
-    val expected = """object a {
-                     |val x = 1
-                     |  val y = 2
-                     |}
-      """.stripMargin
-    val obtained = Scalafmt
-      .format(original,
-              ScalafmtConfig.unitTest40,
-              range = Set(Range(2, 2).inclusive))
-      .get
-    assertNoDiff(obtained, expected)
+  def check(original: String, expected: String, range: Range): Unit = {
+    test(LoggerOps.reveal(original)) {
+      val obtained = Scalafmt
+        .format(original, ScalafmtConfig.unitTest40, range = Set(range))
+        .get
+      assertNoDiff(obtained, expected)
+    }
   }
+  check(
+    """object a {
+      |val x = 1
+      |val y = 2
+      |val z = 3
+      |}
+      |object   a
+      |""".stripMargin,
+    """object a {
+      |val x = 1
+      |  val y = 2
+      |val z = 3
+      |}
+      |object   a
+      |""".stripMargin,
+    Range(3, 3)
+  )
+  check(
+    """object a {
+      |function(a,
+      |b,
+      |x)
+      |}""".stripMargin,
+    """object a {
+      |  function(a, b, x)
+      |}
+      |""".stripMargin,
+    Range(3, 3)
+  )
+  check(
+    """object a {
+      |  function(a,
+      |           bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+      |           x)
+      |}""".stripMargin,
+    """object a {
+      |  function(
+      |      a,
+      |      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+      |      x)
+      |}
+      |""".stripMargin,
+    Range(3, 3)
+  )
+  check(
+    """/**
+      |    * a
+      |  */
+      |object   a
+      |""".stripMargin,
+    """/**
+      |  * a
+      |  */
+      |object   a
+      |""".stripMargin,
+    Range(2, 2)
+  )
+
+  check(
+    """|object a {
+       |  lst.map{a=>
+       |    l >2
+       |    foo   ()
+       |  }
+       |}
+       |""".stripMargin,
+    """|object a {
+       |  lst.map { a =>
+       |    l > 2
+       |    foo   ()
+       |  }
+       |}
+       |""".stripMargin,
+    Range(2, 3)
+  )
 }

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -6,7 +6,10 @@ import org.scalafmt.util.LoggerOps
 import org.scalatest.FunSuite
 
 class RangeTest extends FunSuite with DiffAssertions {
-  def check(original: String, expected: String, range: Range): Unit = {
+  def skip(original: String, expected: String, range: Range): Unit =
+    ignore(LoggerOps.reveal(original)) { () }
+
+    def check(original: String, expected: String, range: Range): Unit = {
     test(LoggerOps.reveal(original)) {
       val obtained = Scalafmt
         .format(original, ScalafmtConfig.unitTest40, range = Seq(range))

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -9,7 +9,7 @@ class RangeTest extends FunSuite with DiffAssertions {
   def check(original: String, expected: String, range: Range): Unit = {
     test(LoggerOps.reveal(original)) {
       val obtained = Scalafmt
-        .format(original, ScalafmtConfig.unitTest40, range = Set(range))
+        .format(original, ScalafmtConfig.unitTest40, range = Seq(range))
         .get
       assertNoDiff(obtained, expected)
     }

--- a/core/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/core/src/test/scala/org/scalafmt/RangeTest.scala
@@ -5,11 +5,8 @@ import org.scalafmt.util.DiffAssertions
 import org.scalafmt.util.LoggerOps
 import org.scalatest.FunSuite
 
-class RangeTest extends FunSuite with DiffAssertions {
-  def skip(original: String, expected: String, range: Range): Unit =
-    ignore(LoggerOps.reveal(original)) { () }
-
-    def check(original: String, expected: String, range: Range): Unit = {
+abstract class AbstractRangeTest extends FunSuite with DiffAssertions {
+  def check(original: String, expected: String, range: Range): Unit = {
     test(LoggerOps.reveal(original)) {
       val obtained = Scalafmt
         .format(original, ScalafmtConfig.unitTest40, range = Seq(range))
@@ -17,6 +14,9 @@ class RangeTest extends FunSuite with DiffAssertions {
       assertNoDiff(obtained, expected)
     }
   }
+}
+
+class RangeTest extends AbstractRangeTest {
   check(
     """object a {
       |val x = 1
@@ -33,6 +33,25 @@ class RangeTest extends FunSuite with DiffAssertions {
       |object   a
       |""".stripMargin,
     Range(3, 3)
+  )
+  check( // no matching line
+    """
+      |
+      |object  a {
+      |val x = 1
+      |val y = 2
+      |val z = 3
+      |}
+      |""".stripMargin,
+    """
+      |
+      |object  a {
+      |val x = 1
+      |val y = 2
+      |val z = 3
+      |}
+      |""".stripMargin,
+    Range(1000, 10000)
   )
   check(
     """object a {

--- a/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
+++ b/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
@@ -70,7 +70,7 @@ class DiffTest extends FunSuite with DiffAssertions {
     assert(obtained == expected)
   }
 
-  test("adjust") {
+  ignore("adjust") {
     val fileDiff = FileDiff(
       "Foo.scala",
       Seq(
@@ -97,19 +97,21 @@ class DiffTest extends FunSuite with DiffAssertions {
   }
 
   test("expand") {
-    val ranges: Seq[FormatTokenRange] = Seq(
-      (13, 13),
-      (17, 17),
-      (98, 128),
-      (129, 133)
-    ).map {
-      case (l, r) => FormatTokenRange(formatOps.tokens(l), formatOps.tokens(r))
-    }
+    val code =
+      """|object a {
+         |  function(a,
+         |           b,
+         |           cccccccccccccccc,
+         |           c)
+         |}
+      """.stripMargin
+    val ast = code.parse[Source].get
+    val r = Seq(Range(3, 4))
+    val ops = new FormatOps(ast, ScalafmtConfig.default40, r)
+    val ranges = FileDiff.getFormatTokenRanges(ops.tokens, r)
+    println(ranges)
     ranges.foreach { range =>
-      println(FileDiff.expandToEnclosingStatements(range, formatOps))
+      println(FileDiff.expandToEnclosingStatements(range, ops))
     }
-//    val expanded = FileDiff.expandToEnclosingStatements()
-
   }
-
 }

--- a/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
+++ b/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
@@ -70,7 +70,7 @@ class DiffTest extends FunSuite with DiffAssertions {
     assert(obtained == expected)
   }
 
-  ignore("adjust") {
+  test("adjust") {
     val fileDiff = FileDiff(
       "Foo.scala",
       Seq(
@@ -81,7 +81,8 @@ class DiffTest extends FunSuite with DiffAssertions {
       )
     )
     val ranges =
-      FileDiff.getFormatTokenRanges(formatOps.tokens, fileDiff.additions)
+      FileDiff.getFormatTokenRanges(formatOps.tokens,
+                                    fileDiff.additions.map(_.toRange))
     val expected =
       """|diff∙import <-> Tree∙object
          |/** Parses a unified diff into FileDiffs.
@@ -96,7 +97,6 @@ class DiffTest extends FunSuite with DiffAssertions {
   }
 
   test("expand") {
-
     val ranges: Seq[FormatTokenRange] = Seq(
       (13, 13),
       (17, 17),
@@ -106,7 +106,7 @@ class DiffTest extends FunSuite with DiffAssertions {
       case (l, r) => FormatTokenRange(formatOps.tokens(l), formatOps.tokens(r))
     }
     ranges.foreach { range =>
-      FileDiff.expandToEnclosingStatements(range, formatOps)
+      println(FileDiff.expandToEnclosingStatements(range, formatOps))
     }
 //    val expanded = FileDiff.expandToEnclosingStatements()
 

--- a/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
+++ b/core/src/test/scala/org/scalafmt/diff/DiffTest.scala
@@ -1,0 +1,115 @@
+package org.scalafmt.diff
+
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.internal.FormatOps
+import org.scalafmt.util.DiffAssertions
+import org.scalafmt.util.logger
+import org.scalatest.FunSuite
+
+class DiffTest extends FunSuite with DiffAssertions {
+  val code =
+    """|package org.scalafmt.diff
+       |
+       |import scala.meta.Tree
+       |
+       |object FileDiff {
+       |  /** Parses a unified diff into FileDiffs.
+       |    * Example commands to produce unified diff:
+       |    */
+       |  def fromUnified(diff: String): Seq[FileDiff] = {
+       |    diff.lines.foreach {
+       |      case NewFile(_ , filename) =>
+       |        addLastFile()
+       |        currentFilename = Some(filename)
+       |      case other =>
+       |        for {
+       |          diffBlock <- DiffBlock.findAllMatchIn(other)
+       |          lineCount = Try(diffBlock.group("lineCount").toInt).getOrElse(1)
+       |        } {
+       |          additions += Addition(startLine, lineCount)
+       |        }
+       |    }
+       |  }
+       |
+       |  def adjustRanges(ast: Tree, fileDiff: FileDiff): FileDiff = {
+       |    val newAdditions =
+       |      fileDiff.additions.map { addition =>
+       |        ???
+       |      }
+       |    fileDiff
+       |  }
+       |}
+       |
+       |class A()
+    """.stripMargin
+  import scala.meta._
+  val ast = code.parse[Source].get
+  val formatOps = new FormatOps(ast, ScalafmtConfig.default)
+
+  ignore("parse") {
+    val diff =
+      """|--- /dev/null
+         |+++ b/core/src/test/scala/org/scalafmt/DiffTest.scala
+         |@@ -54 +54,2 @@ class Router(formatOps: FormatOps) {
+         |-  import Constants._
+         |+  import
+         |+  Constants._
+         |@@ -57 +58 @@ class Router(formatOps: FormatOps) {
+         |-  import TreeOps._
+         |+  import  TreeOps._
+         |@@ -60,3 +61,6 @@ class Router(formatOps: FormatOps) {
+         |-  private def getSplits(formatToken: FormatToken): Seq[Split] = {
+         |-    val style = styleMap.at(formatToken)
+         |-    val leftOwner = owners(formatToken.left)
+         |+  private def getSplits(""".stripMargin
+
+    val expected = List(
+      FileDiff("core/src/test/scala/org/scalafmt/DiffTest.scala",
+               List(Addition(54, 2), Addition(58, 1), Addition(61, 6))))
+    val obtained = FileDiff.fromUnified(diff)
+    assert(obtained == expected)
+  }
+
+  ignore("adjust") {
+    val fileDiff = FileDiff(
+      "Foo.scala",
+      Seq(
+        Addition(3, 1),
+        Addition(7, 1),
+        Addition(23, 8),
+        Addition(33, 1)
+      )
+    )
+    val ranges =
+      FileDiff.getFormatTokenRanges(formatOps.tokens, fileDiff.additions)
+    val expected =
+      """|diff∙import <-> Tree∙object
+         |/** Parses a unified diff into FileDiffs.
+         |    * Example commands to produce unified diff:
+         |    */∙def <-> /** Parses a unified diff into FileDiffs.
+         |    * Example commands to produce unified diff:
+         |    */∙def
+         |}∙def <-> }∙}
+         |}∙class <-> )∙""".stripMargin
+    val obtained = ranges.mkString("\n")
+    assertNoDiff(obtained, expected)
+  }
+
+  test("expand") {
+
+    val ranges: Seq[FormatTokenRange] = Seq(
+      (13, 13),
+      (17, 17),
+      (98, 128),
+      (129, 133)
+    ).map {
+      case (l, r) => FormatTokenRange(formatOps.tokens(l), formatOps.tokens(r))
+    }
+    ranges.foreach { range =>
+      FileDiff.expandToEnclosingStatements(range, formatOps)
+    }
+//    val expanded = FileDiff.expandToEnclosingStatements()
+
+  }
+
+}

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -46,7 +46,8 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
       case _ =>
     }
   )
-  lazy val debugResults: mutable.ArrayBuilder[Result] = mutable.ArrayBuilder.make[Result]
+  lazy val debugResults: mutable.ArrayBuilder[Result] =
+    mutable.ArrayBuilder.make[Result]
   val testDir = "core/src/test/resources"
 
   def tests: Seq[DiffTest]

--- a/core/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/core/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -30,7 +30,7 @@ import org.scalatest.FunSuiteLike
 trait HasTests extends FunSuiteLike with FormatAssertions {
   import LoggerOps._
   import org.scalafmt.config.ScalafmtConfig._
-  val scalafmtRunner = ScalafmtRunner.default.copy(
+  val scalafmtRunner: ScalafmtRunner = ScalafmtRunner.default.copy(
     debug = true,
     maxStateVisits = 150000,
     eventCallback = {
@@ -46,7 +46,7 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
       case _ =>
     }
   )
-  lazy val debugResults = mutable.ArrayBuilder.make[Result]
+  lazy val debugResults: mutable.ArrayBuilder[Result] = mutable.ArrayBuilder.make[Result]
   val testDir = "core/src/test/resources"
 
   def tests: Seq[DiffTest]
@@ -58,11 +58,11 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
     else tests
   }
 
-  def isOnly(name: String) = name.startsWith("ONLY ")
+  def isOnly(name: String): Boolean = name.startsWith("ONLY ")
 
-  def isSkip(name: String) = name.startsWith("SKIP ")
+  def isSkip(name: String): Boolean = name.startsWith("SKIP ")
 
-  def stripPrefix(name: String) =
+  def stripPrefix(name: String): String =
     name.stripPrefix("SKIP ").stripPrefix("ONLY ").trim
 
   def filename2parse(filename: String): Option[Parse[_ <: Tree]] =
@@ -265,7 +265,7 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
     val builder = mutable.ArrayBuilder.make[FormatOutput]()
     new FormatWriter(Debug.formatOps)
       .reconstructPath(Debug.tokens, Debug.state.splits, debug = onlyOne) {
-        case (_, token, whitespace) =>
+        case (_, token, whitespace, _) =>
           builder += FormatOutput(token.left.syntax,
                                   whitespace,
                                   Debug.formatTokenExplored(token))

--- a/utils/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/utils/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -4,6 +4,7 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
 import java.io.PrintWriter
+import java.io.Reader
 
 object FileOps {
 
@@ -53,10 +54,13 @@ object FileOps {
   }
 
   def readFile(file: File): String = {
+    readFile(new BufferedReader(new FileReader(file)))
+  }
+  val lineSeparator: String = System.getProperty("line.separator")
+
+  def readFile(br: BufferedReader): String = {
     // Prefer this to inefficient Source.fromFile.
     val sb = new StringBuilder
-    val br = new BufferedReader(new FileReader(file))
-    val lineSeparator = System.getProperty("line.separator")
     try {
       var line = ""
       while ({

--- a/utils/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/utils/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -19,10 +19,7 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
   val swallowStderr = ProcessLogger(_ => Unit, _ => Unit)
 
   def exec(cmd: Seq[String]): String = {
-    sys.process
-      .Process(cmd, workingDirectory.jfile)
-      .!!(swallowStderr)
-      .trim
+    sys.process.Process(cmd, workingDirectory.jfile).!!(swallowStderr).trim
   }
 
   override def lsTree: Seq[AbsoluteFile] =

--- a/utils/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/utils/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -6,6 +6,7 @@ import scala.util.Try
 import java.io.File
 
 trait GitOps {
+  def diff(baseBranch: String): String
   def lsTree: Seq[AbsoluteFile]
   def rootDir: Option[AbsoluteFile]
 }
@@ -16,7 +17,6 @@ object GitOps {
 
 class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
   val swallowStderr = ProcessLogger(_ => Unit, _ => Unit)
-  val baseCommand = Seq("git")
 
   def exec(cmd: Seq[String]): String = {
     sys.process
@@ -28,7 +28,8 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
   override def lsTree: Seq[AbsoluteFile] =
     Try {
       exec(
-        baseCommand ++ Seq(
+        Seq(
+          "git",
           "ls-tree",
           "-r",
           "HEAD",
@@ -41,9 +42,20 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
 
   override def rootDir: Option[AbsoluteFile] =
     Try {
-      val cmd = baseCommand ++ Seq("rev-parse", "--show-toplevel")
-      val result = AbsoluteFile.fromFile(new File(exec(cmd)), workingDirectory)
+      val topdir = new File(exec(Seq("git", "rev-parse", "--show-toplevel")))
+      val result = AbsoluteFile.fromFile(topdir, workingDirectory)
       require(result.jfile.isDirectory)
       result
     }.toOption
+
+  override def diff(baseBranch: String): String = {
+    exec(
+      Seq(
+        "git",
+        "diff",
+        "-U0",
+        baseBranch
+      )
+    )
+  }
 }


### PR DESCRIPTION
This PR introduces a new feature called "diff formatting". With `scalafmt --diff`, you only format the lines that are touched by a diff. Examples

```shell
# via stdin
$ git diff -U0 master | scalafmt --diff --stdin
... # writes to files
$ svn diff --diff-cmd=diff -x-U0 | scalafmt --diff --stdin # untested, but should work
# via configuration
$ cat .scalafmt.conf
project.git = true
project.baseBranch = master
$ scalafmt --diff
... # writes to file
```

Use cases:
* Interactive IDE setting in a codebase that's not formatted with scalafmt. You could reformat a subsection you edited.
* (hypothetical) gradually introduce scalafmt into a project, or allow a subset of developers to use scalafmt in a codebase (caveat below)
* faster formatting (although nice, I wouldn't call it a selling feature unless for maybe huge source files).

Caveats:
* in a partially formatted codebase, scalafmt may still introduce unnecessarily large diffs. Example

```diff
// line limit    |
-  class Foo extends A with B with C
+  class Foo extends A with B with C with D
// after formatting
class Foo
    extends A
    with B
    with C
    with D
```
A blank enforcement of diff formatting might therefore be unwanted.

Challenges:
* need to guarantee that formatting a sequence of diffs will always produce the same output as formatting everything all the time.


Opening this PR to collect feedback. I would like to get this feature ready for 0.5.

TODOs:
- [x] handle indent for `Case`
- [x] handle indent for `Term.Lambda`
- [ ] setup test that goes through git repo history and formats diff on every commit. Assert the output is identical to formatting the entire project on every commit.
- [ ] select chains
- [ ] large config style lists