### PR TITLE
New ContinuationIndent: extendSite

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
+++ b/core/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
@@ -5,5 +5,6 @@ import metaconfig.ConfigReader
 @ConfigReader
 case class ContinuationIndent(
     callSite: Int = 2,
-    defnSite: Int = 4
+    defnSite: Int = 4,
+    extendSite: Int = 4
 )

--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -59,6 +59,8 @@ import org.scalafmt.util.ValidationOps
   *                                   call site.
   * @param continuationIndentDefnSite Indent width for line continuation at
   *                                   definition/declaration site.
+  * @param continuationIndentExtendSite Indent width for line continuation at
+  *                                     extends or with site.
   * @param sometimesBeforeColonInMethodReturnType If true, scalafmt
   *                                                    may choose to put a newline
   *                                                    before colon : at defs.

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -936,7 +936,11 @@ class Router(formatOps: FormatOps) {
           .flatMap(templateCurly)
           .orElse(template.map(_.tokens.last))
           .getOrElse(rightOwner.tokens.last)
-        binPackParentConstructorSplits(template.toSet, lastToken, 4)
+        binPackParentConstructorSplits(
+          template.toSet,
+          lastToken,
+          style.continuationIndent.extendSite
+        )
       case tok @ FormatToken(_, right @ KwWith(), _) =>
         rightOwner match {
           case template: Template =>

--- a/core/src/test/resources/test/ContinuationIndent.stat
+++ b/core/src/test/resources/test/ContinuationIndent.stat
@@ -1,5 +1,7 @@
 continuationIndent.callSite = 5
 continuationIndent.defnSite = 3
+continuationIndent.extendSite = 2
+maxColumn = 40
 <<< #143
 def foo(
 a: Int,
@@ -19,4 +21,19 @@ def foo(
        2,
        3
   )
+}
+<<< Extend site
+class ExtendTest extends A with B with C with D { self: A with B with C with D with E =>
+}
+>>>
+class ExtendTest
+  extends A
+  with B
+  with C
+  with D {
+  self: A
+    with B
+    with C
+    with D
+    with E =>
 }


### PR DESCRIPTION
This setting sets the indentation at extends/with site. By default is it four (4) (in order to not break current), but the Scala Style Guide (http://docs.scala-lang.org/style/declarations.html#classes) recommends two (2).

