### PR TITLE
Fix #800.

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -234,7 +234,8 @@ class FormatWriter(formatOps: FormatOps) {
   // imperative and error-prone right now.
   def alignmentTokens(
       locations: Array[FormatLocation]): Map[FormatToken, Int] = {
-    if (initStyle.align.tokens.isEmpty) Map.empty[FormatToken, Int]
+    if (initStyle.align.tokens.isEmpty || locations.length != tokens.length)
+      Map.empty[FormatToken, Int]
     else {
       val finalResult = Map.newBuilder[FormatToken, Int]
       var i = 0

--- a/core/src/test/resources/align/ArrayIndexOutOfBounds800.source
+++ b/core/src/test/resources/align/ArrayIndexOutOfBounds800.source
@@ -1,0 +1,23 @@
+style = defaultWithAlign
+onTestFailure = "Search state"
+<<< #800
+object Test {
+  Some(Files.newInputStream(inFile)) match {
+    case Some(reader) ⇒
+      val srcStream: Source[Int, NotUsed] =
+        Source.single((3, 4)).flatMapConcat {
+          case ((n1, n2)) ⇒
+            Source.fromGraph(GraphDSL.create() { implicit b ⇒
+              val src = Source.fromIterator(
+                () ⇒
+                  NodeStreamer.makeIterator(
+                    (n, p) ⇒ "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ))
+              val flow = src ~> procStream
+              SourceShape(flow.outlet)
+            })
+        }
+  }
+}
+>>>
+object Test

--- a/core/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/core/src/test/scala/org/scalafmt/FormatTests.scala
@@ -56,6 +56,10 @@ class FormatTests
     val runner = scalafmtRunner(t.style.runner).copy(parser = parse)
     val obtained =
       Scalafmt.format(t.original, t.style.copy(runner = runner)) match {
+        case Formatted.Failure(e)
+            if t.style.onTestFailure.nonEmpty && e.getMessage.contains(
+              e.getMessage) =>
+          t.expected
         case Formatted.Failure(e: Incomplete) => e.formattedCode
         case Formatted.Failure(e: SearchStateExploded) =>
           logger.elem(e)
@@ -64,7 +68,8 @@ class FormatTests
       }
     debugResults += saveResult(t, obtained, onlyOne)
     if (t.style.rewrite.rules.isEmpty &&
-        !t.style.assumeStandardLibraryStripMargin) {
+        !t.style.assumeStandardLibraryStripMargin &&
+        t.style.onTestFailure.isEmpty) {
       assertFormatPreservesAst(t.original, obtained)(parse,
                                                      t.style.runner.dialect)
     }


### PR DESCRIPTION
The search state exploded so the format writer should not try and
vertically align anything.