### PR TITLE
Fix #728, infix indent for ::

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/IndentConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/IndentConfig.scala
@@ -1,0 +1,8 @@
+package org.scalafmt.config
+
+import metaconfig.ConfigReader
+
+@ConfigReader
+case class IndentConfig(
+    rightAssociativeInfixOperatorsLikeLeftAssociative: Boolean = true
+)

--- a/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/core/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -216,6 +216,7 @@ case class ScalafmtConfig(
     indentOperator: IndentOperator = IndentOperator(),
     newlines: Newlines = Newlines(),
     runner: ScalafmtRunner = ScalafmtRunner.default,
+    indent: IndentConfig = IndentConfig(),
     // Settings which belong to no group
     indentYieldKeyword: Boolean = true,
     @metaconfig.ExtraName("binPackImportSelectors") importSelectors: ImportSelectors =
@@ -246,6 +247,8 @@ case class ScalafmtConfig(
 
   implicit val runnerReader: Reader[ScalafmtRunner] =
     runner.reader
+  implicit val indentConfigReader: Reader[IndentConfig] =
+    indent.reader
   implicit val contIndentReader: Reader[ContinuationIndent] =
     continuationIndent.reader
   implicit val indentReader: Reader[IndentOperator] =

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -470,12 +470,22 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             .findFirstIn(op.tokens.head.syntax)
             .isDefined)) 0
       else if (!modification.isNewline &&
-               !isAttachedSingleLineComment(formatToken.right, formatToken.between)) 0
+               !isAttachedSingleLineComment(formatToken.right,
+                                            formatToken.between)) 0
       else 2
     }
+    val isRightAssociative =
+      style.indent.rightAssociativeInfixOperatorsLikeLeftAssociative &&
+        isRightAssociativeOperator(op.value)
     val expire = (for {
-      arg <- rhsArgs.lastOption
-      token <- arg.tokens.lastOption
+      arg <- {
+        if (isRightAssociative) rhsArgs.headOption
+        else rhsArgs.lastOption
+      }
+      token <- {
+        if (isRightAssociative) arg.tokens.headOption
+        else arg.tokens.lastOption
+      }
     } yield token).getOrElse(owner.tokens.last)
 
     owner.parent match {

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -248,6 +248,11 @@ object TokenOps {
     case _ => false
   }
 
+  // According to spec:
+  // "Operators ending in a colon `:' are right-associative. All other operators are left-associative."
+  // See https://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html
+  def isRightAssociativeOperator(op: String): Boolean = op.endsWith(":")
+
   val formatOnCode = Set(
     "// @formatter:on", // IntelliJ
     "// format: on" // scalariform

--- a/core/src/test/resources/default/ApplyInfix.stat
+++ b/core/src/test/resources/default/ApplyInfix.stat
@@ -320,7 +320,7 @@ x
 1 match {
   case accountIdStr :: userIdStr :: connectorIdStr :: timestampStr :: eventClassStr :: contactIdStr
         :: contactPointIdStr :: contactPointValue :: remoteContactId :: to :: subject :: remoteId
-          :: remoteGroupId :: timeZoneStr :: rest =>
+        :: remoteGroupId :: timeZoneStr :: rest =>
 }
 <<< unfortunate side-effect of #740
 { lazy val propertyName =
@@ -332,4 +332,26 @@ x
   lazy val propertyName =
     ("""[a-zA-Z_][a-zA-Z_0-9]*""".r | """`([^`\\]|\\.)+`""".r ^^ canonicalizePropertyName | """"([^"\\]|\\.)+"""".r ^^ canonicalizeStr //"
   )
+}
+<<< #728
+lazy val ReleaseCmd = Command.command("release") { state =>
+  "set elideOptions in client := Seq(\"-Xelide-below\", \"WARNING\")" ::
+    "client/clean" ::
+      "client/test" ::
+        "server/clean" ::
+          "server/test" ::
+            "server/dist" ::
+              "set elideOptions in client := Seq()" ::
+                state
+}
+>>>
+lazy val ReleaseCmd = Command.command("release") { state =>
+  "set elideOptions in client := Seq(\"-Xelide-below\", \"WARNING\")" ::
+    "client/clean" ::
+    "client/test" ::
+    "server/clean" ::
+    "server/test" ::
+    "server/dist" ::
+    "set elideOptions in client := Seq()" ::
+    state
 }

--- a/core/src/test/resources/unit/Type.stat
+++ b/core/src/test/resources/unit/Type.stat
@@ -78,9 +78,9 @@ AlertEvent :+:
 type Row =
   AlertEvent :+:
     InteractionEvent :+:
-      HistoryEvent :+:
-        PostEvent :+:
-          ImageEvent
+    HistoryEvent :+:
+    PostEvent :+:
+    ImageEvent
 <<< #756
 type a = b_! # D
 >>>


### PR DESCRIPTION
There is a difference how left and right associative infix operators are parsed:

```scala
@ q"a :: b :: c".structure
Term.ApplyInfix(Term.Name("a"), Term.Name("::"), Nil, Seq(Term.ApplyInfix(Term.Name("b"), Term.Name("::"), Nil, Seq(Term.Name("c")))))
@ q"a + b + c".structure
Term.ApplyInfix(Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, Seq(Term.Name("b"))), Term.Name("+"), Nil, Seq(Term.Name("c")))
```

This commit adds an option to indent right associative operators just
like left-associative operators.