### PR TITLE
Resolve config

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/hocon/Hocon2Class.scala
+++ b/core/src/main/scala/org/scalafmt/config/hocon/Hocon2Class.scala
@@ -4,6 +4,7 @@ import scala.util.control.NonFatal
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigResolveOptions
 
 object Hocon2Class {
   private def config2map(config: Config): Map[String, Any] = {
@@ -28,7 +29,7 @@ object Hocon2Class {
     try {
       val config = ConfigFactory.parseString(str)
       val extracted = path match {
-        case Some(p) => config.getConfig(p)
+        case Some(p) => config.getConfig(p).resolve(ConfigResolveOptions.noSystem)
         case _ => config
       }
       Right(config2map(extracted))

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
 - Build docs: `sbt readme/run` will create the docs, which you can open with
   `open readme/target/scalatex/index.html`. Docs are built with [Scalatex](http://www.lihaoyi.com/Scalatex/).
 - Hack on IntelliJ plugin: see [this doc](intellij/readme.md).
-- Hack on scalafmt: see [tutorial](tutorial.md).
+- Hack on scalafmt: see [tutorial](Tutorial.md).
 - Hack on SBT plugin: run `sbt scripted`.
 - Run jmh benchmarks: `run-benchmarks.sh`.
 - Run formatter on millions of lines of code: `core/test:runMain  org.scalafmt.FormatExperimentApp`:


### PR DESCRIPTION
Hi.

I am trying to structure the scalafmt config into multiple files, providing a default set of options with the ability to change / adjust some of the values inside of a project. That is why I am trying to use substitutions for example to add entries to the `project.excludeFilters`.

When using substitutions in HOCON, you need to call `resolve()` at some point in order to substitute the references. Otherwise _bad things_ happen:

```
com.typesafe.config.ConfigException$NotResolved: called unwrapped() on value with unresolved substitutions, need to Config#resolve() first, see API docs
	at com.typesafe.config.impl.ConfigDelayedMerge.unwrapped(ConfigDelayedMerge.java:52)
	at com.typesafe.config.impl.SimpleConfigObject.unwrapped(SimpleConfigObject.java:210)
	at com.typesafe.config.impl.SimpleConfigObject.unwrapped(SimpleConfigObject.java:25)
	at com.typesafe.config.impl.SimpleConfigObject.unwrapped(SimpleConfigObject.java:210)
	at org.scalafmt.config.hocon.Hocon2Class$.config2map(Hocon2Class.scala:22)
	at org.scalafmt.config.hocon.Hocon2Class$.gimmeConfig(Hocon2Class.scala:34)
```

BTW, I could not figure out how to run the tests, just got a compilation error when trying to run `core:test`:

```
[error] /home/claudio/sandbox/scalafmt/testUtils/src/main/scala/org/scalafmt/util/ScalaFile.scala:6: object io is not a member of package org.apache.commons
[error] import org.apache.commons.io.FileUtils
[error]                           ^
[error] /home/claudio/sandbox/scalafmt/testUtils/src/main/scala/org/scalafmt/util/ScalaFile.scala:80: not found: value FileUtils
[error]     FileUtils.copyURLToFile(fileToDownload, destination)
[error]     ^
[error] two errors found
[error] (testUtils/compile:compileIncremental) Compilation failed
```

Looks like there's a dependency on commons-io missing?!