### PR TITLE
fix mainClass not found error on windows machine (that comment makes …

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx8G
+-Xmx4G
 -XX:MaxPermSize=512M
 -XX:ReservedCodeCacheSize=250M

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
-# see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
 -Dfile.encoding=UTF8
 -Xms1G
 -Xmx4G

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx4G
+-Xmx8G
 -XX:MaxPermSize=512M
 -XX:ReservedCodeCacheSize=250M


### PR DESCRIPTION
fix mainClass not found error on windows machine (that comment makes sbt use # as main class)