### PR TITLE
Fix #731: empty-param group with verical style

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -413,7 +413,7 @@ class Router(formatOps: FormatOps) {
 
       // Parameter opening for one parameter group. This format works
       // on a group-by-group basis.
-      case FormatToken(open @ LeftParen(), _, between)
+      case FormatToken(open @ LeftParen(), r, between)
           if style.verticalMultilineAtDefinitionSite && isDefDef(leftOwner) =>
         val close = matchingParentheses(hash(open))
         val indentParam = Num(4)
@@ -456,11 +456,17 @@ class Router(formatOps: FormatOps) {
         val policy =
           Policy(oneLinePerArg.orElse(paramGroupSplitter), lastParen.end)
 
+        val firstIndent =
+          if (r.is[RightParen]) // An empty param group
+            indentSep
+          else
+            indentParam
+
         Seq(
           Split(NoSplit, 0) // If it fits in one block, make it so
             .withPolicy(SingleLineBlock(lastParen)),
           Split(Newline, 1) // Otherwise split vertically
-            .withIndent(indentParam, close, Right)
+            .withIndent(firstIndent, close, Right)
             .withPolicy(policy)
         )
 

--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -109,3 +109,25 @@ final class UserProfile(name: String,
                         school: School)
     extends Profile
     with UserSettings
+
+<<< should work with an empty first param group
+override def load()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+  )(implicit taskCtx: Context,
+    ec: ExecutionContext
+  ): Future[Seq[A] Or B]
+
+<<< should work with an empty non-first param group
+override def load(code: String)()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+    code: String
+  )(
+  )(implicit taskCtx: Context,
+    ec: ExecutionContext
+  ): Future[Seq[A] Or B]


### PR DESCRIPTION
Fix a bug where `verticalMultilineAtDefinitionSite` would fail to format
correctly if there existed an empty param-group at the beginning of the
definition.