### PR TITLE
Make nested path exclusions working on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 build_script:
   - sbt clean compile
 test_script:
-  - sbt test readme/run
+  - sbt test readme/run scripted
 cache:
   - C:\sbt\
   - C:\Users\appveyor\.m2

--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -17,6 +17,7 @@ import org.scalafmt.config.FilterMatcher
 import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 import org.scalafmt.util.LogLevel
+import org.scalafmt.util.OsSpecific
 
 object Cli {
   def nailMain(nGContext: NGContext): Unit = {
@@ -92,7 +93,9 @@ object Cli {
 
   /** Returns file paths defined via options.{customFiles,customExclude} */
   def getFilesFromCliOptions(options: CliOptions): Seq[AbsoluteFile] = {
-    val exclude = FilterMatcher.mkRegexp(options.customExcludes)
+    val excludePaths =
+      options.customExcludes.map(OsSpecific.fixSeparatorsInPathPattern)
+    val exclude = FilterMatcher.mkRegexp(excludePaths)
     expandCustomFiles(options.common.workingDirectory, options.customFiles)
       .filter(x => exclude.findFirstIn(x.path).isEmpty)
   }

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -192,23 +192,36 @@ class CliTest extends FunSuite with DiffAssertions {
     val input = string2dir(
       s"""|/foo.sbt
           |lazy   val x   = project
-          |/target/generated.scala
+          |
+          |/target/FormatMe.scala
+          |object    PleaseFormatMeOtherwiseIWillBeReallySad   {  }
+          |
+          |/target/nested/DoNotFormatMe.scala
           |object    AAAAAAIgnoreME   {  }
+          |
+          |/target/nested/nested2/DoNotFormatMeToo.scala
+          |object    BBBBBBIgnoreME   {  }
           |""".stripMargin
     )
     val expected =
       s"""|/foo.sbt
           |lazy val x = project
           |
-          |/target/generated.scala
+          |/target/FormatMe.scala
+          |object PleaseFormatMeOtherwiseIWillBeReallySad {}
+          |
+          |/target/nested/DoNotFormatMe.scala
           |object    AAAAAAIgnoreME   {  }
+          |
+          |/target/nested/nested2/DoNotFormatMeToo.scala
+          |object    BBBBBBIgnoreME   {  }
           |""".stripMargin
     val options = getConfig(
       Array(
         "--files",
         input.path,
         "--exclude",
-        "target",
+        "target/nested",
         "-i"
       ))
     Cli.run(options)
@@ -216,7 +229,7 @@ class CliTest extends FunSuite with DiffAssertions {
     assertNoDiff(obtained, expected)
   }
 
-  test("--file doesnotexists.scala throws error") {
+  test("--file doesnotexist.scala throws error") {
     def check(filename: String): Unit = {
       val args = Array("-f", s"$filename.scala")
       intercept[FileNotFoundException] {

--- a/core/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/core/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.config
 
 import metaconfig.ConfigReader
+import org.scalafmt.util.OsSpecific
 
 @ConfigReader
 case class ProjectFiles(
@@ -10,5 +11,6 @@ case class ProjectFiles(
     excludeFilters: Seq[String] = Nil
 ) {
   lazy val matcher: FilterMatcher =
-    FilterMatcher(includeFilters, excludeFilters)
+    FilterMatcher(includeFilters.map(OsSpecific.fixSeparatorsInPathPattern),
+                  excludeFilters.map(OsSpecific.fixSeparatorsInPathPattern))
 }

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
 
 ### Quick help
 
+- On Windows add -Dfile.encoding=UTF8 to SBT_OPTS.
 - Run formatting tests: `core/testOnly org.scalafmt.FormatTests`.
 - Write new formatting test: read [this doc](core/src/test/resources/readme.md).
 - Build docs: `sbt readme/run` will create the docs, which you can open with

--- a/utils/src/main/scala/org/scalafmt/util/OsSpecific.scala
+++ b/utils/src/main/scala/org/scalafmt/util/OsSpecific.scala
@@ -5,4 +5,8 @@ object OsSpecific {
   val isWindows: Boolean =
     System.getProperty("os.name").toLowerCase().startsWith("windows")
   val lineSeparator: String = System.getProperty("line.separator")
+
+  def fixSeparatorsInPathPattern(unixSpecificPattern: String): String =
+    if (isWindows) unixSpecificPattern.replace("/", """\\""")
+    else unixSpecificPattern
 }


### PR DESCRIPTION
Now paths like target/foo are accepted also on Windows.
The existing unit test has been extended to verify such cases.
By the way this fixed the `scripted` task when running on Windows.

In fact it was possible to use \\ e.g. in paths passed via --exclude,
but it isn't very helpful and convenient in case of projects built on
various platforms.