### PR TITLE
Another fix for `verticalMultilineAtDefinitionSite`

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -435,7 +435,8 @@ class Router(formatOps: FormatOps) {
         val oneLinePerArg = OneArgOneLineSplit(open).f
         val paramGroupSplitter: PartialFunction[Decision, Decision] = {
           // Indent seperators `)(` by `indentSep`
-          case Decision(t @ FormatToken(_, rp @ RightParen(), _), _) =>
+          case Decision(t @ FormatToken(_, rp @ RightParen(), _), _)
+            if rp == lastParen || next(t).right.is[LeftParen] =>
             Decision(t,
                      Seq(
                        Split(Newline, 0)

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -436,7 +436,7 @@ class Router(formatOps: FormatOps) {
         val paramGroupSplitter: PartialFunction[Decision, Decision] = {
           // Indent seperators `)(` by `indentSep`
           case Decision(t @ FormatToken(_, rp @ RightParen(), _), _)
-            if rp == lastParen || owners(rp) == leftOwner =>
+            if owners(rp) == leftOwner =>
             Decision(t,
                      Seq(
                        Split(Newline, 0)

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -436,7 +436,7 @@ class Router(formatOps: FormatOps) {
         val paramGroupSplitter: PartialFunction[Decision, Decision] = {
           // Indent seperators `)(` by `indentSep`
           case Decision(t @ FormatToken(_, rp @ RightParen(), _), _)
-            if rp == lastParen || next(t).right.is[LeftParen] =>
+            if rp == lastParen || !isCallSite(owners(rp)) =>
             Decision(t,
                      Seq(
                        Split(Newline, 0)

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -436,7 +436,7 @@ class Router(formatOps: FormatOps) {
         val paramGroupSplitter: PartialFunction[Decision, Decision] = {
           // Indent seperators `)(` by `indentSep`
           case Decision(t @ FormatToken(_, rp @ RightParen(), _), _)
-            if rp == lastParen || !isCallSite(owners(rp)) =>
+            if rp == lastParen || owners(rp) == leftOwner =>
             Decision(t,
                      Seq(
                        Split(Newline, 0)

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -53,6 +53,31 @@ def format_![T <: Tree](
     ev2: EC
   ): String
 
+<<< should work with comments
+def format_![T <: Tree](
+    code: String, // The code!
+    code2: String
+  )(implicit ev: Parse[T], // The Parser!!! Some very long comment that goes over limit
+  ex: D): String = 1
+>>>
+def format_![T <: Tree](
+    code: String, // The code!
+    code2: String
+  )(implicit ev: Parse[T], // The Parser!!! Some very long comment that goes over limit
+    ex: D
+  ): String = 1
+
+<<< should not modify into single line if it has comments
+def format_!(
+    code: String, // The code!
+    code2: String
+  ): String = 1
+>>>
+def format_!(
+    code: String, // The code!
+    code2: String
+  ): String = 1
+
 <<< should work with defaulted method
 def format_![T <: Tree](
   name: Name,

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -78,11 +78,11 @@ def format_!(
     code2: String
   ): String = 1
 
-<<< should work with defaulted method
+<<< ONLY should work with defaulted method
 def format_![T <: Tree](
   name: Name,
   code: String = Defaults.code, updatedAt: Instant = Instant.now(),
-  createdAt: Instant = Instant.now())
+  createdAt: Instant = Default.getInstant(a)(b))
   (implicit ev: Parse[T],
   ev2: EC)
   : String
@@ -91,7 +91,7 @@ def format_![T <: Tree](
     name: Name,
     code: String = Defaults.code,
     updatedAt: Instant = Instant.now(),
-    createdAt: Instant = Instant.now()
+    createdAt: Instant = Default.getInstant(a)(b)
   )(implicit ev: Parse[T],
     ev2: EC
   ): String

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -82,6 +82,7 @@ def format_!(
 def format_![T <: Tree](
   name: Name,
   code: String = Defaults.code, updatedAt: Instant = Instant.now(),
+  user: User = new User { def someFunc(): RT = () },
   createdAt: Instant = Default.getInstant(a)(b))
   (implicit ev: Parse[T],
   ev2: EC)
@@ -91,6 +92,7 @@ def format_![T <: Tree](
     name: Name,
     code: String = Defaults.code,
     updatedAt: Instant = Instant.now(),
+    user: User = new User { def someFunc(): RT = () },
     createdAt: Instant = Default.getInstant(a)(b)
   )(implicit ev: Parse[T],
     ev2: EC

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -53,6 +53,24 @@ def format_![T <: Tree](
     ev2: EC
   ): String
 
+<<< should work with defaulted method
+def format_![T <: Tree](
+  name: Name,
+  code: String = Defaults.code, updatedAt: Instant = Instant.now(),
+  createdAt: Instant = Instant.now())
+  (implicit ev: Parse[T],
+  ev2: EC)
+  : String
+>>>
+def format_![T <: Tree](
+    name: Name,
+    code: String = Defaults.code,
+    updatedAt: Instant = Instant.now(),
+    createdAt: Instant = Instant.now()
+  )(implicit ev: Parse[T],
+    ev2: EC
+  ): String
+
 <<< should not affect classes
 final class UserProfile(name: String, age: Int, address: Address, profession: Profesion, school: School)
   extends Profile with UserSettings

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -78,7 +78,7 @@ def format_!(
     code2: String
   ): String = 1
 
-<<< ONLY should work with defaulted method
+<<< should work with defaulted method
 def format_![T <: Tree](
   name: Name,
   code: String = Defaults.code, updatedAt: Instant = Instant.now(),


### PR DESCRIPTION
Yet another bug fix for `verticalMultilineAtDefinitionSite`. I suspect this should be the last one though. 

Fixes an issue where `verticalMultilineAtDefinitionSite` would incorrectly split defaulted parameters that called a method.

ie:
```
def someFunc(
   code: String = Defaults.getCode(a)(b)
  ): RT
```
