### PR TITLE
Remove extra newline from stdout

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -31,7 +31,7 @@ object InputMethod {
     override def write(code: String,
                        original: String,
                        options: CliOptions): Unit = {
-      options.common.out.println(code)
+      options.common.out.print(code)
     }
   }
   case class FileContents(file: AbsoluteFile) extends InputMethod {
@@ -48,7 +48,7 @@ object InputMethod {
         if (codeChanged) FileOps.writeFile(filename, formatted)
         else Unit
       } else {
-        options.common.out.println(formatted)
+        options.common.out.print(formatted)
       }
     }
   }

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -55,7 +55,8 @@ class CliTest extends FunSuite with DiffAssertions {
                       |}""".stripMargin
   val formatted = """|object a extends App {
                      |  pr("h")
-                     |}""".stripMargin
+                     |}
+                     |""".stripMargin
   val customConfig =
     """
       |maxColumn   = 2
@@ -69,7 +70,8 @@ class CliTest extends FunSuite with DiffAssertions {
     """|lazy val x =
        |  project
        |lazy val y =
-       |  project""".stripMargin
+       |  project
+       |""".stripMargin
 
   def gimmeConfig(string: String): ScalafmtConfig =
     Config.fromHocon(string) match {
@@ -109,6 +111,7 @@ class CliTest extends FunSuite with DiffAssertions {
     Cli.run(auto)
     val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
     assertNoDiff(obtained, formatted)
+    assert(obtained.size == formatted.size)
   }
 
   test("scalafmt --stdin --assume-filename") {
@@ -132,6 +135,7 @@ class CliTest extends FunSuite with DiffAssertions {
       ))
     val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
     assertNoDiff(obtained, sbtExpected)
+    assert(obtained.size == sbtExpected.size)
   }
 
   test("scalafmt --test --file tmpFile") {
@@ -326,5 +330,14 @@ class CliTest extends FunSuite with DiffAssertions {
     Cli.main(args) // runs without errors
     val obtained = FileOps.readFile(toFormat)
     assertNoDiff(obtained, "object A\n")
+  }
+
+  private def trimNonNewline(str: String): String = {
+    def isWhitespaceAndNotNewline(ch: Char): Boolean = {
+      ch.isWhitespace && ch != '\n'
+    }
+
+    str.dropWhile(isWhitespaceAndNotNewline)
+      .take(str.lastIndexWhere(ch => !isWhitespaceAndNotNewline(ch)) + 1)
   }
 }

--- a/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/cli/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -331,13 +331,4 @@ class CliTest extends FunSuite with DiffAssertions {
     val obtained = FileOps.readFile(toFormat)
     assertNoDiff(obtained, "object A\n")
   }
-
-  private def trimNonNewline(str: String): String = {
-    def isWhitespaceAndNotNewline(ch: Char): Boolean = {
-      ch.isWhitespace && ch != '\n'
-    }
-
-    str.dropWhile(isWhitespaceAndNotNewline)
-      .take(str.lastIndexWhere(ch => !isWhitespaceAndNotNewline(ch)) + 1)
-  }
 }


### PR DESCRIPTION
I'm not sure if this is intended, but I noticed that the formatted code is written to stdout using println. This makes redirecting the stdout to a file incorrect as it adds an extra new line character.