### PR TITLE
Fix #798.

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -476,6 +476,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     }
     val isRightAssociative =
       style.indent.rightAssociativeInfixOperatorsLikeLeftAssociative &&
+        // NOTE. Silly workaround because we call infixSplit from assignment =, see #798
+        formatToken.left.syntax != "=" &&
         isRightAssociativeOperator(op.value)
     val expire = (for {
       arg <- {

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -888,7 +888,6 @@ class Router(formatOps: FormatOps) {
           insideBlock(formatToken, expire, _.isInstanceOf[LeftBrace])
         rhs match {
           case t: Term.ApplyInfix =>
-            val modification = newlines2Modification(between)
             Seq(
               infixSplit(t, formatToken)
             )

--- a/core/src/test/resources/default/ApplyInfix.stat
+++ b/core/src/test/resources/default/ApplyInfix.stat
@@ -355,3 +355,18 @@ lazy val ReleaseCmd = Command.command("release") { state =>
     "set elideOptions in client := Seq()" ::
     state
 }
+<<< With tuples
+val overrides =
+      "logconfigonstart" ::
+      "quorumsize" ::
+        "hostname" ::
+        "port" ::
+        Nil
+
+>>>
+val overrides =
+  "logconfigonstart" ::
+    "quorumsize" ::
+    "hostname" ::
+    "port" ::
+    Nil


### PR DESCRIPTION
infixSplit is used for both infix applications, where we want to handle
infix operators, and also for assignment, where we don't want to handle
right associative operators.

This commit is a poor fix/hack/workaround for this issue. I would love
to come with a better design/implementation to avoid this duct taping,
but I'm afraid I don't have so much time right now and I want to publish
a fix quickly.