### PR TITLE
Fix #607.

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/core/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -22,5 +22,6 @@ import metaconfig.ConfigReader
 @ConfigReader
 case class OptIn(
     configStyleArguments: Boolean = true,
-    breakChainOnFirstMethodDot: Boolean = true
+    breakChainOnFirstMethodDot: Boolean = true,
+    annotationNewlines: Boolean = false
 )

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -11,6 +11,8 @@ import scala.meta.tokens.Token._
 import org.scalafmt.internal.Decision
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.Modification
+import org.scalafmt.internal.Newline
+import org.scalafmt.internal.Newline2x
 import org.scalafmt.internal.NewlineT
 import org.scalafmt.internal.NoSplit
 import org.scalafmt.internal.Policy
@@ -154,6 +156,9 @@ object TokenOps {
     case c: Comment => c.syntax.startsWith("//")
     case _ => false
   }
+
+  def newlines2Modification(formatToken: FormatToken): Modification =
+    newlines2Modification(formatToken.between, formatToken.right.is[Comment])
 
   def newlines2Modification(between: Vector[Token],
                             rightIsComment: Boolean = false): Modification =

--- a/core/src/test/resources/optIn/Annotation.stat
+++ b/core/src/test/resources/optIn/Annotation.stat
@@ -1,0 +1,62 @@
+optIn.annotationNewlines = true
+<<< keep lines of annotations unchanged
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(@annot @deprecated x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot @annot2 @annot3 @annot4 @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value = "foo", someInt = 5) @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< non-single ident
+@bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa") class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
+>>>
+@bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa") class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
+<<< non-single ident 2
+@bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa")
+class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
+>>>
+@bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa")
+class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()

--- a/core/src/test/resources/optIn/AnnotationParam.stat
+++ b/core/src/test/resources/optIn/AnnotationParam.stat
@@ -1,0 +1,34 @@
+optIn.annotationNewlines = true
+<<< class
+case class Foo(
+  @hidden
+  foo: String = "bar",
+  @hidden x: Int
+)
+>>>
+case class Foo(
+    @hidden
+    foo: String = "bar",
+    @hidden x: Int
+)
+<<< class 2
+case class Foo( @hidden
+foo: String = "bar", @hidden x: Int )
+>>>
+case class Foo(@hidden
+               foo: String = "bar",
+               @hidden x: Int)
+<<< def 2
+def foo( @hidden
+foo: String = "bar", @hidden x: Int ): Int = 2
+>>>
+def foo(@hidden
+        foo: String = "bar",
+        @hidden x: Int): Int = 2
+
+<<< caveat: spaces are preserved even for large annotations
+@annot("aaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "cccccccccccccccc") def foo() = 2
+>>>
+@annot("aaaaaaaaaaaaaaaaaaaaaaaaaa",
+       "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+       "cccccccccccccccc") def foo() = 2


### PR DESCRIPTION
Adds flag optIn.annotationNewlines which gives the user full control
over line breaks around annotations. Supersedes #649.