### PR TITLE
Fix links to Tutorial.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
 - Build docs: `sbt readme/run` will create the docs, which you can open with
   `open readme/target/scalatex/index.html`. Docs are built with [Scalatex](http://www.lihaoyi.com/Scalatex/).
 - Hack on IntelliJ plugin: see [this doc](intellij/readme.md).
-- Hack scalafmt: see [tutorial](tutorial.md).
+- Hack scalafmt: see [tutorial](Tutorial.md).
 - Hack on SBT plugin: run `sbt scripted`.
 - Run jmh benchmarks: `run-benchmarks.sh`.
 - Run formatter on millions of lines of code: `core/test:runMain  org.scalafmt.FormatExperimentApp`:
@@ -23,7 +23,7 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
   See [Browsersync](https://www.browsersync.io/).
 
 ### Tutorial
-There's a details scalafmt: see [tutorial](tutorial.md).
+If you'd like to find out how to work on scalafmt, see this [tutorial](Tutorial.md).
 
 [docs]: http://scalafmt.org
 


### PR DESCRIPTION
The name of the file starts with `T` so it didn't work with `t`. By the way I changed the strange wording. ;)