### PR TITLE
Don't resolve from ivy2local in ScalafmtBotstrap.

### DIFF
--- a/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
+++ b/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
@@ -53,10 +53,15 @@ object ScalafmtBootstrap {
         )
       )
 
-    val repositories = Seq(
-      Cache.ivy2Local,
-      MavenRepository("https://repo1.maven.org/maven2")
-    )
+    val repositories =
+      MavenRepository("https://repo1.maven.org/maven2") :: {
+      // ivy2 local is only necessary when testing the sbt plugin on a locally
+      // published version of scalafmt. See https://github.com/olafurpg/scalafmt/issues/807
+      // for a potential error caused by resolving fron ivy2 local (I can't reproduce the
+      // error so this is a wild guess).
+      if (sys.props.contains("scalafmt.scripted")) Cache.ivy2Local :: Nil
+      else Nil
+    }
 
     val logger = new TermDisplay(new OutputStreamWriter(System.err))
     logger.init(System.err.println("Downloading scalafmt artifacts..."))

--- a/build.sbt
+++ b/build.sbt
@@ -220,6 +220,7 @@ lazy val scalafmtSbt = project
     moduleName := "sbt-scalafmt",
     scriptedLaunchOpts := Seq(
       "-Dplugin.version=" + version.value,
+      "-Dscalafmt.scripted=true",
       // .jvmopts is ignored, simulate here
       "-XX:MaxPermSize=256m",
       "-Xmx2g",


### PR DESCRIPTION
Addreses #807, I'm unable to reproduce the reported error so I can't say
if this commit fixes it or not. The reporter error indicates there's
some race condition with the default ivy resolver in ~/.ivy2/local,
I I'm hoping that this change avoids that error.