### PR TITLE
Bump penalty for select chains of length 1.

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/core/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -15,6 +15,27 @@ import metaconfig.ConfigReader
   *       def foo = 2
   *     }
   *   )
+  *
+  * @param penalizeSingleSelectMultiArgList
+  *   If true, adds a penalty to newlines before a dot starting a select
+  *   chain of length one and argument list. The penalty matches the number
+  *   of arguments to the select chain application.
+  *   {{{
+  *     // If true, favor
+  *     logger.elem(a,
+  *                 b,
+  *                 c)
+  *     // instead of
+  *     logger
+  *       .elem(a, b, c)
+  *
+  *     // penalty is proportional to argument count, example:
+  *     logger.elem(a, b, c)    // penalty 2
+  *     logger.elem(a, b, c, d) // penalty 3, etc.
+  *   }}}
+  *
+  *   If false, matches pre-v0.5 behavior. Note. this option may be
+  *   removed in a future release.
   */
 @ConfigReader
 case class Newlines(
@@ -22,5 +43,6 @@ case class Newlines(
     neverInResultType: Boolean = false,
     neverBeforeJsNative: Boolean = false,
     sometimesBeforeColonInMethodReturnType: Boolean = true,
+    penalizeSingleSelectMultiArgList: Boolean = true,
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false
 )

--- a/core/src/test/resources/default/Select.stat
+++ b/core/src/test/resources/default/Select.stat
@@ -271,3 +271,22 @@ object a {
       computeOrReadCheckpoint(partition, context)
     })
 }
+<<< #599
+{{
+ logger
+      .elem(threp1, threp2, threp3, tax.total.value, tax.usedPersonalDiscount)
+}}
+>>>
+{
+  {
+    logger.elem(threp1,
+                threp2,
+                threp3,
+                tax.total.value,
+                tax.usedPersonalDiscount)
+  }
+}
+<<< No args #599
+  keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected
+>>>
+keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected


### PR DESCRIPTION
Although the change itself is small, this commit changes the
formatted output for a significant amount of code. An example
diff can be seen here: https://github.com/olafurpg/scala-repos/pull/14

Fixes #599.