### PR TITLE
Adds a new style for function defs

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -181,7 +181,21 @@ import org.scalafmt.util.ValidationOps
   *        x + 2
   *    }.filter(_ > 2)
   *  }}}
+  * @param verticalMultiline If true, reformat multi-line function definitions in
+  *  the following way
+  * {{{
+  *   def format(
+  *       code: String,
+  *       age: Int
+  *     )(implicit ev: Parser
+  *     ): String
+  * )
+  * }}}
   *
+  *  All parameters are on their on line indented by four (4), seperation between
+  *  parament groups are indented by two (2). ReturnType is on its own line at
+  *  then end. This will only trigger if the function is already multi-line
+  *  or if a single-line function goes over [[maxColumn]].
   */
 @ConfigReader
 case class ScalafmtConfig(
@@ -209,7 +223,7 @@ case class ScalafmtConfig(
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
     bestEffortInDeeplyNestedCode: Boolean = false,
-    straightCurried: Boolean = false,
+    verticalMultiline: Boolean = false,
     project: ProjectFiles = ProjectFiles()
 ) {
 

--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -181,21 +181,24 @@ import org.scalafmt.util.ValidationOps
   *        x + 2
   *    }.filter(_ > 2)
   *  }}}
-  * @param verticalMultiline If true, reformat multi-line function definitions in
+  * @param verticalMultilineAtDefinitionSite If true, reformat multi-line function definitions in
   *  the following way
   * {{{
   *   def format(
   *       code: String,
   *       age: Int
-  *     )(implicit ev: Parser
+  *     )(implicit ev: Parser,
+  *       c: Context
   *     ): String
   * )
   * }}}
   *
   *  All parameters are on their on line indented by four (4), seperation between
   *  parament groups are indented by two (2). ReturnType is on its own line at
