### PR TITLE
Fix path separators and line endings to make most of tests passing on Windows

### DIFF
--- a/bin/scalafmt.bat
+++ b/bin/scalafmt.bat
@@ -1,1 +1,1 @@
-java -jar PATH_TO/scalafmt.jar %*
+java -jar PATH_TO\scalafmt.jar %*

--- a/cli/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -8,7 +8,6 @@ import org.scalafmt.config.AlignToken
 import org.scalafmt.config.ImportSelectors
 import org.scalafmt.config.IndentOperator
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.util.LoggerOps._
 import org.scalatest.FunSuite
 
 class CliOptionsTest extends FunSuite {

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.InputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -15,7 +14,6 @@ import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.DiffAssertions
 import org.scalafmt.util.FileOps
-import org.scalafmt.util.GitOps
 import org.scalafmt.util.logger
 import org.scalatest.FunSuite
 

--- a/cli/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -8,7 +8,7 @@ import org.scalafmt.util.FileOps
 object FileTestOps {
 
   /**
-    * The inverse of [[dir2string]]. Given a string represenatation creates the
+    * The inverse of [[dir2string]]. Given a string representation creates the
     * necessary files/directories with respective file contents.
     */
   def string2dir(layout: String): AbsoluteFile = {
@@ -25,7 +25,7 @@ object FileTestOps {
     AbsoluteFile.fromPath(root.getAbsolutePath).get
   }
 
-  /** Gives a string represenatation of a directory. For example
+  /** Gives a string representation of a directory. For example
     *
     * /build.sbt
     * val x = project
@@ -44,6 +44,7 @@ object FileTestOps {
             |$contents""".stripMargin
       }
       .mkString("\n")
+      .replace(File.separator, "/") // ensure original separators
   }
 
 }

--- a/core/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/core/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -1,7 +1,6 @@
 package org.scalafmt
 
 import scala.meta.Input.stringToInput
-import scala.meta.Input.stringToInput
 import scala.meta.inputs.Input
 import scala.util.control.NonFatal
 
@@ -9,7 +8,6 @@ import org.scalafmt.Error.Incomplete
 import org.scalafmt.config.FormatEvent.CreateFormatOps
 import org.scalafmt.config.LineEndings.preserve
 import org.scalafmt.config.LineEndings.windows
-import org.scalafmt.config.ScalafmtRunner
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.BestFirstSearch
 import org.scalafmt.internal.FormatOps
@@ -26,7 +24,6 @@ object Scalafmt {
     *
     * @param code Code string to format.
     * @param style Configuration for formatting output.
-    * @param runner Configuration for how the formatting should run.
     * @param range EXPERIMENTAL. Format a subset of lines.
     * @return [[Formatted.Success]] if successful,
     *         [[Formatted.Failure]] otherwise. If you are OK with throwing

--- a/core/src/test/scala/org/scalafmt/BestEffortTest.scala
+++ b/core/src/test/scala/org/scalafmt/BestEffortTest.scala
@@ -1,5 +1,7 @@
 package org.scalafmt
 
+import java.io.File
+
 import scala.meta.Tree
 import scala.meta.parsers.Parse
 
@@ -71,7 +73,8 @@ Defn.Object(
     """.replace("'''", "\"\"\"")
 
   override val tests =
-    parseDiffTests(stateExplosions, "default/StateExplosion.stat")
+    parseDiffTests(stateExplosions,
+                   s"default${File.separator}StateExplosion.stat")
 
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
     val runner = scalafmtRunner(t.style.runner).copy(parser = parse)
@@ -94,7 +97,7 @@ Defn.Object(
   testsToRun.foreach(runTest(run))
 
   override def afterAll(configMap: ConfigMap): Unit = {
-    FileOps
-      .writeFile("target/index.html", Report.heatmap(debugResults.result()))
+    FileOps.writeFile(s"target${File.separator}index.html",
+                      Report.heatmap(debugResults.result()))
   }
 }

--- a/core/src/test/scala/org/scalafmt/ContinuationIndentTests.scala
+++ b/core/src/test/scala/org/scalafmt/ContinuationIndentTests.scala
@@ -1,5 +1,7 @@
 package org.scalafmt
 
+import java.io.File
+
 import scala.meta.Tree
 import scala.meta.parsers.Parse
 
@@ -39,7 +41,8 @@ def foo(
 """.replace("'''", "\"\"\"")
 
   override val tests =
-    parseDiffTests(defnSite3callSite5, "default/continuationIndent.stat")
+    parseDiffTests(defnSite3callSite5,
+                   s"default${File.separator}continuationIndent.stat")
 
   testsToRun.foreach(runTest(run))
 

--- a/core/src/test/scala/org/scalafmt/EmptyFileTest.scala
+++ b/core/src/test/scala/org/scalafmt/EmptyFileTest.scala
@@ -1,12 +1,13 @@
 package org.scalafmt
 
 import org.scalafmt.util.DiffAssertions
+import org.scalafmt.util.OsSpecific.lineSeparator
 import org.scalatest.FunSuite
 
 class EmptyFileTest extends FunSuite with DiffAssertions {
   test("empty tree formats to newline") {
-    Seq("", "\n", "", "   \n  ").foreach { original =>
-      val expected = "\n"
+    Seq("", lineSeparator, "", s"   $lineSeparator  ").foreach { original =>
+      val expected = lineSeparator
       val obtained = Scalafmt.format(original).get
       assert(obtained == expected)
     }

--- a/core/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/core/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -1,5 +1,7 @@
 package org.scalafmt
 
+import java.io.File
+
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.FormatAssertions
@@ -33,7 +35,7 @@ class FidelityTest extends FunSuite with FormatAssertions {
           "/target/",
           "/resources/",
           "/gh-pages/"
-        ).exists(x.contains))
+        ).map(_.replace("/", File.separator)).exists(x.contains))
 
   val examples = files.map(Test.apply)
 

--- a/core/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/core/src/test/scala/org/scalafmt/FormatTests.scala
@@ -1,14 +1,14 @@
 package org.scalafmt
 
-import scala.language.postfixOps
+import java.io.File
 
+import scala.language.postfixOps
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.meta.Tree
 import scala.meta.internal.semantic.Symbol.Global
 import scala.meta.parsers.Parse
-
 import org.scalafmt.Error.Incomplete
 import org.scalafmt.Error.SearchStateExploded
 import org.scalafmt.stats.TestStats
@@ -97,7 +97,8 @@ class FormatTests
     // I don't want to deal with scalaz's Tasks :'(
     val k = for {
       _ <- Future(
-        FileOps.writeFile("target/index.html", Report.heatmap(results)))
+        FileOps.writeFile(s"target${File.separator}index.html",
+                          Report.heatmap(results)))
     } yield ()
     // Travis exits right after running tests.
     if (sys.env.contains("TRAVIS")) Await.ready(k, 20 seconds)

--- a/core/src/test/scala/org/scalafmt/StripMarginTests.scala
+++ b/core/src/test/scala/org/scalafmt/StripMarginTests.scala
@@ -1,5 +1,7 @@
 package org.scalafmt
 
+import java.io.File
+
 import scala.meta.Tree
 import scala.meta.parsers.Parse
 
@@ -126,8 +128,9 @@ val msg = s'''AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
              |'''.stripMargin""".replace("'''", "\"\"\"")
 
   override val tests =
-    parseDiffTests(rawStrings, "stripMargin/String.stat") ++
-      (parseDiffTests(interpolatedStrings, "stripMargin/Interpolate.stat"))
+    parseDiffTests(rawStrings, s"stripMargin${File.separator}String.stat") ++
+      (parseDiffTests(interpolatedStrings,
+                      s"stripMargin${File.separator}Interpolate.stat"))
 
   testsToRun.foreach(runTest(run))
 

--- a/core/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/core/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.FunSuite
 class GitOpsTest extends FunSuite {
   test("lsTree") {
     val files = GitOps().lsTree
-    assert(files.exists(x => x.path.endsWith("scalafmt/.gitignore")))
+    assert(files.exists(x =>
+      x.path.endsWith(s"scalafmt${File.separator}.gitignore")))
   }
 }

--- a/utils/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/utils/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -56,7 +56,6 @@ object FileOps {
     // Prefer this to inefficient Source.fromFile.
     val sb = new StringBuilder
     val br = new BufferedReader(new FileReader(file))
-    val lineSeparator = System.getProperty("line.separator")
     try {
       var line = ""
       while ({
@@ -64,7 +63,7 @@ object FileOps {
         line != null
       }) {
         sb.append(line)
-        sb.append(lineSeparator)
+        sb.append("\n")
       }
     } finally {
       br.close()

--- a/utils/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/utils/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -45,7 +45,7 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
           "HEAD",
           "--name-only"
         )
-      ).split("\n").toSeq.collect {
+      ).split(OsSpecific.lineSeparator).toSeq.collect {
         case f if new File(f).isFile => workingDirectory / f
       }
     }.getOrElse(Nil)

--- a/utils/src/main/scala/org/scalafmt/util/OsSpecific.scala
+++ b/utils/src/main/scala/org/scalafmt/util/OsSpecific.scala
@@ -1,0 +1,8 @@
+package org.scalafmt.util
+
+/** Utils related to differences between various operating systems. */
+object OsSpecific {
+  val isWindows: Boolean =
+    System.getProperty("os.name").toLowerCase().startsWith("windows")
+  val lineSeparator: String = System.getProperty("line.separator")
+}


### PR DESCRIPTION
On Windows it's needed to set SBT_OPTS=-Dfile.encoding=UTF8

The changes are a bit tricky. One could easily make change where all compared line endings will be converted to the same form but, in fact, then we could miss cases where the tested code itself could change line endings in the unexpected way.

`sbt test` passed.
```
[info] Run completed in 29 seconds, 619 milliseconds.
[info] Total number of tests run: 798
[info] Suites: completed 14, aborted 0
[info] Tests: succeeded 798, failed 0, canceled 0, ignored 33, pending 0
[info] All tests passed.
```

Other than that:
- `scripted` still fails on Windows:
```
[info] java.lang.Exception: File: target\src_managed\Generated.scala
[info] Obtained output:
[info] object DontFormatMe { println(1) }
[info] Expected:
[info] object      DontFormatMe   {    println(1)    }
[info]
[info]  at $8bc643ac9d20807c5658$.assertContentsEqual(build.sbt:28)
```
- The result of `core/test:runMain org.scalafmt.FormatExperimentApp` on Windows:
```
Success: 9381

Total: 10698
+----------+----+---+----+--+--+----+----+----+
|Total time| Max|Min|Mean|Q2|Q3|90th|95th|99th|
+----------+----+---+----+--+--+----+----+----+
|    293829|7456|  0|  75|26|75| 177| 292| 693|
+----------+----+---+----+--+--+----+----+----+
[success] Total time: 309 s, completed 2016-12-23 16:19:58
```