### PR TITLE
Upgrade to scala.meta 1.3.

### DIFF
--- a/core/src/main/scala/org/scalafmt/util/TreeClasses.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeClasses.scala
@@ -1,5 +1,6 @@
 package org.scalafmt.util
 
+import scala.collection.immutable.Seq
 import scala.meta.internal.classifiers.classifier
 import scala.meta._
 

--- a/core/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.util
 
 import scala.collection.immutable.Seq
+import scala.meta.Template
 import scala.meta.Name
 import scala.meta.Pat
 import scala.meta.Term
@@ -11,7 +12,36 @@ object InfixApplication {
   def unapply(tree: Tree): Option[(Tree, Name, Seq[Tree])] = tree match {
     case infix: Type.ApplyInfix => Some((infix.lhs, infix.op, infix.children))
     case infix: Term.ApplyInfix => Some((infix.lhs, infix.op, infix.args))
-    case infix: Pat.ExtractInfix => Some((infix.lhs, infix.ref, infix.rhs))
+    case infix: Pat.ExtractInfix => Some((infix.lhs, infix.op, infix.rhs))
     case _ => None
   }
+}
+
+/**
+  * Pattern extractor to concisely and safely query parent chain.
+  *
+  * Example:
+  * {{{
+  *   tree match {
+  *     case (_: Term) `:parent:` (_: Defn) `:parent:` (_: Source) => ???
+  *   }
+  * }}}
+  * The name is backquoted to get right associativity while using
+  * alphabetic characters
+  */
+object `:parent:` {
+  def unapply(tree: Tree): Option[(Tree, Tree)] = tree.parent match {
+    case Some(parent) =>
+      Some(tree -> parent)
+    case _ => None
+  }
+}
+
+object SelfAnnotation {
+  def unapply(t: Type.With): Option[Type.With] =
+    TreeOps.topTypeWith(t) match {
+      case (top: Type.With) `:parent:` (_: Term.Param) `:parent:` (_: Template) =>
+        Some(top)
+      case _ => None
+    }
 }

--- a/core/src/test/resources/align/AlignTokens.stat
+++ b/core/src/test/resources/align/AlignTokens.stat
@@ -361,15 +361,15 @@ Ok(
 }
 <<< mixed object/class/trait
 object mixed {
-final trait False extends Val
-final case object False extends Val
-  final case class Zero(zeroty: nir.Type)                     extends Val
+protected trait False extends Val
+protected case object False extends Val
+  protected case class Zero(zeroty: nir.Type)                     extends Val
 }
 >>>
 object mixed {
-  final trait False                       extends Val
-  final case object False                 extends Val
-  final case class Zero(zeroty: nir.Type) extends Val
+  protected trait False                       extends Val
+  protected case object False                 extends Val
+  protected case class Zero(zeroty: nir.Type) extends Val
 }
 <<< #513
 {

--- a/core/src/test/resources/default/Lambda.stat
+++ b/core/src/test/resources/default/Lambda.stat
@@ -139,3 +139,26 @@ rule {
         DIGIT) ~ OWS
   }
 }
+<<< SKIP y u break line? Answer: Because optimizer.recurseOnBlocks
+{
+  def foo =
+    T({ a =>
+      valueSort.map {
+        vs =>
+          vs match {
+            case ordser: OrderedSerialization[V1] =>
+              Grouped.getBoxFnAndOrder[V1](ordser, fd)
+              val valueF = new Fields("value")
+              val ts2 = tupleSetter
+                .asInstanceOf[TupleSetter[(K, Boxed[V1])]]
+                .contraMap { kv1: (K, V1) =>
+                  (kv1._1, boxfn(kv1._2))
+                }
+              (Some(valueF), ts2)
+          }
+      }
+    })
+}
+>>>
+{
+}

--- a/core/src/test/resources/default/TypeWith.stat
+++ b/core/src/test/resources/default/TypeWith.stat
@@ -1,0 +1,11 @@
+80 columns                                                                     |
+<<< with
+{ def getAnnotationOwner(
+       annotationOwnerLookUp: ScLiteral => Option[
+         PsiAnnotationOwner with PsiElement]): Option[PsiAnnotationOwner] = 1 }
+>>>
+{
+  def getAnnotationOwner(
+      annotationOwnerLookUp: ScLiteral => Option[
+          PsiAnnotationOwner with PsiElement]): Option[PsiAnnotationOwner] = 1
+}

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -1,5 +1,5 @@
 object Deps {
-  val scalameta = "1.1.0"
+  val scalameta = "1.3.0"
   val scalatest = "2.2.1"
   val scalariform = "0.1.8"
 }


### PR DESCRIPTION
1.3 introduced a new encoding for Type.Compound which complicated things
quite a bit. This commit tried to remap the new encoding into the old
encoding. The scala-repos diff is here: https://github.com/olafurpg/scala-repos/commit/c00c1bd6da91d2aec92f6d15933795f09d98ec2a

The diff comes from a quirky bug in
optimizer.recurseOnBlocks, see https://github.com/olafurpg/scalafmt/issues/614, which I think is a scalafmt bug and not scala.meta 1.3 bug.