### PR TITLE
Issue #607 Add param to don't insert new lines after annotations

### DIFF
--- a/cli/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -42,6 +42,7 @@ class CliOptionsTest extends FunSuite {
         |optIn: {
         |  configStyleArguments = true
         |  breakChainOnFirstMethodDot = true
+        |  noNewlineAfterAnnotation = true
         |}
         |maxColumn = 4000
         |poorMansTrailingCommasInConfigStyle = true
@@ -106,32 +107,33 @@ class CliOptionsTest extends FunSuite {
           ))
         assert(obtained.runner.parser == Parse.parseCase)
         assert(obtained.runner.dialect == Paradise211)
-        assert(obtained.runner.optimizer.acceptOptimalAtHints == false)
+        assert(!obtained.runner.optimizer.acceptOptimalAtHints)
         assert(obtained.assumeStandardLibraryStripMargin)
-        assert(obtained.reformatDocstrings == true)
-        assert(obtained.scalaDocs == false)
-        assert(obtained.binPack.callSite == true)
-        assert(obtained.binPack.defnSite == true)
-        assert(obtained.configStyleArguments == true)
-        assert(obtained.neverBeforeJsNative == true)
-        assert(obtained.danglingParentheses == true)
-        assert(obtained.align.openParenCallSite == true)
-        assert(obtained.align.openParenDefnSite == true)
+        assert(obtained.reformatDocstrings)
+        assert(!obtained.scalaDocs)
+        assert(obtained.binPack.callSite)
+        assert(obtained.binPack.defnSite)
+        assert(obtained.configStyleArguments)
+        assert(obtained.neverBeforeJsNative)
+        assert(obtained.danglingParentheses)
+        assert(obtained.align.openParenCallSite)
+        assert(obtained.align.openParenDefnSite)
         assert(obtained.continuationIndent.callSite == 3)
         assert(obtained.continuationIndent.defnSite == 5)
-        assert(obtained.align.mixedOwners == true)
+        assert(obtained.align.mixedOwners)
         assert(obtained.importSelectors == ImportSelectors.binPack)
-        assert(obtained.spaces.inImportCurlyBraces == true)
-        assert(obtained.poorMansTrailingCommasInConfigStyle == true)
-        assert(obtained.sometimesBeforeColonInMethodReturnType == true)
-        assert(obtained.binPackParentConstructors == true)
-        assert(obtained.spaces.afterTripleEquals == true)
-        assert(obtained.unindentTopLevelOperators == true)
-        assert(obtained.align.arrowEnumeratorGenerator == true)
-        assert(obtained.align.ifWhileOpenParen == true)
-        assert(obtained.spaces.beforeContextBoundColon == true)
-        assert(obtained.breakChainOnFirstMethodDot == true)
-        assert(obtained.alwaysBeforeCurlyBraceLambdaParams == true)
+        assert(obtained.spaces.inImportCurlyBraces)
+        assert(obtained.poorMansTrailingCommasInConfigStyle)
+        assert(obtained.sometimesBeforeColonInMethodReturnType)
+        assert(obtained.binPackParentConstructors)
+        assert(obtained.spaces.afterTripleEquals)
+        assert(obtained.unindentTopLevelOperators)
+        assert(obtained.align.arrowEnumeratorGenerator)
+        assert(obtained.align.ifWhileOpenParen)
+        assert(obtained.spaces.beforeContextBoundColon)
+        assert(obtained.breakChainOnFirstMethodDot)
+        assert(obtained.noNewlineAfterAnnotation)
+        assert(obtained.alwaysBeforeCurlyBraceLambdaParams)
         assert(
           obtained.align.tokens ==
             Set(

--- a/core/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/core/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -9,18 +9,30 @@ import metaconfig.ConfigReader
   *     // original
   *     foo
   *       .map(_ + 1)
-  *       .filter( > 2)
+  *       .filter(_ > 2)
   *     // if true
   *     foo
   *       .map(_ + 1)
-  *       .filter( > 2)
+  *       .filter(_ > 2)
   *     // if false
-  *     foo.map(_ + 1).filter( > 2)
+  *     foo.map(_ + 1).filter(_ > 2)
   *   }}}
-  *
+  *  @param noNewlineAfterAnnotation
+  *   If true, don't move annotations to new line.
+  *   {{{
+  *     // original
+  *      @annot @deprecated class B extends A
+  *     // if true
+  *      @annot @deprecated class B extends A
+  *     // if false
+  *     @annot
+  *     @deprecated
+  *     class B extends A
+  *   }}}
   */
 @ConfigReader
 case class OptIn(
     configStyleArguments: Boolean = true,
-    breakChainOnFirstMethodDot: Boolean = true
+    breakChainOnFirstMethodDot: Boolean = true,
+    noNewlineAfterAnnotation: Boolean = false
 )

--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -217,6 +217,7 @@ case class ScalafmtConfig(
 
   def configStyleArguments: Boolean = optIn.configStyleArguments
   def breakChainOnFirstMethodDot: Boolean = optIn.breakChainOnFirstMethodDot
+  def noNewlineAfterAnnotation: Boolean = optIn.noNewlineAfterAnnotation
   def reformatDocstrings: Boolean = docstrings != Docstrings.preserve
   def scalaDocs: Boolean = docstrings == Docstrings.ScalaDoc
   def binPackParentConstructors: Boolean = binPack.parentConstructors

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -40,7 +40,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   val tokens: Array[FormatToken] = FormatToken.formatTokens(tree.tokens)
   val ownersMap = getOwners(tree)
-  val statementStarts = getStatementStarts(tree)
+  val statementStarts = getStatementStarts(tree, initStyle)
   val dequeueSpots = getDequeueSpots(tree) ++ statementStarts.keys
   val matchingParentheses: Map[TokenHash, Token] = getMatchingParentheses(
     tree.tokens)

--- a/core/src/test/resources/optIn/NoNewlineAfterAnnotation.stat
+++ b/core/src/test/resources/optIn/NoNewlineAfterAnnotation.stat
@@ -1,0 +1,53 @@
+optIn.noNewlineAfterAnnotation = true
+maxColumn = 70
+<<< keep lines of annotations unchanged
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(@annot @deprecated x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot @annot2 @annot3 @annot4 @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value = "foo", someInt = 5) @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}


### PR DESCRIPTION
There's added `noNewlineAfterAnnotation` param to OptIn, `stat` test
and the additional check in CliOptionsTest.

The logic related to annotations is located in TreeOps. I changed
it to - when needed - use the alternative approach where we check
whether the line of the beginning of the annotation is the same as
the line of the end of previous one.

Fixes #607