### PR TITLE
Grouping of case [class|object] for newline.alwaysBeforeTopLevelStatements and fixed new test case

### DIFF
--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -77,13 +77,11 @@ object TokenOps {
   }
 
   def isTopLevelStatment(tok: Token, owner: Tree): Boolean = {
-      tok.is[KwObject] ||
-        tok.is[KwDef] ||
-        tok.is[KwPackage] ||
-        tok.is[KwClass] ||
-        tok.is[KwTrait] ||
-        owner.parent.exists(_.is[Defn.Class]) ||
-        owner.parent.exists(_.is[Defn.Trait])
+      tok.is[KwObject] || owner.parent.exists(_.is[Defn.Object]) ||
+        tok.is[KwClass] || owner.parent.exists(_.is[Defn.Class]) ||
+        tok.is[KwDef] || owner.parent.exists(_.is[Defn.Def]) ||
+        tok.is[KwTrait] || owner.parent.exists(_.is[Defn.Trait]) ||
+        tok.is[KwPackage] || (tok.is[KwProtected] && owner.parent.exists(_.is[Pkg]))
   }
 
   def isDocstring(token: Token): Boolean = {

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -60,11 +60,9 @@ object TokenOps {
       val rightOwner = owners(tok.right)
 
       style.newlines.alwaysBeforeTopLevelStatements &&
-        tok.between.count(_.is[KwNew]) < 2 &&
         isTopLevelStatment(tok.right, rightOwner) &&
         !{
           // keep groups of case class/objects with no body in a block
-          
           def hasBody(tree: Tree) = tree.parent.map(_.children).getOrElse(Seq.empty).exists {
             case Template(_, _, _, Some(_)) => true
             case _ => false

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -2,10 +2,7 @@ package org.scalafmt.util
 
 import org.scalafmt.config.FormatEvent.CreateFormatOps
 
-import scala.meta.Defn
-import scala.meta.Pkg
-import scala.meta.Template
-import scala.meta.Tree
+import scala.meta.{Defn, Mod, Pkg, Template, Term, Tree}
 import scala.meta.dialects.Scala211
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
@@ -59,16 +56,34 @@ object TokenOps {
       val newlines = newlinesBetween(tok.between)
       newlines > 1 || (isDocstring(tok.right) && !tok.left.is[Comment])
     } || {
+      val leftOwner = owners(tok.left)
+      val rightOwner = owners(tok.right)
+
       style.newlines.alwaysBeforeTopLevelStatements &&
-        tok.between.count(_.is[KwNew]) < 2 && isTopLevelStatment(tok.right, owners(tok.right))
+        tok.between.count(_.is[KwNew]) < 2 &&
+        isTopLevelStatment(tok.right, rightOwner) &&
+        !{
+          // keep groups of case class/objects with no body in a block
+          
+          def hasBody(tree: Tree) = tree.parent.map(_.children).getOrElse(Seq.empty).exists {
+            case Template(_, _, _, Some(_)) => true
+            case _ => false
+          }
+
+          (TreeOps.isCaseClass(leftOwner) || TreeOps.isCaseObject(leftOwner)) &&
+            (TreeOps.isCaseClass(rightOwner) || TreeOps.isCaseObject(rightOwner)) &&
+            !hasBody(leftOwner) &&
+            !hasBody(rightOwner)
+        }
     }
   }
 
   def isTopLevelStatment(tok: Token, owner: Tree): Boolean = {
       tok.is[KwObject] ||
         tok.is[KwDef] ||
-        tok.is[KwCase] ||
         tok.is[KwPackage] ||
+        tok.is[KwClass] ||
+        tok.is[KwTrait] ||
         owner.parent.exists(_.is[Defn.Class]) ||
         owner.parent.exists(_.is[Defn.Trait])
   }

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -68,8 +68,8 @@ object TokenOps {
             case _ => false
           }
 
-          (TreeOps.isCaseClass(leftOwner) || TreeOps.isCaseObject(leftOwner)) &&
-            (TreeOps.isCaseClass(rightOwner) || TreeOps.isCaseObject(rightOwner)) &&
+          (TreeOps.isCaseClass(leftOwner, matchOnParent = true) || TreeOps.isCaseObject(leftOwner, matchOnParent = true)) &&
+            (TreeOps.isCaseClass(rightOwner, matchOnParent = true) || TreeOps.isCaseObject(rightOwner, matchOnParent = true)) &&
             !hasBody(leftOwner) &&
             !hasBody(rightOwner)
         }
@@ -77,11 +77,11 @@ object TokenOps {
   }
 
   def isTopLevelStatment(tok: Token, owner: Tree): Boolean = {
-      tok.is[KwObject] || owner.parent.exists(_.is[Defn.Object]) ||
-        tok.is[KwClass] || owner.parent.exists(_.is[Defn.Class]) ||
-        tok.is[KwDef] || owner.parent.exists(_.is[Defn.Def]) ||
-        tok.is[KwTrait] || owner.parent.exists(_.is[Defn.Trait]) ||
-        tok.is[KwPackage] || (tok.is[KwProtected] && owner.parent.exists(_.is[Pkg]))
+    tok.is[KwObject] || owner.parent.exists(_.is[Defn.Object]) ||
+      tok.is[KwClass] || owner.parent.exists(_.is[Defn.Class]) ||
+      tok.is[KwDef] || owner.parent.exists(_.is[Defn.Def]) ||
+      tok.is[KwTrait] || owner.parent.exists(_.is[Defn.Trait]) ||
+      tok.is[KwPackage] || (tok.is[KwProtected] && owner.parent.exists(_.is[Pkg]))
   }
 
   def isDocstring(token: Token): Boolean = {

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -460,4 +460,24 @@ object TreeOps {
   // procedure syntax has decltpe: Some("")
   def isProcedureSyntax(defn: Defn.Def): Boolean =
     defn.decltpe.exists(_.tokens.isEmpty)
+
+  def isCaseClass(tree: Tree): Boolean = {
+    tree.is[Defn.Class] && tree.children.exists(_.is[Mod.Case]) ||
+      tree.parent.exists(_.is[Defn.Class]) && tree.parent.exists(_.children.exists(_.is[Mod.Case]))
+  }
+
+  def isCaseObject(tree: Tree): Boolean = {
+    tree.is[Defn.Object] && tree.children.exists(_.is[Mod.Case]) ||
+      tree.parent.exists(_.is[Defn.Object]) && tree.parent.exists(_.children.exists(_.is[Mod.Case]))
+  }
+
+  def isFinalClass(tree: Tree): Boolean = {
+    tree.is[Defn.Class] && tree.children.exists(_.is[Mod.Final]) ||
+      tree.parent.exists(_.is[Defn.Class]) && tree.parent.exists(_.children.exists(_.is[Mod.Final]))
+  }
+
+  def isBasicClass(tree: Tree): Boolean = {
+    tree.is[Defn.Class] && !tree.children.exists(e => e.is[Mod.Final] || e.is[Mod.Case]) ||
+      tree.parent.exists(_.is[Defn.Class]) && !tree.parent.exists(_.children.exists(e => e.is[Mod.Final] || e.is[Mod.Case]))
+  }
 }

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -461,23 +461,28 @@ object TreeOps {
   def isProcedureSyntax(defn: Defn.Def): Boolean =
     defn.decltpe.exists(_.tokens.isEmpty)
 
-  def isCaseClass(tree: Tree): Boolean = {
-    tree.is[Defn.Class] && tree.children.exists(_.is[Mod.Case]) ||
-      tree.parent.exists(_.is[Defn.Class]) && tree.parent.exists(_.children.exists(_.is[Mod.Case]))
+  def isCaseClass(tree: Tree, matchOnParent: Boolean = false): Boolean = tree match {
+    case defn: Defn.Class => defn.mods.exists(_.is[Mod.Case])
+    case _ if matchOnParent => tree.parent.exists(isCaseClass(_))
+    case _ => false
   }
 
-  def isCaseObject(tree: Tree): Boolean = {
-    tree.is[Defn.Object] && tree.children.exists(_.is[Mod.Case]) ||
-      tree.parent.exists(_.is[Defn.Object]) && tree.parent.exists(_.children.exists(_.is[Mod.Case]))
+  def isFinalClass(tree: Tree, matchOnParent: Boolean = false): Boolean = tree match {
+    case defn: Defn.Class => defn.mods.exists(_.is[Mod.Final])
+    case _ if matchOnParent => tree.parent.exists(isFinalClass(_))
+    case _ => false
   }
 
-  def isFinalClass(tree: Tree): Boolean = {
-    tree.is[Defn.Class] && tree.children.exists(_.is[Mod.Final]) ||
-      tree.parent.exists(_.is[Defn.Class]) && tree.parent.exists(_.children.exists(_.is[Mod.Final]))
+  def isCaseObject(tree: Tree, matchOnParent: Boolean = false): Boolean = tree match {
+    case defn: Defn.Object => defn.mods.exists(_.is[Mod.Case])
+    case _ if matchOnParent => tree.parent.exists(isCaseObject(_))
+    case _ => false
   }
 
-  def isBasicClass(tree: Tree): Boolean = {
-    tree.is[Defn.Class] && !tree.children.exists(e => e.is[Mod.Final] || e.is[Mod.Case]) ||
-      tree.parent.exists(_.is[Defn.Class]) && !tree.parent.exists(_.children.exists(e => e.is[Mod.Final] || e.is[Mod.Case]))
+  def isSealedTrait(tree: Tree, matchOnParent: Boolean = false): Boolean = tree match {
+    case defn: Defn.Trait => defn.mods.exists(_.is[Mod.Sealed])
+    case _ if matchOnParent => tree.parent.exists(isSealedTrait(_))
+    case _ => false
   }
+
 }

--- a/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -12,6 +12,7 @@ package a {
       case class C1
       sealed trait T1
       final class FC1
+      override def od = 1
       def a = v1
       def b = v2
       def c: Int
@@ -39,6 +40,8 @@ package a {
       sealed trait T1
 
       final class FC1
+
+      override def od = 1
 
       def a = v1
 

--- a/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -132,6 +132,7 @@ package a {
       case class C3
       case class C4 {}
       case class C5 {}
+      case class C6
 
       sealed trait T1
 
@@ -166,6 +167,8 @@ package a {
       case class C4 {}
 
       case class C5 {}
+
+      case class C6
 
       sealed trait T1
 

--- a/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -16,6 +16,10 @@ package a {
       def b = v2
       def c: Int
       def d: Int = 2
+      def e = a match {
+        case 1 => true
+        case 2 => false
+      }
     }
   }
 }
@@ -43,6 +47,11 @@ package a {
       def c: Int
 
       def d: Int = 2
+
+      def e = a match {
+        case 1 => true
+        case 2 => false
+      }
     }
   }
 }
@@ -87,6 +96,73 @@ package a {
       val v2 = 2
 
       case class C1
+
+      sealed trait T1
+
+      final class FC1
+
+      def a = v1
+
+      def b = v2
+
+      def c: Int
+
+      def d: Int = 2
+    }
+  }
+}
+
+<<< Keep Blocks of case classes with no body together
+package a {
+  import x1.b
+  import x2.b
+
+  package b {
+
+    object a {
+      val v1 = 1
+      val v2 = 2
+
+      case object CO1
+      case class C1
+      case class C2
+      case class C3
+      case class C4 {}
+      case class C5 {}
+
+      sealed trait T1
+
+      final class FC1
+
+      def a = v1
+
+      def b = v2
+
+      def c: Int
+
+      def d: Int = 2
+    }
+  }
+}
+>>>
+package a {
+  import x1.b
+  import x2.b
+
+  package b {
+
+    object a {
+      val v1 = 1
+      val v2 = 2
+
+      case object CO1
+      case class C1
+      case class C2
+      case class C3
+
+      case class C4 {}
+
+      case class C5 {}
 
       sealed trait T1
 


### PR DESCRIPTION
add failing test for match case and newline.alwaysBeforeTopLevelStatements,
fixed the failing test,
keep groups of case [class|object] with no body together