-  *  then end. This will only trigger if the function is already multi-line
-  *  or if a single-line function goes over [[maxColumn]].
+  *  then end. This will only trigger if the function would go over
+  *  [[maxColumn]]. If a multi-line funcion can fit in a single line, it will
+  *  make it so. Note that this setting ignores [[continuation.defnSite]],
+  *  [[binPack.defnSite]], and [[align.openParenDefnSite]].
   */
 @ConfigReader
 case class ScalafmtConfig(
@@ -223,7 +226,7 @@ case class ScalafmtConfig(
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
     bestEffortInDeeplyNestedCode: Boolean = false,
-    verticalMultiline: Boolean = false,
+    verticalMultilineAtDefinitionSite: Boolean = false,
     project: ProjectFiles = ProjectFiles()
 ) {
 

--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -209,6 +209,7 @@ case class ScalafmtConfig(
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
     bestEffortInDeeplyNestedCode: Boolean = false,
+    straightCurried: Boolean = false,
     project: ProjectFiles = ProjectFiles()
 ) {
 

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -413,7 +413,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on a group-by-group basis.
       case FormatToken(open @ LeftParen(), right, between)
-          if style.straightCurried && isDefnSite(leftOwner) =>
+          if style.verticalMultiline && isDefnSite(leftOwner) =>
         val close = matchingParentheses(hash(open))
         val indentParam = Num(4)
         val indentSep = Num(2)
@@ -431,7 +431,7 @@ class Router(formatOps: FormatOps) {
           // A `paramSep` is a `)(`, aka the seperator between two parameter
           // groups. Prepend a newline to these.
           val noNewLineOnParamSep: PartialFunction[Decision, Decision] = {
-            case Decision(t @ FormatToken(_, `close`, between), splits) =>
+            case Decision(t @ FormatToken(_, `close`, _), _) =>
               Decision(t,
                 Seq(Split(Newline, 0)
                   .withIndent(indentSep, close, Right)

--- a/core/src/test/resources/test/ImprivataDefStyle.stat
+++ b/core/src/test/resources/test/ImprivataDefStyle.stat
@@ -1,16 +1,23 @@
 continuationIndent.defnSite = 4
 straightCurried = true
-maxColumn = 40
-<<< curried functions
-def format_![T <: Tree](code: String, foo: Int)(implicit ev: Parse[T], ev2: EC): String
+maxColumn = 80
+<<< curried function over maxColumn
+def format_![T <: Tree](code: String, foo: Int)(f: A => B)(implicit ev: Parse[T], ev2: EC): String
 >>>
 def format_![T <: Tree](
     code: String,
     foo: Int
+  )(f: A => B
   )(implicit ev: Parse[T],
     ev2: EC
   ): String
-<<< curried functions defn.def
+
+<<< ONLY curried functions under maxColumn
+def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
+>>>
+def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
+
+<<< curried function mixed style 1
 def format_![T <: Tree](
     code: String
   )(implicit ev: Parse[T]): String = 1
@@ -19,17 +26,18 @@ def format_![T <: Tree](
     code: String
   )(implicit ev: Parse[T]
   ): String = 1
-<<< idempotent
-def format_![T <: Tree](
-    code: String,
-    foo: Int
+
+<<< curried function mixed style 2
+def format_![T <: Tree](code: String, foo: Int)(
+  f: A => B
   )(implicit ev: Parse[T],
-    ev2: EC
-  ): String
+  ev2: EC)
+  : String
 >>>
 def format_![T <: Tree](
     code: String,
     foo: Int
+  )(f: A => B
   )(implicit ev: Parse[T],
     ev2: EC
   ): String

--- a/core/src/test/resources/test/ImprivataDefStyle.stat
+++ b/core/src/test/resources/test/ImprivataDefStyle.stat
@@ -1,0 +1,35 @@
+continuationIndent.defnSite = 4
+straightCurried = true
+maxColumn = 40
+<<< curried functions
+def format_![T <: Tree](code: String, foo: Int)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](
+    code: String,
+    foo: Int
+  )(implicit ev: Parse[T],
+    ev2: EC
+  ): String
+<<< curried functions defn.def
+def format_![T <: Tree](
+    code: String
+  )(implicit ev: Parse[T]): String = 1
+>>>
+def format_![T <: Tree](
+    code: String
+  )(implicit ev: Parse[T]
+  ): String = 1
+<<< idempotent
+def format_![T <: Tree](
+    code: String,
+    foo: Int
+  )(implicit ev: Parse[T],
+    ev2: EC
+  ): String
+>>>
+def format_![T <: Tree](
+    code: String,
+    foo: Int
+  )(implicit ev: Parse[T],
+    ev2: EC
+  ): String

--- a/core/src/test/resources/test/VericalMultiline.stat
+++ b/core/src/test/resources/test/VericalMultiline.stat
@@ -1,23 +1,23 @@
-continuationIndent.defnSite = 4
-verticalMultiline = true
+verticalMultilineAtDefinitionSite = true
 maxColumn = 80
 <<< curried function over maxColumn
-def format_![T <: Tree](code: String, foo: Int)(f: A => B)(implicit ev: Parse[T], ev2: EC): String
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>
 def format_![T <: Tree](
     code: String,
     foo: Int
-  )(f: A => B
+  )(f: A => B,
+    k: D
   )(implicit ev: Parse[T],
     ev2: EC
   ): String
 
-<<< SKIP curried function under maxColumn
+<<< curried function under maxColumn
 def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 >>>
 def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 
-<<< SKIP small curried functions should fit in one line
+<<< small multi-line functions should fit in one line
 def format_![T <: Tree](
     code: String)(
     f: A => B)
@@ -27,12 +27,15 @@ def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 
 <<< curried function mixed style 1
 def format_![T <: Tree](
-    code: String
-  )(implicit ev: Parse[T]): String = 1
+    code: String,
+    code2: String
+  )(implicit ev: Parse[T], ex: D): String = 1
 >>>
 def format_![T <: Tree](
-    code: String
-  )(implicit ev: Parse[T]
+    code: String,
+    code2: String
+  )(implicit ev: Parse[T],
+    ex: D
   ): String = 1
 
 <<< curried function mixed style 2

--- a/core/src/test/resources/test/VericalMultiline.stat
+++ b/core/src/test/resources/test/VericalMultiline.stat
@@ -1,5 +1,5 @@
 continuationIndent.defnSite = 4
-straightCurried = true
+verticalMultiline = true
 maxColumn = 80
 <<< curried function over maxColumn
 def format_![T <: Tree](code: String, foo: Int)(f: A => B)(implicit ev: Parse[T], ev2: EC): String
@@ -12,8 +12,16 @@ def format_![T <: Tree](
     ev2: EC
   ): String
 
-<<< ONLY curried functions under maxColumn
+<<< SKIP curried function under maxColumn
 def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
+>>>
+def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
+
+<<< SKIP small curried functions should fit in one line
+def format_![T <: Tree](
+    code: String)(
+    f: A => B)
+    (implicit ev: Parse[T]): String
 >>>
 def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 


### PR DESCRIPTION
This is a style that we are currently using and would like to keep using. It formats:

```scala
// maxColumn = 80
// this function is 98 chars long
def format_![T <: Tree](code: String, foo: Int)(f: A => B)(implicit ev: Parse[T], ev2: EC): String
```

to this:

```scala
def format_![T <: Tree](
    code: String,
    foo: Int
  )(f: A => B
  )(implicit ev: Parse[T],
    ev2: EC
  ): String
```

This format will only apply if the function would go over the maxColumn is single-lined. If it is under, it will be singled line. 