### PR TITLE
Work on project.includeMarkdown config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3184,6 +3184,13 @@ project {
 }
 ```
 
+### `project.includeMarkdown`
+```scala mdoc:defaults
+project.includeMarkdown = true
+```
+If true, format triple-backticked `scala mdoc` snippets in Markdown files in the project.
+This will not affect any of the markdown text outside the snippets.
+
 ### `fileOverride`
 
 > Since v2.5.0.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -10,6 +10,7 @@ import metaconfig.annotation.DeprecatedName
 
 case class ProjectFiles(
     git: Boolean = false,
+    includeMarkdown: Boolean = false,
     includePaths: Seq[String] = ProjectFiles.defaultIncludePaths,
     excludePaths: Seq[String] = Nil,
     @DeprecatedName(
@@ -38,8 +39,7 @@ object ProjectFiles {
   private implicit val fs: file.FileSystem = file.FileSystems.getDefault
 
   val defaultIncludePaths =
-    // TODO: figure out how to make `*.md` pattern optional
-    Seq("glob:**.scala", "glob:**.sbt", "glob:**.sc", "glob:**.md")
+    Seq("glob:**.scala", "glob:**.sbt", "glob:**.sc")
 
   private sealed abstract class PathMatcher {
     def matches(path: file.Path): Boolean
@@ -54,8 +54,10 @@ object ProjectFiles {
       val useIncludePaths =
         pf.includePaths.ne(defaultIncludePaths) || pf.includeFilters.isEmpty
       val includePaths = if (useIncludePaths) pf.includePaths else Seq.empty
+      val markdownPaths =
+        if (pf.includeMarkdown) Seq("glob:**.md") else Seq.empty
       new FileMatcher(
-        nio(includePaths) ++ regex(pf.includeFilters),
+        nio(includePaths ++ markdownPaths) ++ regex(pf.includeFilters),
         nio(pf.excludePaths) ++ regex(pf.excludeFilters ++ regexExclude)
       )
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/MarkdownFile.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/MarkdownFile.scala
@@ -19,11 +19,12 @@ final case class MarkdownFile(input: Input, parts: List[MarkdownPart]) {
 object MarkdownFile {
   sealed abstract class State
   object State {
-    case class CodeFence(start: Int, backticks: String, info: String) extends State
+    case class CodeFence(start: Int, backticks: String, info: String)
+        extends State
     case object Text extends State
   }
   class Parser(input: Input) {
-	      private val text = input.text
+    private val text = input.text
     private def newPos(start: Int, end: Int): Position = {
       Position.Range(input, start, end)
     }
@@ -120,8 +121,12 @@ sealed abstract class MarkdownPart {
     }
 }
 final case class Text(value: String) extends MarkdownPart
-final case class CodeFence(openBackticks: Text, info: Text, body: Text, closeBackticks: Text)
-    extends MarkdownPart {
+final case class CodeFence(
+    openBackticks: Text,
+    info: Text,
+    body: Text,
+    closeBackticks: Text
+) extends MarkdownPart {
   var newPart = Option.empty[String]
   var newInfo = Option.empty[String]
   var newBody = Option.empty[String]


### PR DESCRIPTION
+ Tests
+ Basic Documentation
+ Attempt at performance hack to skip irrelevant MD files

The main problem at the moment is that I can't move the tests I made back into the larger existing test class.
I get the failures that are copy/pasted into the comment at top of the new tests.