### PR TITLE
Fix "pr" helper method in docs gen

### DIFF
--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -72,7 +72,7 @@ object Readme {
       names.dropRight(1).map(x => span(user(x), ", ")) :+ user(names.last): _*
     )
 
-  def pr(id: Int) = a(href := repo + s"/pulls/$id", s"#$id")
+  def pr(id: Int) = a(href := repo + s"/pull/$id", s"#$id")
   def issue(id: Int) = a(href := repo + s"/issues/$id", s"#$id")
   def issues(ids: Int*) = span(ids.map(issue): _*)
 


### PR DESCRIPTION
In https://olafurpg.github.io/scalafmt/#0.5.2 /r/therewasanattempt/ to link to https://github.com/olafurpg/scalafmt/pull/658, but instead it links to https://github.com/olafurpg/scalafmt/pulls/658. This fixes that.