### PR TITLE
Improve search state for reactjs style DSLs. Fixes #458

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -876,14 +876,17 @@ class Router(formatOps: FormatOps) {
               case (_, lst) => Math.max(0, lst.length - 1)
             }.getOrElse(0)
           } else 0
-        Seq(
-          Split(NoSplit, 0, ignoreIf = ignoreNoSplit)
-            .withPolicy(noSplitPolicy),
-          Split(Newline.copy(acceptNoSplit = true),
-                2 + nestedPenalty + chainLengthPenalty)
-            .withPolicy(newlinePolicy)
-            .withIndent(2, optimalToken, Left)
-        )
+        if (TokenOps.isSymbolicIdent(left))
+          Seq(Split(NoSplit, 0))
+        else
+          Seq(
+            Split(NoSplit, 0, ignoreIf = ignoreNoSplit)
+              .withPolicy(noSplitPolicy),
+            Split(Newline.copy(acceptNoSplit = true),
+                  2 + nestedPenalty + chainLengthPenalty)
+              .withPolicy(newlinePolicy)
+              .withIndent(2, optimalToken, Left)
+          )
       // ApplyUnary
       case tok @ FormatToken(Ident(_), Literal(), _)
           if leftOwner == rightOwner =>

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -209,6 +209,11 @@ object TokenOps {
     "// format: off" // scalariform
   )
 
+  def isSymbolicIdent(tok: Token): Boolean = tok match {
+    case Ident(name) => !name.head.isLetter
+    case _ => false
+  }
+
   val formatOnCode = Set(
     "// @formatter:on", // IntelliJ
     "// format: on" // scalariform

--- a/core/src/test/resources/default/SearchState.stat
+++ b/core/src/test/resources/default/SearchState.stat
@@ -453,3 +453,30 @@ EventsResponse.fromJson(json, run).success.value.events should be(
             )
         )
     ))
+<<< react #458
+  val TodoApp = ReactComponentB[Unit]("TodoApp")
+    .initialState(State(Nil, ""))
+    .renderS(($, s) =>
+      <.div(
+        <.h3("TODO"),
+        TodoList(s.items),
+        <.form(^.onSubmit ==> $._runState(handleSubmit),  // runState runs a state monad and applies the result.
+          <.input(                                        // _runState is similar but takes a function-to-a-state-monad.
+            ^.onChange ==> $._runState(acceptChange),     // In these cases, the function will be fed the JS event.
+            ^.value := s.text),
+          <.button("Add #", s.items.length + 1)))
+    ).build
+>>>
+val TodoApp = ReactComponentB[Unit]("TodoApp")
+  .initialState(State(Nil, ""))
+  .renderS(
+      ($, s) =>
+        <.div(<.h3("TODO"),
+              TodoList(s.items),
+              <.form(
+                  ^.onSubmit ==> $._runState(handleSubmit), // runState runs a state monad and applies the result.
+                  <.input( // _runState is similar but takes a function-to-a-state-monad.
+                      ^.onChange ==> $._runState(acceptChange), // In these cases, the function will be fed the JS event.
+                      ^.value := s.text),
+                  <.button("Add #", s.items.length + 1))))
+  .build


### PR DESCRIPTION
The trick is to handle symbolic operators differently for select chains. This eliminates a branch on every `<.` selection.

Before:
<img width="435" alt="screen shot 2016-12-19 at 17 48 06" src="https://cloud.githubusercontent.com/assets/1408093/21323312/b3ec4fd4-c614-11e6-938d-b5eb7d0509f5.png">

After:
<img width="658" alt="screen shot 2016-12-19 at 17 47 49" src="https://cloud.githubusercontent.com/assets/1408093/21323316/b8331d3e-c614-11e6-8187-3da38de2a83e.png">
