### PR TITLE
Handle comment breaking wrapping

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -18,7 +18,7 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   }
 
   def forceNewline(implicit line: sourcecode.Line): Decision = {
-    if (isAttachedComment(formatToken.right, formatToken.between)) this
+    if (isAttachedSingleLineComment(formatToken.right, formatToken.between)) this
     else {
       Decision(formatToken, splits.filter(_.modification.isNewline))
     }

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -432,7 +432,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   def getRightAttachedComment(token: Token): Token = {
     val formatToken = leftTok2tok(token)
-    if (isAttachedComment(formatToken.right, formatToken.between))
+    if (isAttachedSingleLineComment(formatToken.right, formatToken.between))
       formatToken.right
     else token
   }
@@ -466,7 +466,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             .findFirstIn(op.tokens.head.syntax)
             .isDefined)) 0
       else if (!modification.isNewline &&
-               !isAttachedComment(formatToken.right, formatToken.between)) 0
+               !isAttachedSingleLineComment(formatToken.right, formatToken.between)) 0
       else 2
     }
     val expire = (for {

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -173,7 +173,7 @@ class FormatWriter(formatOps: FormatOps) {
   private def isCandidate(location: FormatLocation): Boolean = {
     val token = location.formatToken.right
     val code = token match {
-      case c: Comment if isInlineComment(c) => "//"
+      case c: Comment if isSingleLineComment(c) => "//"
       case t => t.syntax
     }
     styleMap.at(location.formatToken).alignMap.get(code).exists {
@@ -197,7 +197,7 @@ class FormatWriter(formatOps: FormatOps) {
     formatToken match {
       // Corner case when line ends with comment
       // TODO(olafur) should this be part of owners?
-      case FormatToken(x, c: Comment, _) if isInlineComment(c) =>
+      case FormatToken(x, c: Comment, _) if isSingleLineComment(c) =>
         owners(x)
       case FormatToken(_, r, _) =>
         owners(r) match {

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -768,7 +768,7 @@ class Router(formatOps: FormatOps) {
       case tok @ FormatToken(Comma(), right, _) =>
         // TODO(olafur) DRY, see OneArgOneLine.
         val rhsIsAttachedComment =
-          tok.right.is[Comment] && newlinesBetween(tok.between) == 0
+          isSingleLineComment(tok.right) && newlinesBetween(tok.between) == 0
         val binPack = isBinPack(leftOwner)
         val isInfix = leftOwner.isInstanceOf[Term.ApplyInfix]
         argumentStarts.get(hash(right)) match {

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -118,10 +118,10 @@ class Router(formatOps: FormatOps) {
       case FormatToken(open @ LeftBrace(), _, _)
           if parents(leftOwner).exists(_.is[Import]) =>
         val close = matchingParentheses(hash(open))
-        val disallowInlineComments = style.importSelectors != ImportSelectors.singleLine
+        val disallowSingleLineComments = style.importSelectors != ImportSelectors.singleLine
         val policy = SingleLineBlock(close,
-                                     disallowInlineComments =
-                                       disallowInlineComments)
+                                     disallowSingleLineComments =
+                                       disallowSingleLineComments)
         val newlineBeforeClosingCurly = newlineBeforeClosingCurlyPolicy(close)
 
         val newlinePolicy = style.importSelectors match {
@@ -250,7 +250,7 @@ class Router(formatOps: FormatOps) {
         val hasBlock =
           nextNonComment(formatToken).right.isInstanceOf[LeftBrace]
         Seq(
-          Split(Space, 0, ignoreIf = isInlineComment(right))
+          Split(Space, 0, ignoreIf = isSingleLineComment(right))
             .withPolicy(SingleLineBlock(endOfFunction)),
           Split(Space, 0, ignoreIf = !hasBlock),
           Split(Newline, 1 + nestedApplies(leftOwner), ignoreIf = hasBlock)
@@ -288,7 +288,8 @@ class Router(formatOps: FormatOps) {
         )
 
       case tok @ FormatToken(left, right, between) if startsStatement(tok) =>
-        val newline: Modification = NewlineT(shouldGet2xNewlines(tok, style, owners))
+        val newline: Modification = NewlineT(
+          shouldGet2xNewlines(tok, style, owners))
         val expire = rightOwner.tokens
           .find(_.is[Equals])
           .map { equalsToken =>
@@ -436,7 +437,7 @@ class Router(formatOps: FormatOps) {
         val paramGroupSplitter: PartialFunction[Decision, Decision] = {
           // Indent seperators `)(` by `indentSep`
           case Decision(t @ FormatToken(_, rp @ RightParen(), _), _)
-            if owners(rp) == leftOwner =>
+              if owners(rp) == leftOwner =>
             Decision(t,
                      Seq(
                        Split(Newline, 0)
@@ -504,7 +505,7 @@ class Router(formatOps: FormatOps) {
         if (isTuple(leftOwner)) {
           Seq(
             Split(NoSplit, 0).withPolicy(
-              SingleLineBlock(close, disallowInlineComments = false))
+              SingleLineBlock(close, disallowSingleLineComments = false))
           )
         } else {
           def penalizeBrackets(penalty: Int): Policy =
@@ -673,7 +674,7 @@ class Router(formatOps: FormatOps) {
           } else singleLine(10)
 
         val noSplitIndent =
-          if (isInlineComment(right)) indent
+          if (isSingleLineComment(right)) indent
           else Num(0)
 
         val isTuple = leftOwner match {
@@ -734,7 +735,7 @@ class Router(formatOps: FormatOps) {
         val expire = lastToken(defDefReturnType(leftOwner).get)
         Seq(
           Split(Space, 0).withPolicy(
-            SingleLineBlock(expire, disallowInlineComments = false))
+            SingleLineBlock(expire, disallowSingleLineComments = false))
         )
 
       case FormatToken(LeftParen(), LeftBrace(), between) =>
@@ -872,7 +873,7 @@ class Router(formatOps: FormatOps) {
         }
 
         val mod: Modification =
-          if (isAttachedComment(right, between)) Space
+          if (isAttachedSingleLineComment(right, between)) Space
           else Newline
 
         val exclude =
@@ -1092,7 +1093,7 @@ class Router(formatOps: FormatOps) {
         }
         val rightIsOnNewLine = newlines > 0
         // Inline comment attached to closing RightParen
-        val attachedComment = !rightIsOnNewLine && isInlineComment(right)
+        val attachedComment = !rightIsOnNewLine && isSingleLineComment(right)
         val newlineModification: Modification =
           if (attachedComment)
             Space // Inline comment will force newline later.
@@ -1235,7 +1236,7 @@ class Router(formatOps: FormatOps) {
                 case d @ Decision(t @ FormatToken(`arrow`, right, between), s)
                     // TODO(olafur) any other corner cases?
                     if !right.isInstanceOf[LeftBrace] &&
-                      !isAttachedComment(right, between) =>
+                      !isAttachedSingleLineComment(right, between) =>
                   Decision(t, s.filter(_.modification.isNewline))
               },
               expire = expire.end

--- a/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -58,11 +58,11 @@ case object AvoidInfix extends Rewrite {
           .filter(fstOpToken, fstArgsToken)(_.is[LF])
           .map(TokenPatch.Remove)
 
-        val hasInlineComment = ctx.tokenTraverser
-          .filter(fstOpToken, fstArgsToken)(TokenOps.isInlineComment)
+        val hasSingleLineComment = ctx.tokenTraverser
+          .filter(fstOpToken, fstArgsToken)(TokenOps.isSingleLineComment)
           .nonEmpty
 
-        if (hasInlineComment)
+        if (hasSingleLineComment)
           Nil
         else
           lhsParensToBeAdded ++ selectorToBeAdded ++ selectorParensToBeAdded ++ toBeRemoved

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -144,7 +144,7 @@ object TokenOps {
     */
   def SingleLineBlock(expire: Token,
                       exclude: Set[Range] = Set.empty,
-                      disallowInlineComments: Boolean = true,
+                      disallowSingleLineComments: Boolean = true,
                       penaliseNewlinesInsideTokens: Boolean = false)(
       implicit line: sourcecode.Line): Policy = {
     Policy(
@@ -152,7 +152,7 @@ object TokenOps {
         case Decision(tok, splits)
             if !tok.right.is[EOF] && tok.right.end <= expire.end &&
               exclude.forall(!_.contains(tok.left.start)) &&
-              (disallowInlineComments || !isInlineComment(tok.left)) =>
+              (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
           if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
             Decision(tok, Seq.empty[Split])
           } else {
@@ -165,7 +165,7 @@ object TokenOps {
     )
   }
 
-  def isInlineComment(token: Token): Boolean = token match {
+  def isSingleLineComment(token: Token): Boolean = token match {
     case c: Comment => c.syntax.startsWith("//")
     case _ => false
   }
@@ -187,8 +187,8 @@ object TokenOps {
   def newlinesBetween(between: Vector[Token]): Int =
     between.count(_.is[LF])
 
-  def isAttachedComment(token: Token, between: Vector[Token]) =
-    isInlineComment(token) && newlinesBetween(between) == 0
+  def isAttachedSingleLineComment(token: Token, between: Vector[Token]) =
+    isSingleLineComment(token) && newlinesBetween(between) == 0
 
   def defnTemplate(tree: Tree): Option[Template] = tree match {
     case t: Defn.Object => Some(t.templ)

--- a/core/src/test/resources/align/comment-wrapping.source
+++ b/core/src/test/resources/align/comment-wrapping.source
@@ -1,0 +1,15 @@
+style = defaultWithAlign
+runner.dialect = Sbt0137
+<<< wrap with inline comment
+lazy val ivyProj = (project in file("ivy"))
+  .dependsOn(interfaceProj,
+             crossProj,
+             logProj % "compile;test->test",
+             ioProj  % "compile;test->test", /*launchProj % "test->test",*/ collectionProj)
+>>>
+lazy val ivyProj = (project in file("ivy"))
+  .dependsOn(interfaceProj,
+             crossProj,
+             logProj % "compile;test->test",
+             ioProj  % "compile;test->test",
+             /*launchProj % "test->test",*/ collectionProj)


### PR DESCRIPTION
Fixes #762

And rename InlineComment to SingleLineComment, aka "//"